### PR TITLE
fix(security): address adversarial review findings

### DIFF
--- a/scripts/hook-block-all.sh
+++ b/scripts/hook-block-all.sh
@@ -12,8 +12,7 @@ input=$(cat)
 for hook in \
   "$SCRIPT_DIR/hook-block-no-verify.sh" \
   "$SCRIPT_DIR/hook-block-short-no-verify.sh" \
-  "$SCRIPT_DIR/hook-block-main-commit.sh" \
-  "$SCRIPT_DIR/hook-block-merge-lock.sh"; do
+  "$SCRIPT_DIR/hook-block-main-commit.sh"; do
   if [[ -x "$hook" ]]; then
     printf '%s\n' "$input" | "$hook" || exit $?
   fi

--- a/scripts/hook-session-start.sh
+++ b/scripts/hook-session-start.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# Hook: SessionStart - Run project-specific setup hooks if present
+# Hook: SessionStart - placeholder for project-specific setup
+#
+# Project-specific setup hooks can be configured in each project's
+# .claude/hooks/ directory and invoked via the claude-wrapper's
+# pre-launch hook mechanism (see ~/.local/bin/claude-wrapper).
 
-set -euo pipefail
-
-input=$(cat)
-cwd=$(echo "$input" | jq -r '.cwd // empty')
-
-if [[ -n "$cwd" ]] && [[ -f "$cwd/.claude/hooks/setup-plaid-token.sh" ]]; then
-  cd "$cwd" && ./.claude/hooks/setup-plaid-token.sh
-fi
+# Consume stdin (required by hook protocol)
+cat >/dev/null


### PR DESCRIPTION
## Summary
- **run-review.sh**: Fail-closed on unparseable adversarial verdict (was silently passing). Added defensive checks for unexpected verdict values.
- **hook-block-all.sh**: Remove merge-lock regex hook (bypassable via variable indirection, heredocs, etc; real enforcement is branch protection + restricted PAT)
- **hook-session-start.sh**: Remove hardcoded Plaid token setup (project-specific code leaked into global infrastructure)

## Context
Adversarial review (`code-critic:adversarial-reviewer`) of `~/.claude/{hooks,scripts}`, `~/.config/bash`, and `~/.config/git/hooks` identified these issues.

## Test plan
- [x] Code-reviewer: PASS (2 iterations)
- [x] Adversarial-reviewer: PASS
- [x] ShellCheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)