### PR TITLE
fix(hooks): graceful PAT fallback for Checks API

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -69,7 +69,8 @@
     "incident-response@claude-code-workflows": false,
     "team-collaboration@claude-code-workflows": false,
     "code-critic@smartwatermelon-marketplace": true,
-    "react-native-3d@smartwatermelon-marketplace": true
+    "react-native-3d@smartwatermelon-marketplace": true,
+    "frontend-design@claude-code-plugins": true
   },
   "alwaysThinkingEnabled": true,
   "gitAttribution": true


### PR DESCRIPTION
## Summary
- **pre-merge-review.sh**: `_fetch_pr_json` now gracefully falls back to fetching PR data without `statusCheckRollup` when fine-grained PATs lack Checks API permission, instead of failing outright
- **settings.json**: Enables the `frontend-design@claude-code-plugins` plugin

## Test plan
- [ ] Run `pre-merge-review.sh` with a fine-grained PAT that lacks Checks permission — should warn and fall back
- [ ] Run `pre-merge-review.sh` with a classic PAT — should succeed on first try
- [ ] Run `pre-merge-review.sh` when `gh pr view` fails for other reasons — should still error out immediately
- [ ] Verify `settings.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)