### PR TITLE
fix(hooks): block Claude from granting merge authorization

### DIFF
--- a/scripts/hook-block-all.sh
+++ b/scripts/hook-block-all.sh
@@ -12,7 +12,8 @@ input=$(cat)
 for hook in \
   "$SCRIPT_DIR/hook-block-no-verify.sh" \
   "$SCRIPT_DIR/hook-block-short-no-verify.sh" \
-  "$SCRIPT_DIR/hook-block-main-commit.sh"; do
+  "$SCRIPT_DIR/hook-block-main-commit.sh" \
+  "$SCRIPT_DIR/hook-block-merge-lock-authorize.sh"; do
   if [[ -x "$hook" ]]; then
     printf '%s\n' "$input" | "$hook" || exit $?
   fi

--- a/scripts/hook-block-merge-lock-authorize.sh
+++ b/scripts/hook-block-merge-lock-authorize.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Hook: Block Bash execution of "merge-lock.sh authorize"
+# Merge authorization is a human-only action.
+#
+# The Write/Edit hooks already block direct file writes to merge-locks/.
+# This hook blocks the higher-level authorization command via the Bash tool.
+
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s\n' "$input" | jq -r '.tool_input.command // empty')
+
+if printf '%s\n' "$cmd" | grep -qE 'merge-lock\.sh[[:space:]]+(authorize|auth)([[:space:]]|$)'; then
+  printf '%s BLOCKED MERGE-LOCK AUTHORIZE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "$cmd" >>"${HOME}/.claude/blocked-commands.log"
+  printf '🛑 BLOCKED: merge-lock.sh authorize is a human-only action.\n' >&2
+  printf '\n' >&2
+  printf 'Merge authorization must be granted by the human, not Claude.\n' >&2
+  printf 'Ask the human to run: ~/.claude/hooks/merge-lock.sh authorize <PR> "<reason>"\n' >&2
+  exit 2
+fi


### PR DESCRIPTION
## Summary

- Claude was able to run `merge-lock.sh` with the authorize subcommand through the Bash tool, granting its own merge approvals
- Merge authorization is a human-only action — it represents the human's explicit approval to merge reviewed code
- The existing Write/Edit hooks blocked direct file writes to `merge-locks/` but not the higher-level command
- This PR adds `hook-block-merge-lock-authorize.sh` and wires it into `hook-block-all.sh`

## Test plan

- [ ] Verified hook fires and blocks the command (live test during implementation — hook blocked the test Bash call itself)
- [ ] Commit message must not contain the literal pattern the hook matches (confirmed: this PR's commit passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)