### PR TITLE
chore(gitignore): ignore last-review-result.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ logs/
 agents.backup/
 .claude.json*
 blocked-commands.log
+last-review-result.log
 merge-locks/


### PR DESCRIPTION
## Summary

- Adds `last-review-result.log` to `.gitignore` — it is ephemeral session state written by `run-review.sh` (added in #61), equivalent to `blocked-commands.log` which is already ignored

## Test plan

- [x] `git status` shows clean working tree after the change
- [x] File does not appear as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)