### PR TITLE
fix(gitignore): restore full ignore rules after accidental overwrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,64 @@
+# Session state and temporary files
+todos/
+plans/
+file-history/
+debug/
+shell-snapshots/
+session-env/
+tasks/
+
+# Conversation logs — NEVER commit these (contain secrets, PII, session data)
+*.jsonl
+
+# Cache and statistics
 mcp-needs-auth-cache.json
+stats-cache.json
+statsig/
+cache/
+paste-cache/
+image-cache/
+plugins/install-counts-cache.json
+plugins/known_marketplaces.json
+plugins/installed_plugins.json
+plugins/marketplaces/*/
+plugins/cache/
+
+# Local configuration (personal settings, permissions)
+settings.local.json
+*.local.json
+
+# Secrets and credentials — never commit
+*.key
+*.pem
+*.p12
+credentials.*
+secrets.*
+
+# Project directories (external projects worked on)
+projects/
+
+# Telemetry and analytics
+telemetry/
+
+# macOS metadata
+.DS_Store
+**/.DS_Store
+
+# BFG reports
+*.bfg-report/
+
+# Auto-memory (may contain sensitive session context)
+memory/
+
+# Empty directories and misc
+bin/
+commands/
+downloads/
+agents-local/
+logs/
+agents.backup/
+.claude.json*
+blocked-commands.log
+last-review-result.log
+merge-locks/
+plugins/blocklist.json


### PR DESCRIPTION
## Summary

- `c5f0086` replaced the entire `.gitignore` with a single line (`mcp-needs-auth-cache.json`) while intending to just add that entry
- Restores the full 63-line file from `426a294` and folds in the intended new entry under the Cache section

## Test plan

- [x] `git status` shows the same untracked files as before the overwrite
- [x] `mcp-needs-auth-cache.json` is now ignored as originally intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)