### PR TITLE
feat(hooks): block git worktree commands and EnterWorktree tool

### DIFF
--- a/scripts/hook-block-all.sh
+++ b/scripts/hook-block-all.sh
@@ -10,12 +10,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 input=$(cat)
 
 for hook in \
-  "$SCRIPT_DIR/hook-block-no-verify.sh" \
-  "$SCRIPT_DIR/hook-block-short-no-verify.sh" \
-  "$SCRIPT_DIR/hook-block-main-commit.sh" \
-  "$SCRIPT_DIR/hook-block-merge-lock-authorize.sh" \
-  "$SCRIPT_DIR/hook-block-api-merge.sh"; do
-  if [[ -x "$hook" ]]; then
-    printf '%s\n' "$input" | "$hook" || exit $?
+  "${SCRIPT_DIR}/hook-block-no-verify.sh" \
+  "${SCRIPT_DIR}/hook-block-short-no-verify.sh" \
+  "${SCRIPT_DIR}/hook-block-main-commit.sh" \
+  "${SCRIPT_DIR}/hook-block-merge-lock-authorize.sh" \
+  "${SCRIPT_DIR}/hook-block-api-merge.sh" \
+  "${SCRIPT_DIR}/hook-block-git-worktree.sh"; do
+  if [[ -x "${hook}" ]]; then
+    printf '%s\n' "${input}" | "${hook}" || exit $?
   fi
 done

--- a/scripts/hook-block-enter-worktree.sh
+++ b/scripts/hook-block-enter-worktree.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Hook: Block the EnterWorktree built-in tool
+#
+# Purpose:
+#   EnterWorktree is a Claude Code built-in tool that creates an isolated git
+#   worktree. CC add-on skills (e.g. superpowers:using-git-worktrees) invoke
+#   this tool for task isolation, which conflicts with the project workflow.
+#
+#   This hook fires via PreToolUse matcher "EnterWorktree" and unconditionally
+#   blocks the tool. The Bash-level `git worktree` command is blocked separately
+#   by hook-block-git-worktree.sh in the hook-block-all.sh chain.
+
+set -euo pipefail
+
+input=$(cat)
+printf '%s BLOCKED ENTER_WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${input}" \
+  >>"${HOME}/.claude/blocked-commands.log"
+printf '🛑 BLOCKED: The EnterWorktree tool is forbidden.\n' >&2
+printf '\n' >&2
+printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
+printf '\n' >&2
+printf 'For task isolation, work directly on a feature branch instead:\n' >&2
+printf '  git checkout -b claude/<description>\n' >&2
+exit 2

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Hook: Block git worktree commands
+#
+# Purpose:
+#   git worktree creates and manages multiple working trees from a single repo.
+#   CC add-on skills occasionally attempt to use worktrees for task isolation,
+#   but this conflicts with the project workflow and causes problems.
+#
+#   Both the Bash-level `git worktree` command and the EnterWorktree built-in
+#   tool are blocked. This script handles the Bash layer.
+#
+# Called by: hook-block-all.sh (PreToolUse Bash hook chain)
+
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s\n' "${input}" | jq -r '.tool_input.command // empty')
+
+# Match: git [optional-flags] worktree [subcommand]
+# Requires `git` to appear as a command (at start of string or after shell operators &&, ||, ;, |).
+# Handles interposed flags: git -C /path worktree add, git --no-pager worktree list, etc.
+# The group (-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)* matches zero or more
+# flag groups before `worktree`. Each group is a token starting with `-`, optionally followed by
+# a non-flag value token. This prevents matching subcommands like `grep` (which don't start with
+# `-`), so `git grep worktree` is NOT blocked.
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]|$)'; then
+  printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
+    >>"${HOME}/.claude/blocked-commands.log"
+  printf '🛑 BLOCKED: git worktree commands are forbidden.\n' >&2
+  printf '\n' >&2
+  printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
+  printf '\n' >&2
+  printf 'For task isolation, work directly on a feature branch instead:\n' >&2
+  printf '  git checkout -b claude/<description>\n' >&2
+  exit 2
+fi

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tests for hook-block-git-worktree.sh
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-git-worktree.sh"
+pass=0
+fail=0
+
+check() {
+  local desc="${1}" expected="${2}" input="${3}" actual
+  actual=0
+  printf '%s\n' "${input}" | "${HOOK}" >/dev/null 2>&1 || actual=$?
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (expected exit ${expected}, got ${actual})"
+    ((fail += 1))
+  fi
+}
+
+make_input() {
+  jq -n --arg cmd "$1" '{"tool_input":{"command":$cmd}}'
+}
+
+echo "=== hook-block-git-worktree tests ==="
+
+# Should BLOCK (exit 2)
+inp="$(make_input 'git worktree add /tmp/wt feature')"
+check "git worktree add" 2 "${inp}"
+inp="$(make_input 'git worktree list')"
+check "git worktree list" 2 "${inp}"
+inp="$(make_input 'git worktree remove /tmp/wt')"
+check "git worktree remove" 2 "${inp}"
+inp="$(make_input 'git worktree prune')"
+check "git worktree prune" 2 "${inp}"
+inp="$(make_input 'git -C /some/path worktree add /tmp/wt')"
+check "git -C /path worktree add" 2 "${inp}"
+inp="$(make_input 'git --no-pager worktree list')"
+check "git --no-pager worktree list" 2 "${inp}"
+inp="$(make_input 'cd /repo && git worktree add /tmp/wt')"
+check "chained: cd && git worktree" 2 "${inp}"
+
+# Should PASS (exit 0)
+inp="$(make_input 'git commit -m msg')"
+check "git commit" 0 "${inp}"
+inp="$(make_input 'git checkout -b worktree-fix')"
+check "git checkout -b worktree-fix" 0 "${inp}"
+inp="$(make_input 'echo git worktree is blocked')"
+check "echo about worktree" 0 "${inp}"
+inp="$(make_input 'brew update')"
+check "unrelated command" 0 "${inp}"
+
+# Additional operator-chaining BLOCK cases
+inp="$(make_input 'ls; git worktree list')"
+check "chained: ; git worktree" 2 "${inp}"
+inp="$(make_input 'true || git worktree list')"
+check "chained: || git worktree" 2 "${inp}"
+inp="$(make_input 'echo x | git worktree add')"
+check "chained: | git worktree" 2 "${inp}"
+
+# False-positive guard: git grep searching for "worktree" string
+inp="$(make_input 'git grep worktree')"
+check "git grep worktree (not blocked)" 0 "${inp}"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]

--- a/settings.json
+++ b/settings.json
@@ -33,6 +33,15 @@
             "command": "~/.claude/scripts/hook-block-merge-locks-write.sh"
           }
         ]
+      },
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/hook-block-enter-worktree.sh"
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## Summary

- **`hook-block-git-worktree.sh`**: Blocks `git worktree` commands at the Bash PreToolUse layer. Added to the `hook-block-all.sh` chain. Regex anchors `git` to command position and requires flag-like tokens before `worktree`, preventing false positives on `git grep worktree` while handling `git -C /path worktree add` and `git --no-pager worktree list`.
- **`hook-block-enter-worktree.sh`**: New `PreToolUse` hook with `matcher: "EnterWorktree"` that unconditionally blocks the built-in tool.
- Fixes pre-existing SC2250 shellcheck style warnings in `hook-block-all.sh`.

## Motivation

CC add-on skills (e.g. `superpowers:using-git-worktrees`) occasionally invoke worktrees for task isolation, which conflicts with the project workflow. Feature branches are the correct isolation mechanism here.

## Test plan

- [x] 15/15 tests passing (`scripts/tests/test-hook-block-git-worktree.sh`)
- [x] shellcheck clean on all new and modified scripts
- [x] code-reviewer: PASS
- [x] adversarial-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)