### PR TITLE
chore: ignore mcp.json (machine-generated, empty boilerplate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ plugins/cache/
 # Local configuration (personal settings, permissions)
 settings.local.json
 *.local.json
+mcp.json
 
 # Secrets and credentials — never commit
 *.key


### PR DESCRIPTION
Adds `mcp.json` to `.gitignore`. The file is auto-generated by Claude Code with empty `mcpServers: {}` content and varies per machine — no value in tracking it.