### PR TITLE
fix(run-review): add log identity fields; scope log to .git/; update protocols

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,16 @@ This protocol exists because of two incidents on 2026-02-24:
 □ Type checking passes (if applicable) - RUN LOCALLY FIRST
 □ AI review clean: git hook auto-runs code-reviewer agent (FREE, local)
 □ Adversarial review clean: git hook auto-runs adversarial-reviewer on EVERY commit (FREE, local)
-□ Verify hook review ran: after EVERY commit, check the log timestamp:
-    head -1 ~/.claude/last-review-result.log
-  If the timestamp is more than ~60 seconds old, the hook did not run for this commit.
-  Treat as unreviewed — do not push until you can confirm a fresh review ran.
+□ Verify hook review ran AND matches this repo: after EVERY commit, read the log header:
+    head -6 $(git rev-parse --git-dir)/last-review-result.log
+  Check ALL of the following — a timestamp alone is not enough:
+  1. Timestamp within ~60 seconds (hook ran for this commit)
+  2. repo: field matches this repo's root path
+  3. branch: field matches your current branch
+  4. commit: field matches HEAD (git rev-parse --short HEAD)
+  If ANY field is missing or wrong: treat as unreviewed. Do not push.
+  (The global ~/.claude/last-review-result.log is now a pointer file with a log: field
+   pointing to the per-repo authoritative log.)
 □ Never claim "AI review: N clean iterations" without seeing actual review output (Bash tool or log file)
 □ No console.log/print statements in production code
 □ No hardcoded secrets
@@ -388,6 +394,11 @@ This protocol exists because of two incidents on 2026-02-24:
 ```
 □ All pre-commit checks pass
 □ Adversarial review clean (runs on every commit via hook)
+□ If subagent-driven-development was used: treat all subagent-reported reviews
+  as UNVERIFIED. Before pushing, run a full-diff adversarial review manually:
+    git diff main..HEAD | claude --agent adversarial-reviewer -p --tools ""
+  Per-commit subagent reviews only cover incremental diffs — cross-cutting issues
+  visible only across the full feature surface will be missed otherwise.
 □ Tests pass IN SIMULATOR (for mobile) or local environment
 □ Linting and type checking clean locally
 □ You are CONFIDENT this will pass CI, not just hopeful

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -721,12 +721,15 @@ _review_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ || true)
 # Also update the global pointer's timestamp to match the completion time.
 # Controllers checking head -1 ~/.claude/last-review-result.log need the
 # completion time (not start time) for the staleness check to be accurate.
-if [[ -f "${_global_log}" ]]; then
-  {
-    printf '%s\n' "${_review_ts}"
-    tail -n +2 "${_global_log}"
-  } >"${_global_log}.tmp" \
-    && mv "${_global_log}.tmp" "${_global_log}" || true
-fi
+# Write all fields from current session variables (not tail -n +2 of the
+# existing file) to avoid a read-modify-write race with concurrent sessions.
+{
+  printf '%s\n' "${_review_ts}"
+  printf 'repo: %s\n' "${_review_repo}"
+  printf 'branch: %s\n' "${_review_branch}"
+  printf 'commit: %s\n' "${_review_commit}"
+  printf 'log: %s\n' "${REVIEW_LOG}"
+} >"${_global_log}.tmp" \
+  && mv "${_global_log}.tmp" "${_global_log}" || true
 log_success "Review timestamp: ${_review_ts}  ← verify this matches commit time"
 exit 0

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -328,12 +328,36 @@ ${file_output}"
 # --- Read diff from stdin ---
 DIFF=$(cat)
 
-# --- Review log: initialized before all exit paths so every outcome is recorded ---
-# Path is announced before any agent runs, making it visible in Claude Code's
-# Bash tool even when nested-claude output is swallowed (see bug report 2026-02-24).
-REVIEW_LOG="${REVIEW_LOG:-${HOME}/.claude/last-review-result.log}"
+# --- Review log: scoped to this repo's .git/ directory ---
+# Rationale: A single global log is overwritten by concurrent sessions in other
+# repos, making cross-repo contamination undetectable (incident 2026-03-08).
+# Per-repo log + identity fields let the controller confirm the log matches
+# the repo and commit they just made.
+GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
+REVIEW_LOG="${REVIEW_LOG:-${GIT_DIR_PATH}/last-review-result.log}"
 _review_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ || true)
-printf '%s\n' "${_review_ts}" >"${REVIEW_LOG}" || true
+_review_repo=$(cd "${GIT_DIR_PATH}/.." >/dev/null 2>&1 && pwd -L || echo "unknown")
+_review_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
+_review_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+{
+  printf '%s\n' "${_review_ts}"
+  printf 'repo: %s\n' "${_review_repo}"
+  printf 'branch: %s\n' "${_review_branch}"
+  printf 'commit: %s\n' "${_review_commit}"
+} >"${REVIEW_LOG}" || true
+
+# Global pointer: keep ~/.claude/last-review-result.log pointed at the most
+# recent per-repo log. Controllers checking the global path will see identity
+# fields that reveal cross-repo contamination immediately.
+_global_log="${HOME}/.claude/last-review-result.log"
+{
+  printf '%s\n' "${_review_ts}"
+  printf 'repo: %s\n' "${_review_repo}"
+  printf 'branch: %s\n' "${_review_branch}"
+  printf 'commit: %s\n' "${_review_commit}"
+  printf 'log: %s\n' "${REVIEW_LOG}"
+} >"${_global_log}" || true
+
 _ec=0 # captured by EXIT trap; declared here so shellcheck sees the assignment
 trap '_ec=$?; [[ -n "${REVIEW_LOG:-}" ]] && printf "exit_code: %d\n" "$_ec" >> "${REVIEW_LOG}" || true' EXIT
 
@@ -344,7 +368,7 @@ if [[ -z "${DIFF}" ]]; then
 fi
 
 # --- Review caching (skip review if diff unchanged since last PASS) ---
-CACHE_DIR="$(git rev-parse --git-dir 2>/dev/null || echo ".git")/claude-review-cache"
+CACHE_DIR="${GIT_DIR_PATH}/claude-review-cache"
 mkdir -p "${CACHE_DIR}"
 
 # Clean up cache entries older than 30 days to prevent unbounded growth

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -336,7 +336,7 @@ DIFF=$(cat)
 GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
 REVIEW_LOG="${REVIEW_LOG:-${GIT_DIR_PATH}/last-review-result.log}"
 _review_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ || true)
-_review_repo=$(cd "${GIT_DIR_PATH}/.." >/dev/null 2>&1 && pwd -L || echo "unknown")
+_review_repo=$(cdup=$(git rev-parse --show-cdup 2>/dev/null) && cd "./${cdup:-.}" >/dev/null 2>&1 && pwd -L || echo "unknown")
 _review_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
 _review_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 {
@@ -718,5 +718,15 @@ _review_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ || true)
   tail -n +2 "${REVIEW_LOG}"
 } >"${REVIEW_LOG}.tmp" \
   && mv "${REVIEW_LOG}.tmp" "${REVIEW_LOG}" || true
+# Also update the global pointer's timestamp to match the completion time.
+# Controllers checking head -1 ~/.claude/last-review-result.log need the
+# completion time (not start time) for the staleness check to be accurate.
+if [[ -f "${_global_log}" ]]; then
+  {
+    printf '%s\n' "${_review_ts}"
+    tail -n +2 "${_global_log}"
+  } >"${_global_log}.tmp" \
+    && mv "${_global_log}.tmp" "${_global_log}" || true
+fi
 log_success "Review timestamp: ${_review_ts}  ← verify this matches commit time"
 exit 0

--- a/tests/test_run_review_identity.bats
+++ b/tests/test_run_review_identity.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Tests that run-review.sh writes identity fields to the review log header.
+#
+# Root cause: ~/.claude/last-review-result.log had no repo/branch/commit
+# fields, making cross-repo contamination undetectable (incident 2026-03-08).
+#
+# Run: bats ~/.claude/tests/test_run_review_identity.bats
+
+setup() {
+  # Create a temp git repo so git commands work
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+  git -C "${TMPDIR_TEST}" init -q
+  git -C "${TMPDIR_TEST}" checkout -q -b test-branch
+  git -C "${TMPDIR_TEST}" config user.email "test@test.com"
+  git -C "${TMPDIR_TEST}" config user.name "Test"
+  touch "${TMPDIR_TEST}/init.txt"
+  git -C "${TMPDIR_TEST}" add init.txt
+  # Use GIT_CONFIG_GLOBAL=/dev/null to skip global hooks (core.hooksPath) in the temp repo
+  GIT_CONFIG_GLOBAL=/dev/null git -C "${TMPDIR_TEST}" commit -q -m "init"
+
+  export EXPECTED_LOG="${TMPDIR_TEST}/.git/last-review-result.log"
+
+  # Mock claude CLI: consume stdin, emit a minimal PASS verdict
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  cat >"${MOCK_DIR}/claude" <<'EOF'
+#!/usr/bin/env bash
+cat > /dev/null
+echo "VERDICT: PASS"
+echo "No blocking issues found."
+EOF
+  chmod +x "${MOCK_DIR}/claude"
+  export CLAUDE_CLI="${MOCK_DIR}/claude"
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}" "${MOCK_DIR}"
+}
+
+# Helper: run review script from within the temp repo with a tiny diff on stdin
+run_review() {
+  cd "${TMPDIR_TEST}" || exit
+  printf 'diff --git a/foo.js b/foo.js\nindex 0000000..1234567 100644\n--- a/foo.js\n+++ b/foo.js\n@@ -0,0 +1 @@\n+const x = 1;\n' \
+    | REVIEW_LOG="${EXPECTED_LOG}" CLAUDE_CLI="${CLAUDE_CLI}" \
+      bash "${HOME}/.claude/hooks/run-review.sh"
+}
+
+@test "log header contains 'repo:' field pointing to the test repo root" {
+  run_review || true
+  grep -q "^repo: ${TMPDIR_TEST}$" "${EXPECTED_LOG}"
+}
+
+@test "log header contains 'branch:' field" {
+  run_review || true
+  grep -q "^branch: test-branch$" "${EXPECTED_LOG}"
+}
+
+@test "log header contains 'commit:' field with a short SHA" {
+  run_review || true
+  grep -qE "^commit: [0-9a-f]{7,}$" "${EXPECTED_LOG}"
+}
+
+@test "log header fields appear before VERDICT output" {
+  run_review || true
+  repo_line=$(grep -n "^repo:" "${EXPECTED_LOG}" | head -1 | cut -d: -f1)
+  verdict_line=$(grep -n "CODE REVIEWER" "${EXPECTED_LOG}" | head -1 | cut -d: -f1)
+  [[ -n "${repo_line}" ]]
+  [[ -n "${verdict_line}" ]]
+  [[ "${repo_line}" -lt "${verdict_line}" ]]
+}
+
+@test "log is written inside .git/ by default (no REVIEW_LOG override)" {
+  cd "${TMPDIR_TEST}"
+  printf 'diff --git a/foo.js b/foo.js\nindex 0000000..1234567 100644\n--- a/foo.js\n+++ b/foo.js\n@@ -0,0 +1 @@\n+const x = 1;\n' \
+    | CLAUDE_CLI="${CLAUDE_CLI}" \
+      bash "${HOME}/.claude/hooks/run-review.sh" || true
+  [[ -f "${TMPDIR_TEST}/.git/last-review-result.log" ]]
+}
+
+@test "global pointer file is updated at ~/.claude/last-review-result.log" {
+  run_review || true
+  [[ -f "${HOME}/.claude/last-review-result.log" ]]
+  grep -q "${TMPDIR_TEST}" "${HOME}/.claude/last-review-result.log"
+}


### PR DESCRIPTION
## Summary

Addresses three root causes from incident report 2026-03-08 (conflated review logs — cross-repo contamination went undetected during PR #910 receipt photo feature).

- **RC1 — Shared log, no identity (infrastructure):** `run-review.sh` now writes `repo:`, `branch:`, and `commit:` identity fields to the log header. Default log path changed from the global `~/.claude/last-review-result.log` to the per-repo `.git/last-review-result.log`, eliminating cross-repo race conditions. A global pointer file is kept at the old path for backward compatibility, containing the same identity fields plus a `log:` field pointing to the authoritative per-repo log. Completion timestamp is synced to both files.
- **RC3 — Content not sanity-checked (protocol):** Pre-commit checklist in CLAUDE.md updated to require verifying all four identity fields (timestamp, repo, branch, commit), not just the timestamp. `head -1` updated to `head -6` with explicit field checks.
- **RC2 — Subagent reviews unverified (protocol):** Pre-push checklist updated to require a manual full-diff adversarial review (`git diff main..HEAD | claude --agent adversarial-reviewer`) before pushing when subagent-driven-development was used, since per-commit subagent reviews only cover incremental diffs.

**Worktree fix:** `_review_repo` previously used `cd "$GIT_DIR/.."` which resolves to `worktrees/` inside a linked worktree. Fixed using `git rev-parse --show-cdup` + `pwd -L` which correctly resolves the worktree root for both standard and worktree layouts, preserving logical paths on macOS.

## Test Plan

- [x] `bats ~/.claude/tests/test_run_review_identity.bats` — 6 new tests all pass (written TDD-first)
- [x] `bats ~/.claude/tests/` — 89/89 tests pass (no regressions)
- [x] Smoke test: per-repo `.git/last-review-result.log` and global pointer both show correct identity fields after a commit
- [ ] Manual contamination test: two concurrent sessions in different repos; confirm each `.git/last-review-result.log` reflects its own repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)