### PR TITLE
fix(pre-merge): prevent duplicate issues and add non-interactive flag gate

### DIFF
--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -341,6 +341,26 @@ for arg in "$@"; do
   fi
 done
 
+# --- Non-interactive flag gate ---
+# When invoked from Claude Code (CLAUDECODE set), require --squash and --delete-branch.
+# Without them the actual merge step will fail, wasting a full analysis cycle.
+if [[ -n "${CLAUDECODE:-}" ]]; then
+  _has_squash=false
+  _has_delete_branch=false
+  for _arg in "$@"; do
+    case "${_arg}" in
+      --squash) _has_squash=true ;;
+      --delete-branch) _has_delete_branch=true ;;
+      *) ;;
+    esac
+  done
+  if [[ "${_has_squash}" != "true" || "${_has_delete_branch}" != "true" ]]; then
+    log_error "Non-interactive merge requires --squash and --delete-branch"
+    log_error "Retry with: gh pr merge ${PR_NUMBER:-<PR>} --squash --delete-branch"
+    exit 1
+  fi
+fi
+
 # --- Fetch PR data ---
 log_info "Fetching PR review data..."
 
@@ -429,6 +449,9 @@ if [[ -x "${MERGE_LOCK}" ]]; then
   fi
   log_success "Merge authorization verified for PR #${PR_NUMBER}"
 fi
+
+# Track lock file path for dedup guard below (empty if merge-lock is not in use)
+MERGE_LOCK_FILE="${HOME}/.claude/merge-locks/pr-${PR_NUMBER}.lock"
 
 # --- Hard block: CHANGES_REQUESTED review state (issue #27) ---
 # Do NOT delegate review state enforcement to Claude. Claude can rationalize
@@ -903,7 +926,15 @@ if echo "${VERDICT_LINE}" | grep -qE "SAFE_TO_MERGE"; then
   # Authorization was already verified at the top of this script (early check).
   log_success "PR review analysis passed - safe to merge"
   # Create GitHub issues for any non-blocking concerns found during review.
-  create_nonblocking_issues "${ANALYSIS_TEXT}"
+  # Guard: if the merge fails and Claude retries within the same authorization
+  # window (30-min TTL), skip issue creation to prevent duplicates.
+  if [[ -f "${MERGE_LOCK_FILE}" ]] && grep -q "^ISSUES_CREATED=1$" "${MERGE_LOCK_FILE}" 2>/dev/null; then
+    log_info "Non-blocking issues already filed for PR #${PR_NUMBER} in this auth window — skipping"
+  else
+    create_nonblocking_issues "${ANALYSIS_TEXT}"
+    # Mark so a retry within the same auth window skips issue creation.
+    [[ -f "${MERGE_LOCK_FILE}" ]] && printf 'ISSUES_CREATED=1\n' >>"${MERGE_LOCK_FILE}" || true
+  fi
   exit 0
 elif echo "${VERDICT_LINE}" | grep -qE "BLOCK_MERGE"; then
   log_error "PR has unresolved review issues - merge blocked"


### PR DESCRIPTION
## Summary

- **Duplicate issue dedup**: when an authorized `gh pr merge` fails (GitHub branch protection, CI not ready, etc.) and Claude retries within the same 30-min auth window, non-blocking tracking issues were created again. Appends `ISSUES_CREATED=1` to the merge-lock file after issue creation; retries within the same window skip issue creation with a log message. Fresh auth windows (new `merge-lock.sh authorize`) behave normally.

- **Non-interactive flag gate**: when invoked from Claude Code (`CLAUDECODE` env set), now requires `--squash` and `--delete-branch`. Without those flags the actual merge step fails after a full 120s Claude analysis cycle. The gate exits in milliseconds before any API call and tells Claude exactly what to retry with. Interactive (human-run) invocations are unaffected.

## Test plan

- [ ] Authorize a PR, run `gh pr merge <N> --squash --delete-branch`, let analysis pass, let the merge itself fail (or interrupt) — confirm `ISSUES_CREATED=1` is appended to the lock file
- [ ] Retry the merge — confirm log says "already filed… skipping" and no duplicate issues are created
- [ ] Run `gh pr merge <N>` (no flags) from within Claude Code — confirm immediate exit with flag guidance, no API calls made
- [ ] Run `gh pr merge <N>` (no flags) from a normal terminal — confirm no gate triggered, review proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)