### PR TITLE
feat: install.sh removes ~/.claude/.git on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -370,6 +370,14 @@ fi
 # Only remove files that are git repo artifacts — not user config files.
 # .pre-commit-config.yaml, .flake8, .editorconfig are repo-tooling that
 # should not exist in the deploy dir, but are harmless if present.
+# Safety: if REPO_DIR and DEPLOY_DIR resolve to the same path, skip —
+# we'd be deleting our own repo's git data.
+_resolved_repo="$(cd "${REPO_DIR}" && pwd -P)"
+_resolved_deploy="$(cd "${DEPLOY_DIR}" && pwd -P)"
+if [[ "${_resolved_repo}" == "${_resolved_deploy}" ]]; then
+  _warn "REPO_DIR and DEPLOY_DIR are the same path — skipping git metadata cleanup"
+else
+
 _GIT_META_FILES=(".git" ".gitignore" ".gitmodules")
 
 for meta in "${_GIT_META_FILES[@]}"; do
@@ -390,6 +398,8 @@ for meta in "${_GIT_META_FILES[@]}"; do
     fi
   fi
 done
+
+fi  # end REPO_DIR != DEPLOY_DIR guard
 
 # ============================================================================
 # 9. SUMMARY


### PR DESCRIPTION
## Summary
- After symlinking, install.sh now removes git metadata (.git, .gitignore, .gitmodules) from ~/.claude if present
- Only true git artifacts — not repo-tooling files
- Checks rm exit code, skips symlinks, respects --dry-run
- Makes fresh clone → install a single-step operation (no manual .git cleanup)

## Test plan
- [x] shellcheck clean
- [x] Dry-run shows no changes (already cleaned up)
- [x] Pre-commit reviewers: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)