### PR TITLE
fix(pre-merge): make Seer Code Review non-blocking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ After committing, verify the hook ran: `head -6 $(git rev-parse --git-dir)/last-
 
 After pushing, you are NOT DONE. Monitor CI and iterate until approved. Do not abandon the PR. If CI fails or remote review finds issues, fix locally, re-review, push again.
 
-Use `bash ~/.claude/scripts/post-push-status.sh <PR#>` to poll CI status. Seer Code Review is treated as blocking — do not merge until it passes.
+Use `bash ~/.claude/scripts/post-push-status.sh <PR#>` to poll CI status. Seer Code Review is **advisory / non-blocking** — its inline findings flow through to the local pre-merge AI analysis but do not block merge. (Seer runs on Sentry infrastructure, which is flaky and rate-limited; treating it as blocking creates merge stalls. Examine its findings as one input alongside CI, human reviewers, and the local code-reviewer agents.)
 
 Full procedure: `~/.claude/docs/CHECKLISTS.md` (Post-Push Procedure)
 

--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -341,13 +341,17 @@ if [[ -n "${_CHANGES_REQUESTED}" ]]; then
 fi
 
 # --- Check for NEUTRAL CI status (blocking) ---
-# Sentry/Seer sets status to "neutral" when there are unresolved comments
-# This is a hard block - don't proceed to AI analysis
-# Exclude Netlify informational checks that return NEUTRAL when nothing changed:
-# - "Pages changed" / "Pages changed - <site-name>" - no pages modified
-# - "Header rules" / "Header rules - <site-name>" - no headers modified
-# - "Redirect rules" / "Redirect rules - <site-name>" - no redirects modified
-# These checks are informational only; NEUTRAL means "nothing to validate"
+# Some checks set status to "neutral" when there are unresolved comments.
+# This is a hard block - don't proceed to AI analysis.
+#
+# Exclusions (NEUTRAL on these is NOT a block):
+# - "Pages changed" / "Header rules" / "Redirect rules" — Netlify informational
+#   checks that return NEUTRAL when nothing changed. Informational only.
+# - "Seer Code Review" (and any "Seer*" check) — Sentry's Seer reports findings
+#   via NEUTRAL conclusion, but it runs on Sentry infrastructure (flaky/rate-
+#   limited). Treated as non-blocking advisory: Seer's inline comments still
+#   flow through to the AI analysis below via the inline comments fetcher,
+#   so any findings are surfaced as advisory input — just not as a hard block.
 NEUTRAL_CHECKS=$(echo "${PR_JSON}" | jq -r '
   .statusCheckRollup // []
   | .[]
@@ -356,6 +360,7 @@ NEUTRAL_CHECKS=$(echo "${PR_JSON}" | jq -r '
       and (.name | startswith("Pages changed") | not)
       and (.name | startswith("Header rules") | not)
       and (.name | startswith("Redirect rules") | not)
+      and (.name | startswith("Seer") | not)
     )
   | "- \(.name): \(.conclusion)"
 ' 2>&1) || true
@@ -643,6 +648,12 @@ CRITICAL RULES:
   - FAILURE/NEUTRAL conclusion = blocking issue that must be addressed
   - SUCCESS = CI passed, but still check inline comments for specific concerns
   - PENDING = check still running, cannot merge yet
+- **SEER EXCEPTION**: "Seer Code Review" check is NON-BLOCKING regardless of
+  conclusion (SUCCESS/FAILURE/NEUTRAL/PENDING). Seer runs on Sentry
+  infrastructure (flaky/rate-limited) and reports findings via NEUTRAL
+  conclusion. Its findings flow through as inline review comments below and
+  are advisory only. Do not block merge on Seer check status — examine its
+  inline comments alongside other input.
 - **INLINE COMMENTS**: Bots like "sentry[bot]" and "Seer" post comments on specific code lines, NOT as review summaries
   - These appear in the "Inline Review Comments" section below
   - IMPORTANT: Outdated comments (code changed) and resolved threads are already filtered out


### PR DESCRIPTION
## Summary

- Add `Seer*` to the `NEUTRAL_CHECKS` jq exclusion in `hooks/pre-merge-review.sh` so Sentry's Seer Code Review can no longer hard-block merges via NEUTRAL conclusion.
- Add a new **SEER EXCEPTION** rule in the AI analysis prompt (`CRITICAL RULES` section) telling the analyzer to treat `Seer Code Review` as non-blocking regardless of conclusion.
- Update `CLAUDE.md` Protocol 5 to match: Seer is advisory, not blocking.

## Why

Seer runs on Sentry's infrastructure (flaky / rate-limited) and reports findings via `NEUTRAL` conclusion. The previous behavior treated NEUTRAL as a hard block, which caused merge stalls when Sentry was slow or down. Seer's findings still flow through the local AI analysis as inline review comments via the existing inline-comment fetcher (lines 394+) — they're just no longer a pre-analysis hard block.

## Test plan

- [x] `shellcheck -S info hooks/pre-merge-review.sh` — only pre-existing SC1091 (info) for runtime-sourced lib
- [x] Pre-commit hooks (code-reviewer + adversarial-reviewer) — both PASS
- [x] Pre-push codebase review — PASS (one non-blocking nit filed as #106 for cosmetic cleanup of now-stale error text at line 375)
- [ ] CI Claude Blocking Review

## Follow-up

- #106: Stale "Sentry/Seer Code Review" reference in `NEUTRAL_CHECKS` error message at line 375 — cosmetic, can be cleaned up via Ralph burndown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)