### PR TITLE
fix(install): re-exec under bash when invoked via `sh install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Re-exec under bash if invoked as "sh install.sh"
 if [ -z "${BASH_VERSION:-}" ]; then
-  exec bash "$0" "$@"
+  exec bash "$0" "$@" || { echo "Error: bash is required but not found in PATH" >&2; exit 1; }
 fi
 
 set -euo pipefail

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Re-exec under bash if invoked as "sh install.sh"
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 # ~/Developer/claude-config/install.sh


### PR DESCRIPTION
## Summary
- Adds a `BASH_VERSION` guard at the top of `install.sh` that `exec`s into bash when the script is invoked via `sh install.sh`
- Placed before `set -euo pipefail` since `pipefail` is itself a bashism
- Fixes syntax error at line 102 (process substitution) when run under `/bin/sh`

## Test plan
- [ ] Run `sh install.sh` — should succeed instead of erroring at line 102
- [ ] Run `./install.sh` — should continue to work as before
- [ ] Run `bash install.sh` — should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)