### PR TITLE
docs: local-review feedback loop for recurring CI findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ Use `bash ~/.claude/scripts/post-push-status.sh <PR#>` to poll CI status. Seer C
 
 Full procedure: `~/.claude/docs/CHECKLISTS.md` (Post-Push Procedure)
 
+**Recurring CI findings = local-review failure**, not normal workflow. See `~/.claude/docs/CODE-REVIEW.md` (Recurring CI Findings Signal Local Review Gaps) for the feedback loop to close those gaps.
+
 ---
 
 ### Protocol 6: PR Lifecycle

--- a/docs/CODE-REVIEW.md
+++ b/docs/CODE-REVIEW.md
@@ -84,6 +84,18 @@ When a pre-commit hook or review agent flags an issue, the **strongly preferred*
 
 ---
 
+## Recurring CI Findings Signal Local Review Gaps
+
+Local review (pre-commit code-reviewer + adversarial-reviewer, pre-push codebase-reviewer) exists to catch issues **before** push. Every finding that slips to CI costs real time and money; local verification is free.
+
+**The rule:** If CI consistently returns findings local review missed, treat it as a local-review failure — not as CI "catching extra stuff."
+
+**Feedback loop:** When a CI finding lands that local review should have caught, note the category. After 2–3 repeats of the same category, update local reviewer prompts, pre-commit hooks, or this file's checklists so the class of issue is caught locally.
+
+**Not normal workflow:** `post-push-loop` iterations are a safety net, not the primary review mechanism. A PR needing 3+ loop iterations means local review needs improvement.
+
+---
+
 ## Return to Main Documentation
 
 → Return to `~/.claude/CLAUDE.md`


### PR DESCRIPTION
## Summary

Documents the principle that recurring CI findings represent a local-review gap to close — not normal workflow. Applies to all repos using the standard local-review + post-push-loop workflow.

## Changes

- \`docs/CODE-REVIEW.md\`: new "Recurring CI Findings Signal Local Review Gaps" section with the feedback-loop rule (2–3 repeats of the same category → update local review config)
- \`CLAUDE.md\`: one-line cross-reference from Protocol 5 for discoverability

## Why

The enhanced local review stack (pre-commit code-reviewer + adversarial-reviewer, pre-push codebase-reviewer) exists to catch issues before push because pushes cost real time and money. If CI keeps catching things local review missed, the free step is underperforming and the expensive step is doing work that should have happened locally. Without a documented feedback loop, the pattern becomes normalized.

## Test plan

- [x] Markdown-only — pre-commit + pre-push review clean
- [ ] Next PR cycle: observe whether the cross-reference makes the principle reachable from session context

🤖 Generated with [Claude Code](https://claude.com/claude-code)