### PR TITLE
fix(post-push-status): defensive API parsing + preflight repo check

### DIFF
--- a/scripts/post-push-status.sh
+++ b/scripts/post-push-status.sh
@@ -26,6 +26,16 @@ fi
 
 echo "RESOLVED_OWNER=${OWNER} RESOLVED_REPO=${REPO}" >&2
 
+# Preflight: confirm the PR exists in the resolved repo before continuing.
+# Without this, running from the wrong CWD silently polls the wrong repo and
+# produces confusing downstream errors (jq blowups on 404 error bodies etc).
+if ! gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.number' >/dev/null 2>&1; then
+  echo "ERROR: PR #${PR_NUMBER} not found in ${OWNER}/${REPO}." >&2
+  echo "  If the PR is in a different repo, set POSTPUSH_OWNER=<owner> POSTPUSH_REPO=<repo>" >&2
+  echo "  or re-run from that repo's directory." >&2
+  exit 1
+fi
+
 CURRENT_COMMIT="${POSTPUSH_CURRENT_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo "")}"
 if [[ -z "${CURRENT_COMMIT}" ]]; then
   echo "ERROR: cannot determine current commit" >&2
@@ -83,8 +93,26 @@ BOT_PATTERN='sentry\[bot\]|claude\[bot\]|coderabbit\[bot\]'
 # Fetch both inline diff comments (pulls/comments) and PR conversation comments
 # (issues/comments). Bots like sentry[bot] post to issues/comments (the PR conversation
 # thread); code review bots typically post to pulls/comments (inline diff comments).
-{ gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" 2>/dev/null || echo "[]"; } >"${TMPFILE}_pulls"
-{ gh api "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" 2>/dev/null || echo "[]"; } >"${TMPFILE}_issues"
+#
+# _safe_api_array: `gh api` prints its error body to stdout BEFORE exiting nonzero,
+# so `{ gh api ... || echo "[]"; }` leaves the file with BOTH the error JSON object
+# and "[]" concatenated — then jq's `.[0] + .[1]` tries to add object+array and
+# explodes. Capture output to a variable first, shape-validate as a JSON array,
+# and only write `[]` if validation fails. Preserves empty-list semantics without
+# letting malformed/error bodies leak through.
+_safe_api_array() {
+  local url="$1"
+  local body
+  if body=$(gh api "${url}" 2>/dev/null) \
+    && echo "${body}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    printf '%s\n' "${body}"
+  else
+    printf '%s\n' "[]"
+  fi
+}
+
+_safe_api_array "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" >"${TMPFILE}_pulls"
+_safe_api_array "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" >"${TMPFILE}_issues"
 jq -s '.[0] + .[1]' "${TMPFILE}_pulls" "${TMPFILE}_issues" >"${TMPFILE}" || echo "[]" >"${TMPFILE}"
 rm -f "${TMPFILE}_pulls" "${TMPFILE}_issues"
 

--- a/scripts/tests/test-post-push-status.sh
+++ b/scripts/tests/test-post-push-status.sh
@@ -42,6 +42,20 @@ gh() {
   local args="$*"
   # Log all calls so tests can assert on owner/repo values flowing through
   echo "MOCK_CALLED_WITH=${args}" >&2
+  # Preflight: bare pulls/<N> existence check (no /comments suffix, no GraphQL).
+  # post-push-status.sh calls `gh api "repos/<O>/<R>/pulls/<N>" --jq .number` as
+  # a preflight to confirm the PR exists in the resolved repo. Always returns
+  # a minimal valid body here so the script proceeds to the real GQL+comments
+  # mocks below. Owner/repo mismatch is still enforced by those downstream
+  # mocks (see PR 99 statusCheckRollup gate).
+  if echo "${args}" | grep -qE 'pulls/[0-9]+( |$)' \
+    && ! echo "${args}" | grep -q "/comments" \
+    && ! echo "${args}" | grep -q "statusCheckRollup"; then
+    local _preflight_pr_num
+    _preflight_pr_num=$(echo "${args}" | grep -oE 'pulls/[0-9]+' | tail -1 | grep -oE '[0-9]+')
+    echo "{\"number\":${_preflight_pr_num}}"
+    return 0
+  fi
   if echo "${args}" | grep -q "statusCheckRollup"; then
     # For PR 99 (owner/repo override test), require owner=testowner so wrong owner hits UNEXPECTED
     if echo "${args}" | grep -qF "number=99" && ! echo "${args}" | grep -qF "owner=testowner"; then


### PR DESCRIPTION
## Summary

Running `post-push-status.sh` from the wrong repo CWD produced a jq blowup instead of a clear error:

```
jq: error (at /tmp/post-push-comments.XXXXXX.json_issues:1): object ({"message":...) and array ([]) cannot be added
```

Root cause: `gh api` prints its error body (e.g. `{"message":"Not Found"}`) to stdout *before* exiting nonzero. The existing `{ gh api ... || echo "[]"; }` group leaves the file with BOTH the error body AND the fallback `[]` concatenated. Downstream `jq -s '.[0] + .[1]'` then tries to add object+array and explodes.

Two fixes on the same script:

1. **Preflight check.** Before polling comments, verify the PR number actually exists in the resolved repo. On mismatch, emit a clear message pointing at `POSTPUSH_OWNER`/`POSTPUSH_REPO` env vars and exit 1. Saves operators from downstream noise when they run the script from the wrong CWD (the common failure mode).
2. **`_safe_api_array` helper.** Captures `gh api` output to a variable, validates it's a JSON array via `jq -e 'type == "array"'`, and only then writes it. Falls back to `[]` on any non-array shape (error object, empty body, malformed). Removes the concatenation hazard entirely.

Test mock updated with a handler for the new preflight URL shape (`pulls/<N>` without `/comments` or GraphQL). All 16 tests still pass.

## Test plan

- [x] `shellcheck -S info` clean on script + test
- [x] `bash` syntax parse clean
- [x] Local unit tests 16/16 PASS
- [x] Manual: `bash post-push-status.sh 73` from wrong CWD → clean exit 1 with preflight message (previously: jq error)
- [x] Manual: `POSTPUSH_OWNER=smartwatermelon POSTPUSH_REPO=dotfiles bash post-push-status.sh 73` → `CI_STATE=SUCCESS`, fetched real claude[bot] comment
- [x] Pre-commit code-reviewer + adversarial-reviewer PASS (twice — once before test-mock fix caught it, once after)
- [x] Pre-push full-diff adversarial-reviewer PASS
- [x] Pre-push codebase-mode adversarial-reviewer PASS with explicit verification of both new behaviors
- [ ] CI claude-blocking-review PASS

Discovered while triaging Batch A's companion work — the script is on the hot path for every batch's post-push CI monitoring, so fixing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)