### PR TITLE
refactor(run-review): parallelize reviewers, CLI preflight, cache versioning, remove dead detection

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -361,10 +361,14 @@ ${file_diff}
     [[ -f "${_result_file}" ]] || continue
     _rout=$(tail -n +2 "${_result_file}")
 
-    # "agent error" synthetic verdict indicates the agent failed — skip the
-    # file rather than counting it as a blocking issue. Matches the prior
-    # serial behavior where agent_exit != 0 incremented skipped_files.
-    if echo "${_rout}" | grep -q "VERDICT: FAIL (agent error"; then
+    # Synthetic transient-failure verdicts (timeout or agent error) indicate
+    # the agent failed — skip the file rather than counting it as a blocking
+    # issue. Matches the prior serial behavior where agent_exit != 0 always
+    # incremented skipped_files. invoke_agent emits either "(timeout)" or
+    # "(agent error: N)"; real content failures produce a bare "VERDICT: FAIL"
+    # followed by SEVERITY/ISSUE/LOCATION lines with no parens on the verdict.
+    # Match any "VERDICT: FAIL (" (parenthesis-suffixed) to catch both.
+    if echo "${_rout}" | grep -q "VERDICT: FAIL ("; then
       log_warn "Agent timeout/error for ${_rfile} - skipping this file"
       ((skipped_files += 1))
       continue

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -101,6 +101,27 @@ if [[ ! -x "${CLAUDE_CLI}" ]]; then
   exit 1
 fi
 
+# Responsiveness check: if the CLI is hung, each agent invocation below
+# burns TIMEOUT_SECONDS (120-300s) before failing. A --version call should
+# return within a few seconds; if `timeout` has to kill it (exit 124), the
+# CLI is hung — fail fast so the caller can diagnose instead of waiting
+# through multiple long timeouts.
+#
+# Note: we ONLY fail on exit 124 (timeout). A CLI that responds with any
+# other nonzero status (broken install, auth expired, etc.) is still
+# responsive — let the real invocation surface the actionable error. Mock
+# CLIs in the test suite exit with configured codes; those must not trip
+# this preflight. See hooks/tests/run-review-test.sh.
+_preflight_rc=0
+timeout 5 "${CLAUDE_CLI}" --version >/dev/null 2>&1 || _preflight_rc=$?
+if [[ ${_preflight_rc} -eq 124 ]]; then
+  log_error "Claude CLI did not respond to --version within 5s: ${CLAUDE_CLI}"
+  log_error "CLI may be hung. Diagnose:"
+  log_error "  timeout 5 ${CLAUDE_CLI} --version"
+  exit 1
+fi
+unset _preflight_rc
+
 # --- Agent invocation function ---
 invoke_agent() {
   local agent_name="$1"
@@ -277,9 +298,10 @@ Review this diff:
 ${file_diff}
 \`\`\`"
 
-    # Create per-file cache key
+    # Create per-file cache key. Includes SCRIPT_SHA so prompt/logic edits
+    # invalidate stale PASS entries (see DIFF_HASH above for rationale).
     local file_cache_key
-    file_cache_key=$(echo "${file_diff}" | sha256sum 2>/dev/null | cut -d' ' -f1 || echo "nocache")
+    file_cache_key=$(printf '%s\n%s\n' "${SCRIPT_SHA:-nover}" "${file_diff}" | sha256sum 2>/dev/null | cut -d' ' -f1 || echo "nocache")
     local file_cache="${CACHE_DIR}/${file//\//_}_${file_cache_key}"
 
     # Invoke agent for this file (|| prevents set -e from propagating on CLI failure)
@@ -404,7 +426,13 @@ mkdir -p "${CACHE_DIR}"
 # Clean up cache entries older than 30 days to prevent unbounded growth
 find "${CACHE_DIR}" -type f -mtime +30 -delete 2>/dev/null || true
 
-DIFF_HASH=$(echo "${DIFF}" | shasum -a 256 | awk '{print $1}')
+# Cache key includes the hash of THIS script so edits to review logic or
+# prompt text automatically invalidate stale PASS entries. Without this,
+# a tightened adversarial prompt would read old PASS cache for identical
+# diffs and silently skip the stricter review. Fail open on shasum miss
+# (falls back to diff-only hash) so cache still works in stripped envs.
+SCRIPT_SHA=$(shasum -a 256 "${BASH_SOURCE[0]}" 2>/dev/null | awk '{print $1}' | cut -c1-12 || echo "nover")
+DIFF_HASH=$(printf '%s\n%s\n' "${SCRIPT_SHA}" "${DIFF}" | shasum -a 256 | awk '{print $1}')
 CACHE_FILE="${CACHE_DIR}/${DIFF_HASH}"
 
 if [[ -f "${CACHE_FILE}" ]]; then
@@ -709,102 +737,14 @@ END_ISSUE"
   fi
 fi
 
-# --- Detect when adversarial review is warranted ---
-# EXPANDED: More aggressive detection - extra review time beats CI cycles
-detect_security_critical() {
-  local files
-  files=$(git diff --cached --name-only 2>/dev/null || echo "")
-
-  # Path-based patterns (primary detection) - SIGNIFICANTLY EXPANDED
-  # Philosophy: Better to over-review than under-review
-  local path_patterns=(
-    # Authentication & Authorization
-    'auth|oauth|jwt|password|session|login|register|signin|signup|sso|saml|ldap|credential|token'
-    # Payment & Financial
-    'payment|billing|stripe|paypal|checkout|transaction|invoice|subscription|pricing|cart|order'
-    # Database & Data
-    'db|database|model|migration|schema|query|sql|orm|prisma|sequelize|typeorm|repository|entity'
-    # Security & Cryptography
-    'security|crypto|encryption|secret|vault|key|certificate|hash|cipher'
-    # API & External Services
-    'api|webhook|endpoint|middleware|interceptor|gateway|route|controller|handler'
-    # User Data & Privacy
-    'user|account|profile|permission|role|access|admin|privilege|member'
-    # Configuration & Infrastructure
-    'config|env|environment|setting|\.env|secret|credential'
-    # State Management (often security-sensitive)
-    'store|state|reducer|context|provider'
-    # Forms & Input (validation, injection risks)
-    'form|input|validate|sanitize|filter'
-    # File Operations (path traversal, uploads)
-    'file|upload|download|storage|asset|media'
-    # Network & Communication
-    'http|fetch|axios|request|socket|websocket|sse'
-    # Testing (ensure security tests exist)
-    'test|spec|\.test\.|\.spec\.'
-  )
-
-  local combined_pattern
-  combined_pattern=$(printf '%s|' "${path_patterns[@]}")
-  combined_pattern="${combined_pattern%|}" # Remove trailing |
-
-  if echo "${files}" | grep -qiE "(${combined_pattern})"; then
-    return 0 # Warrants adversarial review
-  fi
-
-  # Content-based detection (scan diff for sensitive patterns)
-  local content_patterns=(
-    # Secrets & Keys
-    'API_KEY|SECRET_KEY|PRIVATE_KEY|ACCESS_TOKEN|REFRESH_TOKEN|BEARER|PASSWORD'
-    # Auth patterns
-    'bcrypt|argon2|pbkdf2|authenticate|authorize|permission|isAdmin|hasRole'
-    # Payment
-    'stripe|paypal|braintree|credit.?card|payment.?intent|charge'
-    # Database queries
-    'SELECT|INSERT|UPDATE|DELETE|DROP|CREATE TABLE|ALTER TABLE|query\(|execute\('
-    # Security functions
-    'encrypt|decrypt|hash|salt|nonce|cipher|sign|verify'
-    # Dangerous patterns (injection risks)
-    'eval\(|exec\(|system\(|shell_exec|child_process|subprocess|dangerouslySetInnerHTML'
-    # File operations
-    'readFile|writeFile|unlink|rmdir|chmod|chown|createReadStream|createWriteStream'
-    # Network
-    'fetch\(|axios\.|http\.|https\.|request\(|\.get\(|\.post\(|\.put\(|\.delete\('
-    # Environment variables
-    'process\.env|import\.meta\.env|getenv|os\.environ'
-    # Error handling (often reveals sensitive info)
-    'catch\s*\(|\.catch\(|try\s*{|throw\s+new'
-  )
-
-  local content_pattern
-  content_pattern=$(printf '%s|' "${content_patterns[@]}")
-  content_pattern="${content_pattern%|}"
-
-  if echo "${DIFF}" | grep -qiE "(${content_pattern})"; then
-    return 0 # Warrants adversarial review
-  fi
-
-  # File extension check - certain extensions always warrant scrutiny
-  if echo "${files}" | grep -qiE '\.(sql|env|key|pem|crt|p12|pfx|jks)$'; then
-    return 0
-  fi
-
-  # Size-based heuristic: Larger changes warrant more scrutiny
-  local line_count
-  line_count=$(echo "${DIFF}" | wc -l | tr -d ' ')
-  if [[ ${line_count} -gt 200 ]]; then
-    return 0 # Large changes warrant adversarial review
-  fi
-
-  return 1 # Doesn't need adversarial review
-}
-
-IS_SECURITY_CRITICAL=false
-if detect_security_critical; then
-  IS_SECURITY_CRITICAL=true
-fi
-
 # --- Agent-Based Review Flow ---
+# Both code-reviewer and adversarial-reviewer run on every commit regardless
+# of content. The prior detect_security_critical heuristic (~90 lines of
+# regex patterns matching paths/content/extensions) was removed because its
+# only consumer was a single log_info — it never changed reviewer behavior,
+# prompt content, or cache policy. If differentiated scrutiny is ever
+# needed, wire it with intent (different prompt, different timeout, or
+# separate cache bucket) instead of resurrecting the dead heuristic.
 
 # Build cache keys
 CODE_REVIEWER_CACHE="${CACHE_DIR}/code-reviewer-${DIFF_HASH}"
@@ -872,13 +812,8 @@ fi
 
 # Step 2: Run adversarial-reviewer (always)
 # The adversarial-reviewer runs on every commit alongside code-reviewer.
-# Security-critical detection is still logged for informational purposes.
 ADVERSARIAL_OUTPUT=""
 ADVERSARIAL_VERDICT="N/A"
-
-if [[ "${IS_SECURITY_CRITICAL}" == true ]]; then
-  log_info "Security-critical files detected — adversarial review has elevated scrutiny"
-fi
 
 # Check if adversarial-reviewer agent exists
 if ! find -L "${HOME}/.claude/plugins/marketplaces" -name "adversarial-reviewer.md" -type f 2>/dev/null | grep -q .; then

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -249,26 +249,48 @@ perform_chunked_review() {
   local skipped_files=0
   local issues_output=""
 
-  # Review each file separately
+  # Parallel dispatch: up to CHUNK_PARALLEL claude invocations in flight.
+  # Each subshell writes its result (file path on line 1, agent output from
+  # line 2 onwards) to a unique file under _chunk_results. Aggregation runs
+  # serially after `wait`. Bound prevents pathological diffs (50 files)
+  # from launching 50 concurrent claude processes.
+  local CHUNK_PARALLEL
+  CHUNK_PARALLEL=$(git config --get --type=int review.chunkParallel 2>/dev/null || echo "4")
+  local _chunk_results
+  _chunk_results=$(mktemp -d)
+  local -a _chunk_pids=()
+
+  # Dispatch phase: build per-file prompt, spawn background invoke_agent.
+  # Skip-if-too-large is still serial (and bumps skipped_files directly).
   while IFS= read -r file; do
     [[ -z "${file}" ]] && continue
 
     local file_diff
     file_diff=$(git diff --cached -U10 -- "${file}" 2>/dev/null || echo "")
-
     [[ -z "${file_diff}" ]] && continue
 
     local file_lines
     file_lines=$(echo "${file_diff}" | wc -l | tr -d ' ')
 
-    # Skip if file diff is too large
     if [[ ${file_lines} -gt ${REVIEW_CHUNK_SIZE} ]]; then
       log_warn "Skipping ${file} (${file_lines} lines > ${REVIEW_CHUNK_SIZE} chunk size)"
       ((skipped_files += 1))
       continue
     fi
 
-    # Build prompt for this file
+    # Bounded concurrency: reap finished pids, sleep if still at cap.
+    while [[ ${#_chunk_pids[@]} -ge ${CHUNK_PARALLEL} ]]; do
+      local -a _alive_pids=()
+      local _p
+      for _p in "${_chunk_pids[@]}"; do
+        if kill -0 "${_p}" 2>/dev/null; then
+          _alive_pids+=("${_p}")
+        fi
+      done
+      _chunk_pids=("${_alive_pids[@]}")
+      [[ ${#_chunk_pids[@]} -lt ${CHUNK_PARALLEL} ]] || sleep 0.1
+    done
+
     local file_prompt
     file_prompt="Reviewing file: ${file}
 
@@ -304,36 +326,65 @@ ${file_diff}
     file_cache_key=$(printf '%s\n%s\n' "${SCRIPT_SHA:-nover}" "${file_diff}" | sha256sum 2>/dev/null | cut -d' ' -f1 || echo "nocache")
     local file_cache="${CACHE_DIR}/${file//\//_}_${file_cache_key}"
 
-    # Invoke agent for this file (|| prevents set -e from propagating on CLI failure)
-    local file_output
-    local agent_exit=0
-    file_output=$(invoke_agent "code-reviewer" "${file_prompt}" "${file_cache}") || agent_exit=$?
+    # Sanitize file path to a safe filename for the result file.
+    local _safe_name="${file//\//__}"
+    _safe_name="${_safe_name// /_}"
 
-    # If agent failed (timeout, error), skip this file — don't block the commit
-    if [[ ${agent_exit} -ne 0 ]]; then
-      log_warn "Agent timeout/error for ${file} - skipping this file"
+    # Background dispatch. Each subshell captures invoke_agent stdout;
+    # stderr (progress lines) flows through to the user's terminal. Empty
+    # output on agent error is normalized here so the aggregate loop can
+    # treat it uniformly.
+    (
+      _fout=$(invoke_agent "code-reviewer" "${file_prompt}" "${file_cache}") || true
+      [[ -n "${_fout}" ]] || _fout="VERDICT: FAIL (agent error: invoke_agent produced no output)"
+      {
+        printf '%s\n' "${file}"
+        printf '%s\n' "${_fout}"
+      } >"${_chunk_results}/${_safe_name}"
+    ) &
+    _chunk_pids+=("$!")
+  done <<<"${files}"
+
+  # Wait for all remaining background jobs.
+  wait 2>/dev/null || true
+
+  # Aggregate phase: walk the per-file result files, accumulate counts,
+  # build the issues_output digest. Runs serially on the main shell so
+  # all state updates are safe.
+  local _result_file _rfile _rout
+  for _result_file in "${_chunk_results}"/*; do
+    [[ -f "${_result_file}" ]] || continue
+    _rfile=$(head -1 "${_result_file}")
+    _rout=$(tail -n +2 "${_result_file}")
+
+    # "agent error" synthetic verdict indicates the agent failed — skip the
+    # file rather than counting it as a blocking issue. Matches the prior
+    # serial behavior where agent_exit != 0 incremented skipped_files.
+    if echo "${_rout}" | grep -q "VERDICT: FAIL (agent error"; then
+      log_warn "Agent timeout/error for ${_rfile} - skipping this file"
       ((skipped_files += 1))
       continue
     fi
 
-    # Parse verdict
-    if echo "${file_output}" | grep -q "VERDICT: FAIL"; then
-      if echo "${file_output}" | grep -q "SEVERITY: BLOCKING"; then
+    if echo "${_rout}" | grep -q "VERDICT: FAIL"; then
+      if echo "${_rout}" | grep -q "SEVERITY: BLOCKING"; then
         ((blocking_count += 1))
         overall_verdict="FAIL"
       else
         ((warning_count += 1))
       fi
 
-      # Accumulate issues for final display
       issues_output="${issues_output}
 
-=== Issues in ${file} ===
-${file_output}"
+=== Issues in ${_rfile} ===
+${_rout}"
     fi
 
     ((reviewed_files += 1))
-  done <<<"${files}"
+  done
+
+  rm -rf "${_chunk_results}"
+  unset _chunk_results _chunk_pids
 
   # Display accumulated issues
   if [[ -n "${issues_output}" ]]; then
@@ -788,15 +839,57 @@ ${DIFF}
 printf 'diff_lines: %d\n' "${DIFF_LINES}" >>"${REVIEW_LOG}" || true
 log_info "Review log: ${REVIEW_LOG}"
 
-# Step 1: Run code-reviewer (always)
-# || true: invoke_agent may return 1 on transient CLI failure; set -e must not kill the script.
-# Errors surface as "VERDICT: FAIL (agent error: N)" in output and are handled below.
-CODE_REVIEWER_OUTPUT=$(invoke_agent "code-reviewer" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}") || true
+# Run code-reviewer and adversarial-reviewer in parallel when both are
+# available. Each reviewer's stdout is captured to its own temp file so
+# the outputs don't interleave. stderr (log_info progress lines) flows
+# through to the user's terminal — it may interleave between the two
+# agents but remains readable because each log line is agent-prefixed.
+#
+# Parallelization roughly halves wall time on the common two-agent path
+# (previously serial at 60-120s each; now both run concurrently).
+#
+# Serial fallback: when adversarial-reviewer isn't installed, only
+# code-reviewer runs (unchanged from the prior serial behavior).
+
+ADVERSARIAL_OUTPUT=""
+ADVERSARIAL_VERDICT="N/A"
+ADVERSARIAL_AVAILABLE=true
+if ! find -L "${HOME}/.claude/plugins/marketplaces" -name "adversarial-reviewer.md" -type f 2>/dev/null | grep -q .; then
+  log_warn "adversarial-reviewer agent not found - skipping (see ~/.claude/docs/CUSTOM_AGENTS.md for setup)"
+  ADVERSARIAL_AVAILABLE=false
+fi
+
+if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
+  _cr_out=$(mktemp)
+  _ar_out=$(mktemp)
+  # Subshells inherit set -e. invoke_agent handles its own errors and always
+  # echoes a verdict line (real output, or synthetic "VERDICT: FAIL (agent
+  # error/timeout)"). `|| true` on the wait calls suppresses propagation of
+  # the subshell's exit status; the same empty-output guard below handles
+  # any silent failure.
+  (invoke_agent "code-reviewer" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}" >"${_cr_out}") &
+  _cr_pid=$!
+  (invoke_agent "adversarial-reviewer" "${AGENT_PROMPT}" "${ADVERSARIAL_CACHE}" >"${_ar_out}") &
+  _ar_pid=$!
+  wait "${_cr_pid}" || true
+  wait "${_ar_pid}" || true
+  CODE_REVIEWER_OUTPUT=$(cat "${_cr_out}")
+  ADVERSARIAL_OUTPUT=$(cat "${_ar_out}")
+  rm -f "${_cr_out}" "${_ar_out}"
+  unset _cr_out _ar_out _cr_pid _ar_pid
+else
+  # Serial path (no adversarial): only code-reviewer runs.
+  CODE_REVIEWER_OUTPUT=$(invoke_agent "code-reviewer" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}") || true
+fi
+
 # Guard: invoke_agent may exit 0 but produce no output (silent agent failure).
 # Normalise to a transient-error verdict so the non-blocking check below handles it.
 [[ -n "${CODE_REVIEWER_OUTPUT}" ]] || CODE_REVIEWER_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
+if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
+  [[ -n "${ADVERSARIAL_OUTPUT}" ]] || ADVERSARIAL_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
+fi
 
-# Parse verdict from output (errors produce "VERDICT: FAIL (agent error: ...)")
+# Parse verdict from code-reviewer output
 if echo "${CODE_REVIEWER_OUTPUT}" | grep -q "VERDICT: PASS"; then
   CODE_REVIEWER_VERDICT="PASS"
 elif echo "${CODE_REVIEWER_OUTPUT}" | grep -q "VERDICT: FAIL"; then
@@ -810,21 +903,8 @@ else
   exit 1
 fi
 
-# Step 2: Run adversarial-reviewer (always)
-# The adversarial-reviewer runs on every commit alongside code-reviewer.
-ADVERSARIAL_OUTPUT=""
-ADVERSARIAL_VERDICT="N/A"
-
-# Check if adversarial-reviewer agent exists
-if ! find -L "${HOME}/.claude/plugins/marketplaces" -name "adversarial-reviewer.md" -type f 2>/dev/null | grep -q .; then
-  log_warn "adversarial-reviewer agent not found - skipping (see ~/.claude/docs/CUSTOM_AGENTS.md for setup)"
-  ADVERSARIAL_VERDICT="N/A"
-else
-  # || true: same set -e guard as code-reviewer above
-  ADVERSARIAL_OUTPUT=$(invoke_agent "adversarial-reviewer" "${AGENT_PROMPT}" "${ADVERSARIAL_CACHE}") || true
-  # Guard: same silent-failure normalisation as code-reviewer above
-  [[ -n "${ADVERSARIAL_OUTPUT}" ]] || ADVERSARIAL_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
-
+# Parse verdict from adversarial-reviewer output (when available)
+if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
   if echo "${ADVERSARIAL_OUTPUT}" | grep -q "VERDICT: PASS"; then
     ADVERSARIAL_VERDICT="PASS"
   elif echo "${ADVERSARIAL_OUTPUT}" | grep -q "VERDICT: FAIL"; then

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -348,13 +348,17 @@ ${file_diff}
   # Wait for all remaining background jobs.
   wait 2>/dev/null || true
 
-  # Aggregate phase: walk the per-file result files, accumulate counts,
-  # build the issues_output digest. Runs serially on the main shell so
-  # all state updates are safe.
-  local _result_file _rfile _rout
-  for _result_file in "${_chunk_results}"/*; do
+  # Aggregate phase: walk per-file results in the original git-diff file
+  # order (so the issues_output digest is deterministic and matches the
+  # pre-parallel serial order, not alphabetic-by-sanitized-name). Runs
+  # serially on the main shell so accumulator updates are safe.
+  local _result_file _rfile _rout _agg_safe
+  while IFS= read -r _rfile; do
+    [[ -z "${_rfile}" ]] && continue
+    _agg_safe="${_rfile//\//__}"
+    _agg_safe="${_agg_safe// /_}"
+    _result_file="${_chunk_results}/${_agg_safe}"
     [[ -f "${_result_file}" ]] || continue
-    _rfile=$(head -1 "${_result_file}")
     _rout=$(tail -n +2 "${_result_file}")
 
     # "agent error" synthetic verdict indicates the agent failed — skip the
@@ -381,7 +385,7 @@ ${_rout}"
     fi
 
     ((reviewed_files += 1))
-  done
+  done <<<"${files}"
 
   rm -rf "${_chunk_results}"
   unset _chunk_results _chunk_pids
@@ -462,7 +466,7 @@ _global_log="${HOME}/.claude/last-review-result.log"
 } >"${_global_log}" || true
 
 _ec=0 # captured by EXIT trap; declared here so shellcheck sees the assignment
-trap '_ec=$?; [[ -n "${REVIEW_LOG:-}" ]] && printf "exit_code: %d\n" "$_ec" >> "${REVIEW_LOG}" || true' EXIT
+trap '_ec=$?; rm -rf "${_chunk_results:-}" 2>/dev/null; rm -f "${_cr_out:-}" "${_ar_out:-}" 2>/dev/null; [[ -n "${REVIEW_LOG:-}" ]] && printf "exit_code: %d\n" "$_ec" >> "${REVIEW_LOG}" || true' EXIT
 
 if [[ -z "${DIFF}" ]]; then
   log_warn "No staged changes to review"

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -102,12 +102,23 @@ stage_large_change() {
 # Output is written to a separate file and cat'd by the mock to avoid
 # heredoc expansion issues when output contains double-quotes or other
 # special characters that would break an inline printf '%s\n' "${output}".
+#
+# The mock short-circuits on --version so run-review.sh's CLI preflight
+# passes quickly (preflight calls `timeout 5 ${CLI} --version` and only
+# fails the whole script on exit 124). Without this fast-path, a mock
+# configured to exit nonzero would still pass preflight (preflight tolerates
+# non-124 exits) but a mock that sleeps — like Test 5's inline sleep mock —
+# would hit the 5s timeout and kill the whole test run.
 make_mock_claude() {
   local mock_dir="$1" exit_code="$2" output="$3"
   mkdir -p "${mock_dir}"
   printf '%s\n' "${output}" >"${mock_dir}/output.txt"
   cat >"${mock_dir}/claude" <<EOF
 #!/usr/bin/env bash
+if [[ "\$1" == "--version" ]]; then
+  echo "mock-claude 0.0.0-test"
+  exit 0
+fi
 cat "${mock_dir}/output.txt"
 exit ${exit_code}
 EOF
@@ -294,8 +305,14 @@ stage_small_change
 # If review.timeout is ignored (TIMEOUT_SECONDS=120 hardcoded), the mock would finish in ~2s.
 MOCK5_DIR="${TMPDIR_TEST}/mock5"
 mkdir -p "${MOCK5_DIR}"
+# Fast-path --version so the CLI preflight (timeout 5) doesn't kill us before
+# the real test scenario. The real invocation (without --version) still sleeps.
 cat >"${MOCK5_DIR}/claude" <<'MOCKEOF'
 #!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "mock-claude 0.0.0-test"
+  exit 0
+fi
 sleep 5
 echo "VERDICT: PASS"
 echo "No blocking issues found."
@@ -393,6 +410,11 @@ MOCK8_DIR="${TMPDIR_TEST}/mock8"
 mkdir -p "${MOCK8_DIR}"
 cat >"${MOCK8_DIR}/claude" <<'MOCKEOF'
 #!/usr/bin/env bash
+# Fast-path --version so CLI preflight passes (see make_mock_claude).
+if [[ "$1" == "--version" ]]; then
+  echo "mock-claude 0.0.0-test"
+  exit 0
+fi
 # Exits successfully but produces no output (simulates a silent agent failure)
 exit 0
 MOCKEOF

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -432,11 +432,56 @@ assert_eq \
   "${exit_t8}"
 
 # =========================================================
+# TEST 9: Chunked-mode timeout verdicts are counted as skips, not warnings
+#
+# invoke_agent emits two distinct synthetic verdicts on transient failure:
+#   - "VERDICT: FAIL (timeout)"       — exit 124 from `timeout` command
+#   - "VERDICT: FAIL (agent error: N)" — any other non-zero exit
+# The parallel aggregate loop greps for "VERDICT: FAIL (" so both are
+# classified as skips (non-fatal, don't count toward blocking_count).
+# Regression test: previously the grep was "VERDICT: FAIL (agent error",
+# which missed the timeout case and miscounted timeouts as warnings.
+# Caught by Seer on PR #128; see issue #129.
+# =========================================================
+echo ""
+echo "=== Test 9: chunked-mode timeout verdicts classified as skips ==="
+
+setup_repo
+stage_large_change
+
+# Mock emits a timeout-style synthetic verdict (matches what invoke_agent
+# produces on real timeout) instead of actual sleep — faster, deterministic.
+MOCK9_DIR="${TMPDIR_TEST}/mock9"
+make_mock_claude "${MOCK9_DIR}" 0 "VERDICT: FAIL (timeout)"
+
+TEST9_LOG="${TMPDIR_TEST}/test9-review.log"
+rm -f "${TEST9_LOG}"
+
+exit_t9=0
+cd "${REPO_DIR}"
+git config review.maxLines 10
+REVIEW_LOG="${TEST9_LOG}" CLAUDE_CLI="${MOCK9_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || exit_t9=$?
+git config --unset review.maxLines 2>/dev/null || true
+cd - >/dev/null
+
+log_content9="$(cat "${TEST9_LOG}" 2>/dev/null || echo "")"
+
+assert_eq \
+  "chunked timeout does not block commit (exit 0)" \
+  "0" \
+  "${exit_t9}"
+
+assert_contains \
+  "log notes files were skipped (not counted as warnings)" \
+  "skipped" \
+  "${log_content9}"
+
+# =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 11 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 13 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Batch B of the local-first-review strengthening work. Five changes to `hooks/run-review.sh` addressing findings 3, 5, 6, 8, 9 from the audit. Three commits for easier bisect if needed.

**Commit 1 — cleanups (finding 3, 8, 9)**
- Drop `detect_security_critical` (~90 lines of regex whose only consumer was a single `log_info`). Both reviewers run on every commit regardless; the flag never affected prompts, timeouts, cache buckets, or agent selection.
- Add CLI preflight: `timeout 5 claude --version` before any real agent call. Only bails on exit 124 (hang) — non-124 exits are allowed through so the real call surfaces actionable errors. Catches hung CLIs in ~5s instead of burning up to 8 minutes of agent timeouts.
- Version the review cache: fold the script's own SHA (first 12 chars) into `DIFF_HASH` and the per-file chunk cache key. Any edit to `run-review.sh` auto-invalidates stale PASS cache so prompt/logic changes take effect immediately.
- Test mocks updated with `--version` fast-path so the preflight passes in the test harness.

**Commit 2 — parallelization (findings 5, 6)**
- Top-level `code-reviewer` + `adversarial-reviewer` now run in parallel. Roughly halves wall time on the common two-agent path (~60-120s each, previously serial). Dogfooded on its own commit: code-reviewer 49s + adversarial 60s ran concurrently in 60s total (vs. 109s serial).
- Chunked-mode per-file review dispatches up to `CHUNK_PARALLEL` (default 4, overridable via `git config review.chunkParallel N`) concurrent invocations with bounded concurrency. Subshells write results to per-file temp files; aggregation stays serial so accumulator state (`blocking_count`, `warning_count`, `issues_output`) remains correct.
- Adversarial-unavailable falls back to the prior serial code-reviewer-only path — unchanged behavior.

**Commit 3 — review feedback (in-flight)**
Incorporates two non-blocking observations from commit 2's pre-commit review: extend the existing EXIT trap to clean up temp dir / temp files on abnormal exit; restore original git-diff file ordering in the issues digest (the parallel aggregate walked the glob lexically).

## Auto-filed follow-ups

Pre-push codebase review flagged two pre-existing bugs unrelated to this diff:

- #126: `sha256sum` not available on macOS by default — chunked cache always falls to `"nocache"` literal on Darwin
- #127: `--mode=full-diff`/`--mode=codebase` silently routed to chunked review on large diffs; mode-specific prompts never reached

## Test plan

- [x] `shellcheck -S info` clean (only pre-existing SC2249/SC1091 remain)
- [x] `bash` syntax parse clean
- [x] Unit tests 11/11 PASS after each commit (baseline, post-cleanup, post-parallel, post-feedback)
- [x] Parallel behavior observed on commit 3: two agents ran concurrently in ~max(49s, 60s) instead of summed
- [x] Pre-commit code-reviewer + adversarial-reviewer PASS
- [x] Pre-push full-diff adversarial-reviewer PASS
- [x] Pre-push codebase-mode adversarial-reviewer PASS (filed 2 pre-existing follow-ups)
- [ ] CI claude-blocking-review PASS

## Companion

Batch A (dotfiles#73) landed in dotfiles — strict pre-push in Claude sessions is now live and already caught a bug during this PR's preparation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)