### PR TITLE
fix(pre-merge-review): bump default timeout to 180s, remove stale Seer wording

### DIFF
--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -28,7 +28,10 @@ set -euo pipefail
 
 # --- Configuration ---
 CLAUDE_CLI="${CLAUDE_CLI:-${HOME}/.local/bin/claude}"
-TIMEOUT_SECONDS=120
+# Default 180s handles typical PRs; large PRs with 30k+ token smart-diffs
+# routinely exceeded the prior 120s default and timed out unnecessarily.
+# Override via `git config review.preMergeTimeout N` when needed.
+TIMEOUT_SECONDS=$(git config --get --type=int review.preMergeTimeout 2>/dev/null || echo "180")
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -366,13 +369,17 @@ NEUTRAL_CHECKS=$(echo "${PR_JSON}" | jq -r '
 ' 2>&1) || true
 
 if [[ -n "${NEUTRAL_CHECKS}" ]]; then
+  # Reached only when a non-Netlify, non-Seer check is NEUTRAL. Seer is
+  # explicitly excluded by the filter above (treated as advisory), so its
+  # findings are never the trigger for this branch.
   echo "" >&2
   log_error "CI checks with NEUTRAL status (indicates unresolved issues):"
   echo "${NEUTRAL_CHECKS}" >&2
   echo "" >&2
   log_error "NEUTRAL status means the check found issues that need attention."
   log_error "Common causes:"
-  log_error "  - Sentry/Seer Code Review: Has inline comments on code"
+  log_error "  - Non-Seer review bots: Inline comments on code requiring resolution"
+  log_error "  - Coverage / quality gates: Threshold not met (soft-failing as NEUTRAL)"
   log_error "  - Other reviewers: Requested changes not yet addressed"
   echo "" >&2
   log_error "Actions:"


### PR DESCRIPTION
## Summary

Batch C of the local-first-review work. Two small cleanups to `hooks/pre-merge-review.sh`.

**Timeout bump.** Default timeout: 120s → 180s, overridable via `git config review.preMergeTimeout N`. Large PRs with 30k+ token smart-diffs routinely exceeded the prior 120s default and timed out even though Claude was still productively reasoning. The companion codebase-review mode in `run-review.sh` already uses 300s (`review.codebaseTimeout`); aligning pre-merge closer to that range without overshooting.

**Stale Seer wording.** When the NEUTRAL-status filter (lines 355-366) was updated in an earlier PR to exclude Seer — making Seer advisory-only per Protocol 5 — the error message in the downstream block at line 375 was never updated. It still listed "Sentry/Seer Code Review" as the first "common cause" even though the branch is now unreachable for Seer. Replaced with causes that actually reach this branch: non-Seer review bots, coverage/quality gates, other reviewers. Added a leading comment making the branch's preconditions explicit for future maintenance.

Closes #106.

## Test plan

- [x] `shellcheck -S info` clean (only pre-existing SC1091 for the `source` line shellcheck can't follow)
- [x] `bash` syntax parse clean
- [x] Pre-commit code-reviewer + adversarial-reviewer PASS
- [x] Pre-push full-diff adversarial-reviewer PASS
- [x] Pre-push codebase-mode adversarial-reviewer PASS (explicit verification of both behaviors)
- [ ] CI claude-blocking-review PASS

## Observation (not blocking this PR)

The standalone `test-pre-merge-review.sh` at the repo root is pre-existing broken: it eval's function definitions via `sed -n '.../p' | grep -v '^# ---'` from the installed pre-merge-review.sh, which pulls in the `source "${_LIB_DIR}/lib-review-issues.sh"` line. `_LIB_DIR` resolves to the test script's directory (repo root) rather than `hooks/`, so the source fails and no assertions run. Unchanged by this PR. Worth filing as a separate follow-up to either move the test under `hooks/tests/` or rework how it loads functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)