### PR TITLE
ci: allow bot actors to invoke claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,10 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          # claude-code-action rejects non-User actors unless explicitly allowed.
+          # The `if:` guard above still filters on @claude mention content; this
+          # list only names bots whose comments/issues are legitimate triggers.
+          allowed_bots: "claude[bot],github-actions[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs


### PR DESCRIPTION
Adds `allowed_bots: "claude[bot],github-actions[bot]"` to the claude-code-action step in `.github/workflows/claude.yml`.

Recent releases of `anthropics/claude-code-action@v1` reject runs where `github.actor` is a Bot unless explicitly allowed. First observed on `nightowlstudiollc/kebab-tax-netlify` PR #173. Reusable-workflow version landed in [smartwatermelon/github-workflows#60](https://github.com/smartwatermelon/github-workflows/pull/60) (v2.0.2).

The `if:` guard in this workflow still filters on `@claude` mention content; the allowlist only names bots whose events are legitimate secondary triggers. Named list, not `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)