### PR TITLE
fix(review): skip pre-commit review on sync/* branches

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -517,6 +517,19 @@ if [[ -f "${CACHE_FILE}" ]]; then
   rm -f "${CACHE_FILE}"
 fi
 
+# Skip review entirely on sync branches.
+# `sync/*` branches are created by sync-to-public.sh and contain content
+# that has already passed full review in the source (private) repo. Running
+# the size-cap check against an aggregated sync diff produces false blocks
+# on legitimate, already-reviewed code.
+_current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [[ "${REVIEW_MODE}" == "commit" ]] && [[ "${_current_branch}" == sync/* ]]; then
+  log_info "Sync branch (${_current_branch}) - skipping review (content already reviewed upstream)"
+  printf 'skipped: sync branch (%s)\n' "${_current_branch}" >>"${REVIEW_LOG}" || true
+  exit 0
+fi
+unset _current_branch
+
 # Progressive review strategy based on diff size
 DIFF_LINES=$(echo "${DIFF}" | wc -l | tr -d ' ')
 

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -477,11 +477,57 @@ assert_contains \
   "${log_content9}"
 
 # =========================================================
+# TEST 10: sync/* branches skip review regardless of diff size
+#
+# Sync commits aggregate content already reviewed in the source repo.
+# Running the size cap against them produces false blocks, so `sync/*`
+# branches must exit 0 without invoking the reviewer.
+# =========================================================
+echo ""
+echo "=== Test 10: sync/* branch skips review even when diff > skipThreshold ==="
+
+setup_repo
+cd "${REPO_DIR}"
+git checkout -q -b "sync/2026-04-23-test"
+# Stage a diff well above the default 2500-line skipThreshold so the
+# test would hit the "BLOCKING: Diff too large" path if the sync-skip
+# logic regressed.
+for i in $(seq 1 3000); do echo "line_${i}_content" >>bigfile.sh; done
+git add bigfile.sh
+cd - >/dev/null
+
+MOCK10_DIR="${TMPDIR_TEST}/mock10"
+# Mock should never be invoked — if run-review.sh calls it, the sync skip
+# broke and the test's "skipped: sync branch" assertion will also fail.
+make_mock_claude "${MOCK10_DIR}" 1 "MOCK SHOULD NOT RUN"
+
+TEST10_LOG="${TMPDIR_TEST}/test10-review.log"
+rm -f "${TEST10_LOG}"
+
+exit_t10=0
+cd "${REPO_DIR}"
+REVIEW_LOG="${TEST10_LOG}" CLAUDE_CLI="${MOCK10_DIR}/claude" \
+  bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || exit_t10=$?
+cd - >/dev/null
+
+assert_eq \
+  "sync branch exits 0 (review skipped)" \
+  "0" \
+  "${exit_t10}"
+
+log_content10="$(cat "${TEST10_LOG}" 2>/dev/null || echo "")"
+
+assert_contains \
+  "log notes sync-branch skip reason" \
+  "skipped: sync branch" \
+  "${log_content10}"
+
+# =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 13 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 15 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- `sync-to-public.sh` (in other repos, e.g. `nightowlstudiollc/financial-agent`) aggregates content already reviewed in the source repo and lands it on a `sync/<date>-<slug>` branch in the destination public repo. The diff can legitimately exceed `review.skipThreshold`, producing a false "Diff too large" block on already-reviewed code.
- `run-review.sh` now short-circuits with exit 0 when the current branch matches `sync/*` in commit mode. Full-diff and codebase review modes are unchanged.
- The review log records `skipped: sync branch (<branch-name>)` for audit.

## Test plan
- [x] Added Test 10 in `hooks/tests/run-review-test.sh` that stages a >3000-line diff on a `sync/*` branch and asserts both exit 0 and the log entry. 15/15 assertions pass.
- [x] Verified regression catch: temporarily reverting the hook change fails 2 of the 15 assertions (exit 1 + log says "blocked: diff too large").
- [ ] End-to-end: re-run `./sync-to-public.sh --push` in `nightowlstudiollc/financial-agent` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)