### PR TITLE
docs(claude-md): default plan execution to subagent-driven

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,13 @@ Before declaring work done, output the full Completion Verification template fro
 
 ---
 
+## Execution Preferences
+
+- **Plan execution defaults to subagent-driven.** When a plan is ready to execute, dispatch a fresh subagent per task (or per commit boundary) — do NOT ask "subagent-driven vs inline." The decision is pre-made. Override only when I explicitly say "inline," "execute in this session," or "don't use subagents."
+- Rationale: the choice is always the same, and asking is a blocking question I often miss for minutes at a time. Defaulting eliminates wasted wall-clock time.
+
+---
+
 ## Technical Standards
 
 ### Architecture


### PR DESCRIPTION
## Summary

- Adds an **Execution Preferences** section to `CLAUDE.md` codifying that plan execution should default to subagent-driven dispatch without asking.
- Override remains explicit ("inline," "execute in this session," "don't use subagents").

## Why

The "subagent-driven vs inline" question is asked at the start of every plan execution and the answer is always the same. It's a blocking prompt that often goes unanswered for minutes when I miss the notification — pure wasted wall-clock time. Encoding the default in `CLAUDE.md` removes the question entirely.

## Test plan

- [x] `markdownlint` passes
- [x] Pre-push adversarial-reviewer + codebase-reviewer both PASS
- [ ] After merge: confirm the symlinked `~/.claude/CLAUDE.md` reflects the new section (`install.sh` already deployed; no rerun needed since CLAUDE.md is symlinked, not copied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)