### PR TITLE
feat: add commit message context to chunked code reviewer

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -195,6 +195,49 @@ invoke_agent() {
 
 # --- Helper Functions for Progressive Review ---
 
+# Read the developer's commit message for the current invocation, so it can be
+# injected into review prompts as "DEVELOPER INTENT". Without this, the
+# chunked reviewer judges each file in isolation and can flag false positives
+# when the rationale spans files (e.g. a project rename where storage-key
+# changes look unsafe unless you also see the bundle-ID change that makes the
+# renamed app a fresh install). Echoes nothing when no message is available
+# so callers can omit the header entirely instead of emitting an empty one.
+#
+# Sources by mode:
+#   commit                  -> $GIT_DIR/COMMIT_EDITMSG (template '#' lines stripped)
+#   full-diff / pre-push    -> git log -1 --format=%B HEAD
+#   codebase                -> empty (no specific commit context)
+_read_commit_message() {
+  local msg=""
+  case "${REVIEW_MODE}" in
+    codebase)
+      return 0
+      ;;
+    commit)
+      local git_dir editmsg
+      git_dir=$(git rev-parse --git-dir 2>/dev/null || echo "")
+      [[ -n "${git_dir}" ]] || return 0
+      editmsg="${git_dir}/COMMIT_EDITMSG"
+      [[ -f "${editmsg}" ]] || return 0
+      # Strip git-template comment lines (leading '#') and leading/trailing
+      # blank lines. Use grep -v to drop comments; awk trims surrounding blanks.
+      msg=$(grep -v '^#' "${editmsg}" 2>/dev/null \
+        | awk 'NF{found=1} found{print}' \
+        | awk 'BEGIN{n=0} {lines[n++]=$0} END{end=n-1; while(end>=0 && lines[end]~/^[[:space:]]*$/) end--; for(i=0;i<=end;i++) print lines[i]}')
+      ;;
+    *)
+      # full-diff, pre-push, and any future post-commit modes
+      msg=$(git log -1 --format=%B HEAD 2>/dev/null \
+        | awk 'NF{found=1} found{print}' \
+        | awk 'BEGIN{n=0} {lines[n++]=$0} END{end=n-1; while(end>=0 && lines[end]~/^[[:space:]]*$/) end--; for(i=0;i<=end;i++) print lines[i]}')
+      ;;
+  esac
+  # Suppress whitespace-only results so callers can test for "non-empty" cleanly.
+  if [[ -n "${msg//[[:space:]]/}" ]]; then
+    printf '%s\n' "${msg}"
+  fi
+}
+
 show_large_diff_summary() {
   local total_lines="$1"
 
@@ -266,6 +309,21 @@ perform_chunked_review() {
   _chunk_results=$(mktemp -d)
   local -a _chunk_pids=()
 
+  # Read the commit message ONCE for this run; injected into every per-file
+  # prompt so the reviewer sees developer intent across chunks. See
+  # _read_commit_message for source-by-mode behavior.
+  local commit_msg commit_msg_section
+  commit_msg=$(_read_commit_message)
+  if [[ -n "${commit_msg}" ]]; then
+    commit_msg_section="DEVELOPER INTENT (commit message):
+${commit_msg}
+---
+
+"
+  else
+    commit_msg_section=""
+  fi
+
   # Dispatch phase: build per-file prompt, spawn background invoke_agent.
   # Skip-if-too-large is still serial (and bumps skipped_files directly).
   while IFS= read -r file; do
@@ -298,7 +356,7 @@ perform_chunked_review() {
     done
 
     local file_prompt
-    file_prompt="Reviewing file: ${file}
+    file_prompt="${commit_msg_section}Reviewing file: ${file}
 
 IMPORTANT: You are being invoked as a focused analysis tool with --no-session-persistence.
 Do NOT output Protocol 0 environment check or any preamble.
@@ -855,7 +913,22 @@ ADVERSARIAL_CACHE="${CACHE_DIR}/adversarial-${DIFF_HASH}"
 
 # Build structured prompt for agents
 # Use string concatenation - safe variable expansion without command execution
-AGENT_PROMPT="You are performing a pre-commit code review. Analyze the diff below and identify issues BEFORE code is committed.
+#
+# Inject the developer's commit message (when available) so the reviewer sees
+# intent before code. Same pattern as the chunked path; section is omitted
+# entirely when no message is available.
+COMMIT_MSG=$(_read_commit_message)
+if [[ -n "${COMMIT_MSG}" ]]; then
+  COMMIT_MSG_SECTION="DEVELOPER INTENT (commit message):
+${COMMIT_MSG}
+---
+
+"
+else
+  COMMIT_MSG_SECTION=""
+fi
+
+AGENT_PROMPT="${COMMIT_MSG_SECTION}You are performing a pre-commit code review. Analyze the diff below and identify issues BEFORE code is committed.
 
 IMPORTANT: You are being invoked as a focused analysis tool with --no-session-persistence.
 Do NOT output Protocol 0 environment check or any preamble.


### PR DESCRIPTION
## Summary

The chunked reviewer in `hooks/run-review.sh` reviews each file in isolation. When the rationale for a change spans files, this produces false-positive `BLOCK` findings because the reviewer cannot see context from other chunks. A recent project-rename PR hit this concretely: storage-key prefix changes in 3 files were each flagged as "needs migration", but the same PR also changed the bundle ID in `app.json` — making the renamed app a fresh install with no upgrade path, so migration is moot. The developer's commit message explained this exactly, but the reviewer never sees the commit message.

This PR adds a single-source helper that reads the commit message at hook runtime and injects it as a `DEVELOPER INTENT (commit message):` header at the top of every per-file review prompt. The same injection is applied to the single-pass commit-mode prompt for behavioral consistency across diff sizes.

## Change

- New helper `_read_commit_message()` (one source of truth)
- Injection site 1: per-file prompt inside `perform_chunked_review()` (called once per run, value reused per chunk)
- Injection site 2: single-pass commit-mode `AGENT_PROMPT` builder
- When no message is available the section is omitted entirely (no empty headers)

## Source by mode

| Mode | Source |
| --- | --- |
| `commit` (pre-commit) | `$GIT_DIR/COMMIT_EDITMSG`, with git template `#` lines stripped and surrounding blank lines trimmed |
| `full-diff` / `pre-push` | `git log -1 --format=%B HEAD` |
| `codebase` | empty (no specific commit context) |

## Scope (intentionally narrow)

- No changes to mode routing, threshold logic, caching, or agent invocation
- No changes to full-diff or codebase prompts (per task spec)
- The pre-push codebase reviewer correctly noticed that the helper's comment lists `full-diff / pre-push` but the full-diff branch doesn't yet call it; that's a separate follow-up tracked in #147 (and a related `set -e` pipefail edge case in #148)

## Test plan

- [x] `bash -n hooks/run-review.sh` — syntax clean
- [x] `shellcheck -S info hooks/run-review.sh` — zero new findings (only the two pre-existing SC2249 / SC1091 from before this branch)
- [x] Standalone helper test in a temp git repo, covering all 6 cases:
  - commit mode reads `COMMIT_EDITMSG` and strips `#` template lines while preserving the body
  - full-diff mode reads `HEAD` commit message
  - codebase mode returns empty
  - missing `COMMIT_EDITMSG` returns empty
  - comments-only `COMMIT_EDITMSG` returns empty
  - `pre-push` (any non-`commit`/`codebase` mode) is treated as the post-commit case
- [x] Self-review: pre-commit hook ran code-reviewer + adversarial-reviewer against this very change — both PASS
- [x] Pre-push hook ran full-diff + codebase review — PASS, two non-blocking issues filed for follow-ups