### PR TITLE
feat: switch issue-comments fetch to GraphQL with isMinimized filter

### DIFF
--- a/scripts/post-push-status.sh
+++ b/scripts/post-push-status.sh
@@ -111,8 +111,79 @@ _safe_api_array() {
   fi
 }
 
+# _fetch_issue_comments_gql: GraphQL fetch for PR conversation (issues/comments).
+# Why GraphQL instead of REST: the REST issues/comments endpoint does not return
+# `isMinimized`, so previously-collapsed bot comments (e.g. PASS reviews
+# minimized by claude-blocking-review.yml's minimizeComment mutation) were still
+# surfaced as findings. GraphQL exposes `isMinimized`, letting us skip them.
+#
+# The --jq projection reshapes GraphQL nodes into the REST-compatible JSON
+# shape the python parser expects (user.login, created_at, body, path, line),
+# so the parser block stays unchanged. Bot authors are reported by GraphQL as
+# `Bot` __typename with login stripped of the `[bot]` suffix; we re-append it
+# so BOT_PATTERN (which expects `claude[bot]` etc.) still matches.
+_fetch_issue_comments_gql() {
+  local owner="$1" repo="$2" number="$3"
+  # Heredoc keeps $owner/$name/$number literal — they're GraphQL variables, not
+  # bash expansions. `gh api -f owner=... -f name=... -F number=...` substitutes them.
+  local query
+  query=$(
+    cat <<'GQLEOF'
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      comments(last: 100) {
+        nodes {
+          body
+          createdAt
+          isMinimized
+          author {
+            __typename
+            login
+          }
+        }
+      }
+    }
+  }
+}
+GQLEOF
+  )
+  # Reshape GraphQL nodes into REST-compatible objects so the python parser is
+  # unchanged. Bot authors come back from GraphQL with `[bot]` stripped from
+  # login; re-append it so BOT_PATTERN matches `claude[bot]`, `sentry[bot]`, etc.
+  local jq_filter
+  jq_filter=$(
+    cat <<'JQEOF'
+.data.repository.pullRequest.comments.nodes
+  | map(select(.isMinimized == false))
+  | map({
+      user: { login: (
+        if .author == null then ""
+        elif .author.__typename == "Bot" then (.author.login + "[bot]")
+        else .author.login
+        end
+      ) },
+      created_at: .createdAt,
+      body: .body,
+      path: "",
+      line: null
+    })
+JQEOF
+  )
+  local body
+  if body=$(gh api graphql \
+        -f query="${query}" \
+        -f owner="${owner}" -f name="${repo}" -F number="${number}" \
+        --jq "${jq_filter}" 2>/dev/null) \
+    && echo "${body}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    printf '%s\n' "${body}"
+  else
+    printf '%s\n' "[]"
+  fi
+}
+
 _safe_api_array "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" >"${TMPFILE}_pulls"
-_safe_api_array "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" >"${TMPFILE}_issues"
+_fetch_issue_comments_gql "${OWNER}" "${REPO}" "${PR_NUMBER}" >"${TMPFILE}_issues"
 jq -s '.[0] + .[1]' "${TMPFILE}_pulls" "${TMPFILE}_issues" >"${TMPFILE}" || echo "[]" >"${TMPFILE}"
 rm -f "${TMPFILE}_pulls" "${TMPFILE}_issues"
 

--- a/scripts/tests/test-post-push-status.sh
+++ b/scripts/tests/test-post-push-status.sh
@@ -80,34 +80,57 @@ EOF
     echo '[]'
     return 0
   fi
-  if echo "${args}" | grep -q "issues/42/comments"; then
-    cat <<'EOF'
-[
-  {"id":10,"user":{"login":"sentry[bot]"},"created_at":"2024-01-15T12:00:00Z","body":"Critical: SQL injection vulnerability detected","html_url":"https://github.com/..."},
-  {"id":11,"user":{"login":"sentry[bot]"},"created_at":"2024-01-14T08:00:00Z","body":"Stale finding from prior iteration","html_url":"https://github.com/..."}
-]
-EOF
-    return 0
-  fi
-  if echo "${args}" | grep -qF "testowner/testrepo/issues/99/comments"; then
-    echo '[]'
+  # GraphQL issues/comments fetch (replaces former REST issues/<N>/comments path).
+  # Detect by the comments(last:...) selector inside a pullRequest(number:...) query.
+  # The production code passes the PR number via `-F number=<N>`, so the args
+  # string contains `number=<N>` reliably; route by that.
+  #
+  # The real `gh api graphql --jq <filter>` applies the filter to the response
+  # before returning it. To exercise the production --jq projection (Bot →
+  # `<login>[bot]` reconstruction, isMinimized filter), this mock returns the
+  # raw GraphQL response and then pipes it through the actual `--jq` value
+  # extracted from the call's args. That way the test verifies the real
+  # production projection: minimized comments dropped, Bot authors reshaped.
+  if echo "${args}" | grep -q "comments(last:" && echo "${args}" | grep -q "pullRequest(number:"; then
+    local raw=""
+    if echo "${args}" | grep -qF "number=42"; then
+      raw='{"data":{"repository":{"pullRequest":{"comments":{"nodes":[
+        {"body":"Critical: SQL injection vulnerability detected","createdAt":"2024-01-15T12:00:00Z","isMinimized":false,"author":{"__typename":"Bot","login":"sentry"}},
+        {"body":"Stale finding from prior iteration","createdAt":"2024-01-14T08:00:00Z","isMinimized":false,"author":{"__typename":"Bot","login":"sentry"}},
+        {"body":"<!-- claude-blocking-review --> VERDICT: PASS minimized","createdAt":"2024-01-15T13:00:00Z","isMinimized":true,"author":{"__typename":"Bot","login":"claude"}}
+      ]}}}}}'
+    elif echo "${args}" | grep -qF "number=99" && echo "${args}" | grep -qF "owner=testowner"; then
+      raw='{"data":{"repository":{"pullRequest":{"comments":{"nodes":[]}}}}}'
+    elif echo "${args}" | grep -qF "number=43"; then
+      # PR 43: comment between PST-string and UTC commit time (timezone trap).
+      raw='{"data":{"repository":{"pullRequest":{"comments":{"nodes":[
+        {"body":"Stale PST-timezone trap comment","createdAt":"2026-03-13T01:00:00Z","isMinimized":false,"author":{"__typename":"Bot","login":"sentry"}}
+      ]}}}}}'
+    else
+      echo "UNEXPECTED GraphQL comments call: ${args}" >&2
+      return 1
+    fi
+    # Extract the --jq filter from the original argv (positional, not flatten)
+    # so we apply the real production projection on the raw response.
+    local jq_filter="" capture=0
+    for a in "$@"; do
+      if [[ "${capture}" == "1" ]]; then
+        jq_filter="${a}"
+        break
+      fi
+      if [[ "${a}" == "--jq" ]]; then
+        capture=1
+      fi
+    done
+    if [[ -n "${jq_filter}" ]]; then
+      printf '%s' "${raw}" | jq -c "${jq_filter}"
+    else
+      printf '%s' "${raw}"
+    fi
     return 0
   fi
   if echo "${args}" | grep -q "pulls/43/comments"; then
     echo '[]'
-    return 0
-  fi
-  # PR 43: issues/comments with a comment created between PST-string and UTC time of commit.
-  # Commit at 2026-03-13T02:08:00Z (= 2026-03-12T18:08:00-08:00 PST).
-  # Comment at 2026-03-13T01:00:00Z is 1 hour BEFORE commit in UTC (stale → should be filtered).
-  # Old bug: "2026-03-13T01:00:00Z" > "2026-03-12T18:08:00-08:00" (string compare) → not filtered.
-  # Fixed:   "2026-03-13T01:00:00Z" < "2026-03-13T02:08:00Z" (UTC vs UTC) → correctly filtered.
-  if echo "${args}" | grep -q "issues/43/comments"; then
-    cat <<'EOF'
-[
-  {"id":20,"user":{"login":"sentry[bot]"},"created_at":"2026-03-13T01:00:00Z","body":"Stale PST-timezone trap comment","html_url":"https://github.com/..."}
-]
-EOF
     return 0
   fi
   echo "UNEXPECTED gh call: ${args}" >&2
@@ -134,6 +157,15 @@ assert_contains "issues/comments fresh sentry[bot] finding included" "SQL inject
 echo ""
 echo "=== Test: Timestamp filter excludes stale issues/comments ==="
 assert_not_contains "stale issues/comment excluded" "Stale finding from prior iteration" "${output}"
+
+echo ""
+echo "=== Test: Minimized GraphQL comments are filtered out ==="
+# PR 42 mock has a claude[bot] comment with isMinimized:true. The new
+# _fetch_issue_comments_gql jq filter should drop it before the python parser
+# sees it, so VERDICT: PASS body must NOT appear in output. (claude[bot]'s
+# inline pulls/comment finding from PR 42 still appears — different code path,
+# different content.)
+assert_not_contains "minimized PASS comment dropped" "VERDICT: PASS" "${output}"
 
 echo ""
 echo "=== Test: Finding fields present ==="


### PR DESCRIPTION
## Summary

Coordinating change to [smartwatermelon/github-workflows#83](https://github.com/smartwatermelon/github-workflows/pull/83) (tracking issue: [#82](https://github.com/smartwatermelon/github-workflows/issues/82)). That upstream PR taught the CI `claude-blocking-review` workflow to call GraphQL `minimizeComment(classifier: RESOLVED)` on its own PASS comment after posting it, so PASS comments end up collapsed in the PR thread (audit trail preserved, visual noise reduced).

However, `scripts/post-push-status.sh` was still fetching issues/comments via the REST API, and the REST endpoint **does not return `isMinimized`** — that field is GraphQL-only. The result: the scraper kept surfacing those minimized PASS comments as `FINDING` lines, polluting the post-push loop with phantom findings.

## What changed

- New `_fetch_issue_comments_gql` helper that:
  - Issues a GraphQL `pullRequest.comments(last: 100)` query selecting `body`, `createdAt`, `isMinimized`, and `author { __typename, login }`.
  - Uses `--jq` to filter out minimized comments (`select(.isMinimized == false)`) and reshape GraphQL nodes into the REST-compatible JSON shape (`user.login`, `created_at`, `body`, `path`, `line`) the existing python parser already expects.
  - Re-appends `[bot]` to `Bot`-typename logins (GraphQL strips it), so `BOT_PATTERN` (`claude\[bot\]|sentry\[bot\]|coderabbit\[bot\]`) keeps matching.
  - Falls back to `[]` on any failure (matches `_safe_api_array` semantics).
- Replaces the single `_safe_api_array "repos/.../issues/<N>/comments"` call with the new helper.
- **No python parser changes** — the jq projection makes the GraphQL output drop in transparently.

## Why pulls/comments stays on REST

Pulls/comments are inline diff review comments — they're typically real findings (e.g., from sentry[bot]), they're not subject to the new minimization workflow, and the REST shape works fine. Switching that path too would be churn without benefit.

## Test plan

- [x] `bash -n scripts/post-push-status.sh` — clean
- [x] `shellcheck -S info scripts/post-push-status.sh scripts/tests/test-post-push-status.sh` — zero findings
- [x] `bash scripts/tests/test-post-push-status.sh` — 17/17 pass (added 1 new assertion: `assert_not_contains "minimized PASS comment dropped" "VERDICT: PASS"`). The test mock now extracts `--jq` from the call's argv and pipes the raw GraphQL response through the real production filter via `jq -c`, so the test exercises the actual projection (Bot→`<login>[bot]` reshape + minimized drop) rather than baking that behavior into the fixtures.
- [x] Smoke test against PR #128 (real-world: contains a minimized claude[bot] PASS comment): baseline produced 3 findings (2 sentry[bot] inline + 1 claude[bot] PASS); after fix, produces 2 findings (PASS correctly skipped, real findings preserved).
- [x] Smoke test against PR #149 (un-minimized claude[bot] PASS): still surfaces correctly — proves Bot login reconstruction works and we don't break the un-minimized path.
- [x] Pre-commit + pre-push reviewers (code-reviewer, adversarial-reviewer, codebase reviewer): all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)