### PR TITLE
feat: pre-merge hook honors gh --repo flag for cross-CWD merges

### DIFF
--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -19,6 +19,11 @@ set -euo pipefail
 #     * Large diffs (> 1000 lines): Extracts complete diff sections
 #       for files with inline comments, summarizes others
 #     * Ensures critical review context is always visible
+#   - Honors `gh --repo OWNER/NAME` (and `-R`, `--repo=`, `-R=`) so the
+#     caller can invoke `gh pr merge` from any directory. When --repo is
+#     supplied, REPO_OWNER/REPO_NAME are parsed directly from the flag and
+#     propagated to all downstream `gh pr view` / `gh pr diff` calls,
+#     bypassing the CWD-dependent `gh repo view` resolution.
 #
 # EXIT CODES:
 #   0 = Review passed (safe to merge)
@@ -164,19 +169,58 @@ if ! command -v gh &>/dev/null; then
 fi
 
 # --- Parse arguments ---
-# Expected: pr merge [PR_NUMBER] [--flags...]
-# PR number might be positional or we use current branch's PR
-
-shift 2 # Remove "pr" and "merge"
-
+# Expected forms (the wrappers pass the full original $@ through):
+#   pr merge [PR_NUMBER] [--flags...]
+#   -R owner/repo pr merge [PR_NUMBER] [--flags...]
+#   --repo owner/repo pr merge [PR_NUMBER] [--flags...]
+#   --repo=owner/repo pr merge [PR_NUMBER] [--flags...]
+#
+# We can't naively `shift 2` because global flags may precede `pr merge`.
+# Walk the args once, skipping flags (and their separated values for the
+# known two-token globals), and treat the third positional as PR_NUMBER.
+# Also capture --repo / -R for downstream propagation.
 PR_NUMBER=""
+GH_REPO_OVERRIDE=""
+_skip_next=0
+_pending_capture=""
+_positional_count=0
 for arg in "$@"; do
-  # If arg is a number, it's the PR number
-  if [[ "${arg}" =~ ^[0-9]+$ ]]; then
-    PR_NUMBER="${arg}"
-    break
+  if [[ "${_skip_next}" == "1" ]]; then
+    if [[ "${_pending_capture}" == "repo" ]]; then
+      GH_REPO_OVERRIDE="${arg}"
+    fi
+    _pending_capture=""
+    _skip_next=0
+    continue
   fi
+  case "${arg}" in
+    -R | --repo)
+      _skip_next=1
+      _pending_capture=repo
+      ;;
+    --hostname | --config-dir | --token)
+      _skip_next=1
+      ;;
+    --repo=*) GH_REPO_OVERRIDE="${arg#*=}" ;;
+    -R=*) GH_REPO_OVERRIDE="${arg#*=}" ;;
+    --*=* | -*) ;; # other flags: pass over (single-token; no value to skip)
+    *)
+      # Positional. Order: [pr] [merge] [PR_NUMBER]
+      _positional_count=$((_positional_count + 1))
+      if [[ ${_positional_count} -ge 3 && -z "${PR_NUMBER}" && "${arg}" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="${arg}"
+      fi
+      ;;
+  esac
 done
+
+# Build REPO_FLAG passthrough array for downstream gh calls.
+# When empty, "${REPO_FLAG[@]}" expands to nothing under bash 5+ on macOS
+# (the script's target platform), so call sites can spread it unconditionally.
+REPO_FLAG=()
+if [[ -n "${GH_REPO_OVERRIDE}" ]]; then
+  REPO_FLAG=(--repo "${GH_REPO_OVERRIDE}")
+fi
 
 # --- Non-interactive flag gate ---
 # When invoked from Claude Code (CLAUDECODE set), require --squash and --delete-branch.
@@ -216,7 +260,7 @@ _fetch_pr_json() {
   local stderr_file
   stderr_file=$(mktemp)
   for fields in "${PR_JSON_FIELDS}" "${PR_JSON_FIELDS_FALLBACK}"; do
-    if result=$(command gh pr view "${pr_args[@]}" --json "${fields}" 2>"${stderr_file}"); then
+    if result=$(command gh pr view "${pr_args[@]}" "${REPO_FLAG[@]}" --json "${fields}" 2>"${stderr_file}"); then
       rm -f "${stderr_file}"
       echo "${result}"
       return 0
@@ -398,21 +442,29 @@ fi
 
 # --- Fetch detailed review comments ---
 # Get review threads which include inline comments
-REVIEW_COMMENTS=$(command gh pr view "${PR_NUMBER}" --comments 2>&1) || {
+REVIEW_COMMENTS=$(command gh pr view "${PR_NUMBER}" "${REPO_FLAG[@]}" --comments 2>&1) || {
   log_warn "Could not fetch detailed comments, continuing with basic review data"
   REVIEW_COMMENTS=""
 }
 
 # --- Fetch inline review comments (where Sentry bot posts) ---
 # These are comments on specific lines of code, separate from review summaries
-REPO_OWNER=$(command gh repo view --json owner -q '.owner.login' 2>&1) || {
-  log_warn "Could not determine repo owner"
-  REPO_OWNER=""
-}
-REPO_NAME=$(command gh repo view --json name -q '.name' 2>&1) || {
-  log_warn "Could not determine repo name"
-  REPO_NAME=""
-}
+if [[ -n "${GH_REPO_OVERRIDE}" ]]; then
+  # --repo was provided explicitly; parse OWNER/NAME directly. Avoids a
+  # `gh repo view` call that would fall back to CWD (which may not be the
+  # target repo at all when the caller is invoking from elsewhere).
+  REPO_OWNER="${GH_REPO_OVERRIDE%/*}"
+  REPO_NAME="${GH_REPO_OVERRIDE#*/}"
+else
+  REPO_OWNER=$(command gh repo view --json owner -q '.owner.login' 2>&1) || {
+    log_warn "Could not determine repo owner"
+    REPO_OWNER=""
+  }
+  REPO_NAME=$(command gh repo view --json name -q '.name' 2>&1) || {
+    log_warn "Could not determine repo name"
+    REPO_NAME=""
+  }
+fi
 
 INLINE_COMMENTS=""
 if [[ -n "${REPO_OWNER}" && -n "${REPO_NAME}" ]]; then
@@ -507,7 +559,7 @@ else
 fi
 
 # Get the full diff for context
-PR_DIFF=$(command gh pr diff "${PR_NUMBER}" 2>&1) || {
+PR_DIFF=$(command gh pr diff "${PR_NUMBER}" "${REPO_FLAG[@]}" 2>&1) || {
   log_warn "Could not fetch PR diff"
   PR_DIFF=""
 }

--- a/tests/test_pre_merge_repo_flag.bats
+++ b/tests/test_pre_merge_repo_flag.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# Tests for --repo / -R passthrough in pre-merge-review.sh
+#
+# Background: pre-merge-review.sh resolves the target repo via `gh repo view`
+# (CWD-dependent) and then issues `gh pr view N` / `gh pr diff N` calls that
+# also fall back to CWD when --repo is absent. When the caller invokes
+# `gh -R owner/repo pr merge N` (or `--repo owner/repo`) from outside the
+# target repo's clone, the CWD-based resolution picks up the wrong repo and
+# the GraphQL query later fails with "Could not resolve to a PullRequest with
+# the number of N".
+#
+# Fix: parse --repo (and -R, --repo=, -R=) from the original args; when
+# provided, set REPO_OWNER/REPO_NAME directly from the flag value (skipping
+# the CWD-dependent `gh repo view` calls) and propagate --repo to all
+# `gh pr view` / `gh pr diff` invocations. Also replaces the brittle
+# `shift 2` with a global-flag-aware positional counter.
+#
+# Run: bats ~/.claude/tests/test_pre_merge_repo_flag.bats
+
+SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+VALID_JSON='{"number":123,"title":"test PR","reviewDecision":"APPROVED","reviews":[],"comments":[],"state":"OPEN","statusCheckRollup":[{"name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+
+setup() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  export PATH="${MOCK_DIR}:${PATH}"
+
+  # Mock gh that records every invocation to ${MOCK_DIR}/gh_calls.log,
+  # one line per call, args separated by '|'. Returns canned responses
+  # so the script reaches the GraphQL block (and beyond) without falling
+  # over on missing data.
+  cat >"${MOCK_DIR}/gh" <<EOF
+#!/usr/bin/env bash
+# Record this invocation: subcommand path + flags
+printf '%s\n' "\$(IFS='|'; echo "\$*")" >>"${MOCK_DIR}/gh_calls.log"
+
+# pr view --json ... → return PR JSON
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  for arg in "\$@"; do
+    if [[ "\${arg}" == "--json" ]]; then
+      echo '${VALID_JSON}'
+      exit 0
+    fi
+  done
+  # pr view --comments → return empty
+  echo ""
+  exit 0
+fi
+
+# pr diff → empty
+if [[ "\$1" == "pr" && "\$2" == "diff" ]]; then
+  echo ""
+  exit 0
+fi
+
+# repo view → return owner/name (the WRONG one — proves we used --repo
+# when test asserts otherwise)
+if [[ "\$1" == "repo" && "\$2" == "view" ]]; then
+  for arg in "\$@"; do
+    if [[ "\${arg}" == ".owner.login" ]]; then
+      echo "wrong-owner"
+      exit 0
+    fi
+    if [[ "\${arg}" == ".name" ]]; then
+      echo "wrong-name"
+      exit 0
+    fi
+  done
+  exit 0
+fi
+
+# api → empty array (no inline comments)
+if [[ "\$1" == "api" ]]; then
+  if [[ "\$2" == "graphql" ]]; then
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+    exit 0
+  fi
+  echo "[]"
+  exit 0
+fi
+
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  # Mock claude CLI — must exist and be executable for preflight to pass.
+  # Returns a SAFE_TO_MERGE verdict so the script reaches normal completion.
+  cat >"${MOCK_DIR}/claude" <<'CLAUDE_EOF'
+#!/usr/bin/env bash
+cat >/dev/null # consume stdin prompt
+echo "VERDICT: SAFE_TO_MERGE"
+echo "All good."
+exit 0
+CLAUDE_EOF
+  chmod +x "${MOCK_DIR}/claude"
+  export CLAUDE_CLI="${MOCK_DIR}/claude"
+
+  # Mock merge-lock.sh — always authorized so we test only the parsing path.
+  cat >"${MOCK_DIR}/merge-lock.sh" <<'LOCK_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "check" ]]; then
+  exit 0
+fi
+LOCK_EOF
+  chmod +x "${MOCK_DIR}/merge-lock.sh"
+  export MOCK_LOCK="${MOCK_DIR}/merge-lock.sh"
+
+  # Mock create_nonblocking_issues so the lib doesn't try to file issues
+  # or read state we haven't mocked. The script sources lib-review-issues.sh
+  # which provides this; we don't need to override unless it misbehaves.
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+}
+
+# Run the script with a custom argv. Sets up a clean mock HOME with the
+# merge-lock and lib symlinked, so the script's `source` of lib-review-issues.sh
+# resolves correctly relative to the real script.
+_run_script() {
+  env HOME="${MOCK_DIR}/home" PATH="${MOCK_DIR}:${PATH}" \
+    bash -c "
+      export HOME='${MOCK_DIR}/home'
+      export CLAUDE_CLI='${CLAUDE_CLI}'
+      mkdir -p \"\${HOME}/.claude/hooks\"
+      cp '${MOCK_LOCK}' \"\${HOME}/.claude/hooks/merge-lock.sh\"
+      chmod +x \"\${HOME}/.claude/hooks/merge-lock.sh\"
+      '${SCRIPT}' $*
+    " 2>&1
+}
+
+# Helper: count `gh repo view` invocations recorded by the mock.
+_repo_view_count() {
+  if [[ ! -f "${MOCK_DIR}/gh_calls.log" ]]; then
+    echo 0
+    return
+  fi
+  grep -c '^repo|view' "${MOCK_DIR}/gh_calls.log" || true
+}
+
+# Helper: assert that some `gh pr view N` call had `--repo OWNER/NAME`.
+_pr_view_has_repo() {
+  local owner_repo="$1"
+  grep -E "^pr\|view\|" "${MOCK_DIR}/gh_calls.log" \
+    | grep -qE "(^|\|)--repo\|${owner_repo}(\||$)"
+}
+
+# Helper: assert that some `gh pr diff N` call had `--repo OWNER/NAME`.
+_pr_diff_has_repo() {
+  local owner_repo="$1"
+  grep -E "^pr\|diff\|" "${MOCK_DIR}/gh_calls.log" \
+    | grep -qE "(^|\|)--repo\|${owner_repo}(\||$)"
+}
+
+# Helper: assert that some `gh pr view N` was invoked with the given PR number.
+_pr_view_has_number() {
+  local pr_num="$1"
+  grep -E "^pr\|view\|" "${MOCK_DIR}/gh_calls.log" \
+    | grep -qE "(^|\|)${pr_num}(\||$)"
+}
+
+# ── -R short form ────────────────────────────────────────────────────────────
+
+@test "gh -R owner/repo pr merge 123 --squash --delete-branch: --repo propagated; gh repo view skipped" {
+  run _run_script -R owner/repo pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  [[ "$(_repo_view_count)" -eq 0 ]]
+  _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── --repo long form ─────────────────────────────────────────────────────────
+
+@test "gh --repo owner/repo pr merge 123 --squash --delete-branch: --repo propagated" {
+  run _run_script --repo owner/repo pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  [[ "$(_repo_view_count)" -eq 0 ]]
+  _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── --repo=value form ────────────────────────────────────────────────────────
+
+@test "gh --repo=owner/repo pr merge 123 --squash --delete-branch: --repo propagated" {
+  run _run_script --repo=owner/repo pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  [[ "$(_repo_view_count)" -eq 0 ]]
+  _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── -R=value form ────────────────────────────────────────────────────────────
+
+@test "gh -R=owner/repo pr merge 123 --squash --delete-branch: --repo propagated" {
+  run _run_script -R=owner/repo pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  [[ "$(_repo_view_count)" -eq 0 ]]
+  _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── No --repo: legacy CWD-based behavior preserved ───────────────────────────
+
+@test "gh pr merge 123 --squash --delete-branch (no --repo): gh repo view IS called; pr view has NO --repo flag" {
+  run _run_script pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  # Without --repo, the script falls back to gh repo view (CWD-based) — the
+  # exact pre-fix behavior, preserved by the new parser.
+  [[ "$(_repo_view_count)" -ge 1 ]]
+  # And no --repo flag is added to pr view / pr diff.
+  ! _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── Multiple global flags: only --repo captured ──────────────────────────────
+
+@test "gh -R owner/repo --hostname example.com pr merge 123: only --repo captured; --hostname value not consumed as PR" {
+  # --hostname takes a separate value (example.com) which the parser must skip.
+  # If the parser mishandles it, "example.com" or some other token could be
+  # mistaken for the PR number — but we passed 123 explicitly so this asserts
+  # the parser still finds it.
+  run _run_script -R owner/repo --hostname example.com pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  [[ "$(_repo_view_count)" -eq 0 ]]
+  _pr_view_has_repo "owner/repo"
+  _pr_view_has_number "123"
+}
+
+# ── --repo with global flag AFTER subcommand ─────────────────────────────────
+
+@test "gh pr merge 123 --squash (no --repo, no extra flags): PR_NUMBER still extracted" {
+  # Sanity: regression check that the new positional-count logic doesn't
+  # accidentally treat "merge" or "pr" as PR_NUMBER (neither is numeric, so
+  # this would only matter if the count check were buggy).
+  run _run_script pr merge 123 --squash --delete-branch
+
+  [[ "${status}" -eq 0 ]]
+  _pr_view_has_number "123"
+}


### PR DESCRIPTION
## Summary

Today's session hit two `gh pr merge` failures against PRs in two different repos when running from a CWD that wasn't the target repo's clone — `gh -R owner/repo pr merge N` was reaching `pre-merge-review.sh`, but the script's GraphQL query later bailed with **"Could not resolve to a PullRequest with the number of N"** because the repo was being resolved from the (wrong) current directory.

Two underlying bugs in `hooks/pre-merge-review.sh`:

1. **Brittle `shift 2`** assumed `$@` always started with `pr merge`. With `gh -R owner/repo pr merge ...` the global flag and its value land in front, and `shift 2` strips them off, leaving the script blind to `--repo`. PR_NUMBER detection still happened to work (the loop picked the first numeric arg), but the assumption was the kind that breaks the next time anything depends on positional args.
2. **No `--repo` extraction or propagation.** The script called `gh repo view` (lines 408/412) and `gh pr view` / `gh pr diff` (lines 219, 401, 510) without `--repo`, so all of them fell back to the CWD. `REPO_OWNER`/`REPO_NAME` resolved to the wrong repo, and the GraphQL query keyed on those then 404'd on the PR number.

## Fix

- Replace `shift 2` with a global-flag-aware single pass over `$@`. The parser skips known two-token global flags (`-R/--repo/--hostname/--config-dir/--token`), recognizes `--repo=value` / `-R=value`, and only treats the **third** positional as PR_NUMBER (so `pr` and `merge` themselves can never be misread).
- When `--repo OWNER/NAME` is supplied, set `REPO_OWNER`/`REPO_NAME` directly from the flag value and skip the CWD-dependent `gh repo view` calls entirely.
- Build a `REPO_FLAG=(--repo "$override")` array (empty when no override) and spread it into every `gh pr view` and `gh pr diff` call site so they target the correct repo regardless of CWD.

The two upstream wrappers (`gh()` in `dotfiles/bash/functions.sh` and `~/.local/bin/gh`) already pass the full `$@` through and need no changes — this is purely a script-side fix.

## Test plan

- [x] `bats tests/test_pre_merge_repo_flag.bats` — 7/7 pass (covers `-R`, `--repo`, `--repo=`, `-R=`, the no-flag baseline, and interleaved `--hostname`)
- [x] `bats tests/test_pre_merge_*.bats` — same baseline failure count as `main` (21); zero regressions introduced. The pre-existing failures are unrelated env issues (missing `parse_nonblocking_issues` / output-string mismatches).
- [x] `bats tests/test_gh_wrapper*.bats` — 18/18 pass; wrapper behavior unchanged.
- [x] `shellcheck -S info hooks/pre-merge-review.sh` — same single preexisting SC1091 (lib path) as `main`; no new findings.
- [x] `bash -n hooks/pre-merge-review.sh` — clean.
- [x] Smoke test from `/tmp`: `command gh -R smartwatermelon/claude-config pr view 150 --json number,state -q '.state'` → returns `MERGED` (confirming `gh -R` itself addresses the right repo from any CWD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)