### PR TITLE
feat(review): add model selection (haiku for commits, sonnet for branch review)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,8 +5,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -15,8 +13,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 #   review.maxLines        - Max lines for full review (default: 1000)
 #   review.skipThreshold   - Skip AI review beyond this (default: 2500)
 #   review.chunkSize       - Max lines per file in chunked mode (default: 800)
+#   review.model           - Claude model ID (default: haiku for commits, sonnet for full-diff/codebase)
 #
 # EXAMPLES:
 #   git config --global review.maxLines 2000
@@ -94,6 +95,23 @@ done
 # Override timeout for codebase mode (longer due to tool-access exploration)
 if [[ "${REVIEW_MODE}" == "codebase" ]]; then
   TIMEOUT_SECONDS=$(git config --get --type=int review.codebaseTimeout 2>/dev/null || echo "300")
+fi
+
+# --- Model selection ---
+# Priority: git config review.model > mode-based default > CLI default
+# Haiku for commit-level (small diffs, fast feedback); Sonnet for branch/codebase analysis.
+REVIEW_MODEL=$(git config --get review.model 2>/dev/null || echo "")
+if [[ -z "${REVIEW_MODEL}" ]]; then
+  case "${REVIEW_MODE}" in
+    commit)   REVIEW_MODEL="claude-haiku-4-5-20251001" ;;
+    full-diff) REVIEW_MODEL="claude-sonnet-4-6" ;;
+    codebase) REVIEW_MODEL="claude-sonnet-4-6" ;;
+    *)        REVIEW_MODEL="" ;;
+  esac
+fi
+MODEL_ARGS=()
+if [[ -n "${REVIEW_MODEL}" ]]; then
+  MODEL_ARGS=(--model "${REVIEW_MODEL}")
 fi
 
 # --- Colors ---
@@ -183,7 +201,7 @@ invoke_agent() {
   local exit_code=0
   # Use || to prevent set -e from propagating if the CLI exits non-zero.
   # exit_code is then set to the actual failure code for the handler below.
-  agent_output=$(echo "${prompt}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "${agent_name}" -p --tools "" --no-session-persistence 2>&1) || exit_code=$?
+  agent_output=$(echo "${prompt}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "${agent_name}" -p "${MODEL_ARGS[@]}" --tools "" --no-session-persistence 2>&1) || exit_code=$?
 
   # Handle timeout - BLOCK commit (strict mode)
   if [[ ${exit_code} -eq 124 ]]; then
@@ -899,7 +917,7 @@ END_ISSUE"
   codebase_exit=0
   # Invoke WITHOUT --tools "" so agent gets default tool access (Read, Grep, Glob).
   # --allowedTools restricts to safe read-only tools only.
-  CODEBASE_OUTPUT=$(echo "${CODEBASE_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "adversarial-reviewer" -p --allowedTools "Read,Grep,Glob" --no-session-persistence 2>&1) || codebase_exit=$?
+  CODEBASE_OUTPUT=$(echo "${CODEBASE_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "adversarial-reviewer" -p "${MODEL_ARGS[@]}" --allowedTools "Read,Grep,Glob" --no-session-persistence 2>&1) || codebase_exit=$?
 
   codebase_end=$(date +%s)
   codebase_elapsed=$(( codebase_end - codebase_start ))
@@ -1024,6 +1042,10 @@ ${DIFF}
 # Bash tool even when subsequent output is swallowed by the nested claude process.
 printf 'diff_lines: %d\n' "${DIFF_LINES}" >>"${REVIEW_LOG}" || true
 log_info "Review log: ${REVIEW_LOG}"
+if [[ -n "${REVIEW_MODEL}" ]]; then
+  log_info "Model: ${REVIEW_MODEL}"
+  printf 'model: %s\n' "${REVIEW_MODEL}" >>"${REVIEW_LOG}" || true
+fi
 
 # Run code-reviewer and adversarial-reviewer in parallel when both are
 # available. Each reviewer's stdout is captured to its own temp file so


### PR DESCRIPTION
## Summary

Part of the Anthropic spend reduction initiative.

- **Commit-level review** now defaults to `claude-haiku-4-5-20251001` — fast, cheap, and sufficient for small diffs (single-commit pre-commit review)
- **Branch-level (full-diff) and codebase review** stays on `claude-sonnet-4-6` — needs more reasoning capability for cross-file analysis and systemic issues
- **Per-repo override** available via `git config review.model <model-id>` for cases where a specific model is needed
- **Issues trigger removed** from Claude Code workflow — stops cascade from Ralph/Dependabot issue creation triggering unnecessary GH Actions runs
- Model selection logged to review log for auditability

## Details

### Model selection priority
1. `git config review.model` (explicit per-repo override)
2. Mode-based default (haiku for `commit`, sonnet for `full-diff`/`codebase`)
3. Empty (CLI default, for unknown modes)

### Cost impact
- Commit-level reviews (the most frequent invocation) move from Sonnet to Haiku
- Issues trigger removal eliminates spurious GH Actions runs from automated issue creation

## Test plan

- [x] shellcheck -S info passes (no new warnings)
- [x] Pre-commit review passed using haiku (visible in review log: `Model: claude-haiku-4-5-20251001`)
- [x] Pre-push full-diff review passed using sonnet
- [x] Pre-push codebase review passed using sonnet
- [ ] Verify `git config review.model <override>` takes precedence over defaults