### PR TITLE
ci: add Haiku A/B test to blocking review

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -17,3 +17,11 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  claude-review-haiku:
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      model: "claude-haiku-4-5-20251001"
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Adds an advisory `claude-review-haiku` job alongside the existing blocking `claude-review` (Sonnet) job in the CI blocking review workflow.

- Both jobs run in parallel on every PR, calling the same reusable workflow (`claude-blocking-review.yml@v3.0.0`)
- Sonnet (`claude-review`) remains the required status check — Haiku is advisory only
- After 2+ weeks of data, we compare verdicts to evaluate whether Haiku produces comparable review quality at lower cost

## Test plan

- [ ] Verify both jobs appear in the Actions tab on this PR
- [ ] Confirm `claude-review` (Sonnet) still runs as before
- [ ] Confirm `claude-review-haiku` runs with Haiku model
- [ ] Verify only `claude-review` is configured as a required status check (Haiku is advisory)