### PR TITLE
fix(review): treat VERDICT: Revise as synonym for FAIL

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -523,7 +523,7 @@ ${file_diff}
       continue
     fi
 
-    if echo "${_rout}" | grep -q "VERDICT: FAIL"; then
+    if echo "${_rout}" | grep -qE "VERDICT: (FAIL|Revise)"; then
       if echo "${_rout}" | grep -q "SEVERITY: BLOCKING"; then
         ((blocking_count += 1))
         overall_verdict="FAIL"
@@ -818,7 +818,7 @@ ${DIFF}
     printf 'full-diff: PASS\n' >>"${REVIEW_LOG}" || true
     log_success "Full-diff review passed"
     exit 0
-  elif echo "${FULL_DIFF_OUTPUT}" | grep -q "VERDICT: FAIL"; then
+  elif echo "${FULL_DIFF_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
     if echo "${FULL_DIFF_OUTPUT}" | grep -q "SEVERITY: BLOCKING"; then
       printf 'full-diff: FAIL (blocking)\n' >>"${REVIEW_LOG}" || true
       log_error "Full-diff review found blocking cross-file issues"
@@ -958,7 +958,7 @@ END_ISSUE"
     fi
 
     exit 0
-  elif echo "${CODEBASE_OUTPUT}" | grep -q "VERDICT: FAIL"; then
+  elif echo "${CODEBASE_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
     if echo "${CODEBASE_OUTPUT}" | grep -q "SEVERITY: BLOCKING"; then
       printf 'codebase: FAIL (blocking)\n' >>"${REVIEW_LOG}" || true
       log_error "Codebase review found blocking issues"
@@ -1100,7 +1100,7 @@ fi
 # Parse verdict from code-reviewer output
 if echo "${CODE_REVIEWER_OUTPUT}" | grep -q "VERDICT: PASS"; then
   CODE_REVIEWER_VERDICT="PASS"
-elif echo "${CODE_REVIEWER_OUTPUT}" | grep -q "VERDICT: FAIL"; then
+elif echo "${CODE_REVIEWER_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
   CODE_REVIEWER_VERDICT="FAIL"
 else
   log_error "Could not parse code-reviewer verdict"
@@ -1115,7 +1115,7 @@ fi
 if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
   if echo "${ADVERSARIAL_OUTPUT}" | grep -q "VERDICT: PASS"; then
     ADVERSARIAL_VERDICT="PASS"
-  elif echo "${ADVERSARIAL_OUTPUT}" | grep -q "VERDICT: FAIL"; then
+  elif echo "${ADVERSARIAL_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
     ADVERSARIAL_VERDICT="FAIL"
   else
     log_error "Could not parse adversarial-reviewer verdict"

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -523,11 +523,52 @@ assert_contains \
   "${log_content10}"
 
 # =========================================================
+# TEST 11: "VERDICT: Revise" is treated as FAIL (blocking)
+#
+# Reviewers sometimes emit "VERDICT: Revise" instead of "VERDICT: FAIL".
+# The script must treat Revise as a synonym for FAIL: when combined with
+# SEVERITY: BLOCKING, it should block the commit (exit 1).
+# =========================================================
+echo ""
+echo "=== Test 11: VERDICT: Revise treated as blocking FAIL ==="
+
+setup_repo
+stage_small_change
+
+MOCK11_DIR="${TMPDIR_TEST}/mock11"
+make_mock_claude "${MOCK11_DIR}" 0 "VERDICT: Revise
+
+ISSUE: Hardcoded secret
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: Remove the hardcoded credential."
+
+TEST11_LOG="${TMPDIR_TEST}/test11-review.log"
+rm -f "${TEST11_LOG}"
+
+exit_t11=0
+cd "${REPO_DIR}"
+REVIEW_LOG="${TEST11_LOG}" CLAUDE_CLI="${MOCK11_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || exit_t11=$?
+cd - >/dev/null
+
+assert_eq \
+  "VERDICT: Revise with BLOCKING severity blocks commit (exit 1)" \
+  "1" \
+  "${exit_t11}"
+
+log_content11="$(cat "${TEST11_LOG}" 2>/dev/null || echo "")"
+
+assert_contains \
+  "log records FAIL verdict (Revise normalized to FAIL)" \
+  "FAIL" \
+  "${log_content11}"
+
+# =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 15 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 17 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Reviewers sometimes emit `VERDICT: Revise` instead of `VERDICT: FAIL`, which fell through to the "Could not parse verdict" error path and blocked commits unnecessarily
- Updated all 5 verdict-parsing grep calls in `run-review.sh` to match both `FAIL` and `Revise` via `grep -qE "VERDICT: (FAIL|Revise)"`
- Added Test 11 confirming `VERDICT: Revise` with `SEVERITY: BLOCKING` correctly blocks the commit

## Test plan
- [x] All 17 test assertions pass (including new Test 11)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)