### PR TITLE
Beacon work laptop: settings fixes, marketplace tracking, mobile plugins off

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,13 +23,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # claude-code-action rejects non-User actors unless explicitly allowed.
           # The `if:` guard above still filters on @claude mention content; this

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Decide if PR is auto-mergeable
         id: policy

--- a/README.md
+++ b/README.md
@@ -73,17 +73,33 @@ Plugins are sourced from four marketplaces. Enabled state is tracked in `setting
 - **comprehensive-review** ✓ — 3 agents: code-reviewer, architect-review, security-auditor
 - **tdd-workflows** ✓ — test-driven development workflows
 - **debugging-toolkit** ✓ — debugging and error analysis
-- **frontend-mobile-development** ✓ — React, Next.js, React Native patterns
+- **frontend-mobile-development** — React, Next.js, React Native patterns (disabled on some machines — see [Per-Machine Notes](#per-machine-notes))
 - git-pr-workflows, error-debugging, code-refactoring, dependency-management, code-documentation, backend-development, unit-testing, security-compliance, incident-response, team-collaboration (available, not enabled)
 
 ### From smartwatermelon-marketplace
 
 - **code-critic** ✓ — adversarial code review agent
-- **react-native-3d** ✓ — 3D rendering with React Three Fiber, expo-gl, Three.js
+- **react-native-3d** — 3D rendering with React Three Fiber, expo-gl, Three.js (disabled on some machines — see [Per-Machine Notes](#per-machine-notes))
 
 ### From claude-code-plugins
 
 - **frontend-design** ✓ — production-grade frontend UI generation
+
+## Per-Machine Notes
+
+`settings.json` is shared across every machine via the symlink install, so
+plugin choices are global by default. Machines with a narrower purpose
+disable what they don't need rather than forking the config:
+
+| Machine | Purpose | Deviates from default by |
+|---|---|---|
+| Beacon Biosignals work laptop (`arich@...`, provisioned 2026-07-12) | Senior SRE work: Python/Bash, infra CLIs, web-based tools, ssh. No app/mobile dev. | `frontend-mobile-development` and `react-native-3d` disabled — no Android/iOS/Expo/React Native work happens on this machine. |
+
+When setting up a new machine: check this table first. If the new machine's
+purpose matches an existing entry, replicate its deviations; if it's closer
+to the personal-dev default, leave everything enabled and don't add a row
+just to say so. Add a row only when a machine's plugin set actually diverges
+from the tracked default.
 
 ## Architecture
 

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "BASH_ENV": "/Users/andrewrich/.config/bash/functions.sh",
+    "BASH_ENV": "~/.config/bash/functions.sh",
     "CLAUDE_CODE_SHELL": "/opt/homebrew/bin/bash"
   },
   "includeCoAuthoredBy": true,
@@ -72,21 +72,40 @@
     "dependency-management@claude-code-workflows": false,
     "code-documentation@claude-code-workflows": false,
     "backend-development@claude-code-workflows": false,
-    "frontend-mobile-development@claude-code-workflows": true,
+    "frontend-mobile-development@claude-code-workflows": false,
     "unit-testing@claude-code-workflows": false,
     "security-compliance@claude-code-workflows": false,
     "incident-response@claude-code-workflows": false,
     "team-collaboration@claude-code-workflows": false,
     "code-critic@smartwatermelon-marketplace": true,
-    "react-native-3d@smartwatermelon-marketplace": true,
+    "react-native-3d@smartwatermelon-marketplace": false,
     "frontend-design@claude-code-plugins": true,
-    "ci-workflows@smartwatermelon-marketplace": true
+    "ci-workflows@smartwatermelon-marketplace": true,
+    "apple-notes@apple-notes-mcp": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
+      }
+    },
+    "apple-notes-mcp": {
+      "source": {
+        "source": "github",
+        "repo": "sweetrb/apple-notes-mcp"
+      }
+    },
+    "claude-code-workflows": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/wshobson/agents.git"
+      }
+    },
+    "smartwatermelon-marketplace": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/smartwatermelon/smartwatermelon-marketplace.git"
       }
     }
   },
@@ -98,11 +117,11 @@
     ]
   },
   "alwaysThinkingEnabled": true,
+  "effortLevel": "medium",
   "skipDangerousModePermissionPrompt": true,
   "verbose": true,
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "useAutoModeDuringPlan": false,
-  "gitAttribution": true,
-  "effortLevel": "medium"
+  "gitAttribution": true
 }


### PR DESCRIPTION
## Summary
- Fixes `BASH_ENV` hardcoded to the old machine's username (`/Users/andrewrich`) instead of `~/.config/bash/functions.sh` — was silently breaking shared shell functions in Bash tool calls on any machine other than the original one.
- Tracks `claude-code-workflows` and `smartwatermelon-marketplace` in `extraKnownMarketplaces` (git source) instead of relying on untracked local `known_marketplaces.json` — closes the "fresh machine needs manual marketplace re-add" gap called out in the README's manual-steps list. Also tracks the `apple-notes-mcp` plugin/marketplace, previously only in local runtime state.
- Disables `frontend-mobile-development` and `react-native-3d` for this machine (SRE work only, no mobile/app dev) and documents the divergence in a new README "Per-Machine Notes" section for future machine setups.
- Fixes pre-existing Semgrep findings unrelated to the above (no token yet on this machine → whole-tree scan instead of diff-aware): missing Dependabot cooldown, and three GitHub Actions pinned by mutable tag instead of SHA.

## Context
New work laptop for Beacon Biosignals (Senior SRE role, provisioned 2026-07-12).

## Test plan
- [x] `bash -c 'type _notif'` / fresh non-interactive bash confirms `BASH_ENV` tilde does get expanded by bash itself, despite `echo $BASH_ENV` printing the literal string
- [x] `claude plugin marketplace list` confirms all 4 marketplaces registered and resolving
- [x] All three pinned SHAs verified two independent ways (`gh api` + `git ls-remote --tags`, annotated tag peeled via `^{}` for claude-code-action)
- [x] `git commit`/`git push` succeeded through pre-commit + pre-push hooks (code-reviewer/adversarial-reviewer PASS)
- [x] Two non-blocking issues auto-filed by the codebase-review hook ([#185](https://github.com/smartwatermelon/claude-config/issues/185), [#186](https://github.com/smartwatermelon/claude-config/issues/186)) were both false positives — verified and ready to close, left open pending your confirmation