### PR TITLE
fix: skip review for submodule-pointer-only diffs

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -717,6 +717,22 @@ if ! echo "${DIFF}" 2>/dev/null | grep -qE '^[+-][^+-]'; then
   exit 0
 fi
 
+# --- Check for submodule-pointer-only changes ---
+# A `Subproject commit <sha>` bump is opaque to every review mode here — this
+# script has no access to the submodule's own history, so codebase-mode review
+# can only ever restate "contents not inspectable" as a non-blocking issue on
+# every bump (see claude-config#192). Operates on DIFF content directly (not
+# file names), so — unlike the markdown/lockfile skips below — it's safe to
+# apply in every mode, including full-diff/codebase where DIFF is piped from
+# main...HEAD rather than the staged index.
+SUBMODULE_ONLY_LINES=$(echo "${DIFF}" | grep -E '^[+-][^+-]' | grep -vE '^[+-]Subproject commit [0-9a-f]{40}$' || true)
+if [[ -z "${SUBMODULE_ONLY_LINES}" ]]; then
+  log_info "Submodule-pointer-only changes detected - skipping review (contents not inspectable)"
+  printf 'skipped: submodule-pointer-only\n' >>"${REVIEW_LOG}" || true
+  exit 0
+fi
+unset SUBMODULE_ONLY_LINES
+
 # --- Check for documentation-only / lockfile-only changes (commit mode only) ---
 # These short-circuits compare staged-index file names against skip-eligible
 # patterns. In --mode=full-diff and --mode=codebase the real diff source is


### PR DESCRIPTION
## Summary
- Add an early-exit guard in `run-review.sh` that skips review when every changed content line is a bare `Subproject commit <sha>` line
- Fixes the recurring "contents not inspectable" non-blocking filler that codebase-mode review filed on every submodule bump (#192) — this script has no access to the submodule's own history, so it could never say anything more useful
- Operates on DIFF content (not file names), so unlike the markdown/lockfile skips it applies safely across every review mode (commit, full-diff, codebase)

## Test plan
- [x] Manually piped a synthetic submodule-pointer-only diff — confirmed the review is skipped (exit 0)
- [x] Manually piped a mixed diff (submodule bump + real code change) — confirmed review still runs and evaluates the code change
- [x] Pre-commit code-reviewer + adversarial-reviewer both pass
- [x] Pre-push full-diff + codebase review both pass, no new tracking issues filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)