### PR TITLE
Make non-blocking issue filing repo- and author-aware

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -173,13 +173,15 @@ _parse_issue_fields() {
 }
 
 # Write an issue body to the local pending-issues fallback dir.
-# Prints the path of the file it wrote.
+# Prints the path of the file it wrote. Returns 1 (printing nothing) if the
+# directory or file couldn't be written, so callers can fail loudly instead
+# of logging a "Saved to: " message with an empty path.
 _write_pending_issue_file() {
   local title="$1"
   local body="$2"
   local pending_dir="$3"
 
-  mkdir -p "${pending_dir}"
+  mkdir -p "${pending_dir}" || return 1
   local slug
   slug=$(echo "${title}" | { tr '[:upper:]' '[:lower:]' || true; } | { tr -cs 'a-z0-9' '-' || true; } | { sed 's/-*$//' || true; } | cut -c1-40)
   # Use PR_NUMBER in filename when available, otherwise use date-based prefix
@@ -190,7 +192,7 @@ _write_pending_issue_file() {
     slug_index=$((slug_index + 1))
     fallback_file="${pending_dir}/${file_prefix}-${slug}-${slug_index}.md"
   done
-  printf "%s\n" "${body}" >"${fallback_file}"
+  printf "%s\n" "${body}" >"${fallback_file}" || return 1
   echo "${fallback_file}"
 }
 
@@ -219,7 +221,10 @@ create_apple_note_issue() {
   command -v osascript >/dev/null 2>&1 || return 1
 
   local escaped_title escaped_body body_html
+  # AppleScript string literals can't span lines, so the title (unlike the
+  # body, which converts newlines to <br>) must not contain any.
   escaped_title=$(_escape_for_applescript "${title}")
+  escaped_title="${escaped_title//$'\n'/ }"
   escaped_body=$(_escape_for_applescript "${body}")
   body_html="${escaped_body//$'\n'/<br>}"
 
@@ -261,11 +266,14 @@ _process_issue_block_apple_note() {
     log_success "Filed private tech-debt note: ${title}"
     log_success "  -> Notes.app / Tech Debt folder (${hashtags})"
   else
-    local fallback_file
-    fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}")
     log_warn "Could not create Apple Note automatically (osascript unavailable or failed)."
-    log_warn "  Saved to: ${fallback_file}"
-    log_warn "  File this privately (e.g. paste into Notes.app 'Tech Debt' folder) — do not create a public GitHub issue for this."
+    local fallback_file
+    if fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}"); then
+      log_warn "  Saved to: ${fallback_file}"
+      log_warn "  File this privately (e.g. paste into Notes.app 'Tech Debt' folder) — do not create a public GitHub issue for this."
+    else
+      log_warn "  Could not write fallback file either (${pending_dir}) — this finding is lost: ${title}"
+    fi
   fi
 }
 
@@ -285,18 +293,22 @@ _format_issue_bullet() {
   printf -- "- **%s** (%s, \`%s\`): %s\n" "${title}" "${source}" "${location}" "${details}"
 }
 
-# Post all parsed issue blocks as a single aggregated PR comment.
-# Used for beacon-biosignals PRs that aren't Andrew's own work — visible to
-# that PR's participants only, not announced org-wide.
+# Post all parsed issue blocks as a single aggregated PR comment. Used for
+# beacon-biosignals PRs that aren't the reviewer's own work — visible to that
+# PR's participants only, not announced org-wide, and not attributed to a
+# public GitHub issue. Falls back to per-issue pending files (same as the
+# other two filing paths) if the comment can't be posted, so a `gh` failure
+# never silently drops a finding.
 post_nonblocking_as_pr_comment() {
   local parsed="$1"
+  local pending_dir="$2"
 
   if [[ -z "${PR_NUMBER:-}" ]]; then
     log_warn "Skipping PR-comment filing: no PR_NUMBER in context"
     return 0
   fi
 
-  local comment_body="### Non-blocking review notes"$'\n\n'"Filed as a comment, not a tracking issue, because this isn't Andrew's PR."$'\n'
+  local comment_body="### Non-blocking review notes"$'\n\n'"Filed as a comment rather than a tracking issue, since this is a peer PR review."$'\n'
   local current_block="" bullet
   while IFS= read -r line; do
     if [[ "${line}" == "---ISSUE---" ]]; then
@@ -312,8 +324,16 @@ post_nonblocking_as_pr_comment() {
 
   if command gh pr comment "${PR_NUMBER}" --repo "${REPO_OWNER}/${REPO_NAME}" --body "${comment_body}" >/dev/null 2>&1; then
     log_success "Posted non-blocking review notes as a PR comment on #${PR_NUMBER}"
+    return 0
+  fi
+
+  log_warn "Could not post non-blocking review notes as a PR comment on #${PR_NUMBER}"
+  local fallback_file
+  if fallback_file=$(_write_pending_issue_file "pr-${PR_NUMBER}-nonblocking-notes" "${comment_body}" "${pending_dir}"); then
+    log_warn "  Saved to: ${fallback_file}"
+    log_warn "  Paste this into a comment on PR #${PR_NUMBER} manually."
   else
-    log_warn "Could not post non-blocking review notes as a PR comment on #${PR_NUMBER}"
+    log_warn "  Could not write fallback file either (${pending_dir}) — these findings are lost for PR #${PR_NUMBER}"
   fi
 }
 
@@ -336,7 +356,7 @@ create_nonblocking_issues() {
   [[ -n "${parsed}" ]] || return 0
 
   if is_corporate_repo && ! is_self_authored; then
-    post_nonblocking_as_pr_comment "${parsed}"
+    post_nonblocking_as_pr_comment "${parsed}" "${pending_dir}"
     return 0
   fi
 
@@ -408,10 +428,13 @@ _process_issue_block() {
     rm -f "${gh_stderr_file}"
     [[ -n "${gh_err}" ]] && log_warn "  gh error: ${gh_err}"
     # Fallback: write to file
-    local fallback_file
-    fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}")
     log_warn "Could not create GitHub issue automatically."
-    log_warn "  Saved to: ${fallback_file}"
-    log_warn "  Run: gh issue create --repo ${REPO_OWNER}/${REPO_NAME} --title \"${title}\" --body-file ${fallback_file} --label \"${labels}\""
+    local fallback_file
+    if fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}"); then
+      log_warn "  Saved to: ${fallback_file}"
+      log_warn "  Run: gh issue create --repo ${REPO_OWNER}/${REPO_NAME} --title \"${title}\" --body-file ${fallback_file} --label \"${labels}\""
+    else
+      log_warn "  Could not write fallback file either (${pending_dir}) — this finding is lost: ${title}"
+    fi
   fi
 }

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -49,8 +49,12 @@ is_corporate_repo() {
   [[ "${REPO_OWNER:-}" == "beacon-biosignals" ]]
 }
 
-# Memoized authenticated gh login. Returns 1 (and leaves the cache empty)
-# on failure so a later successful call isn't blocked by an earlier one.
+# Memoized authenticated gh login, cached for the lifetime of this shell
+# process. A failed lookup leaves the cache empty so a later successful call
+# isn't blocked by an earlier one — but a successful lookup is never
+# invalidated, so switching gh accounts mid-process (e.g. `gh auth switch`)
+# won't be picked up. Not a concern in a hook process, which only lives for
+# one commit/merge.
 _GH_LOGIN_CACHE=""
 _cached_gh_login() {
   if [[ -z "${_GH_LOGIN_CACHE:-}" ]]; then
@@ -204,6 +208,10 @@ _escape_for_applescript() {
 # Create a private note in the Notes.app "Tech Debt" folder via osascript.
 # Returns 1 (without touching Notes.app) when osascript is unavailable,
 # e.g. on Linux, so the caller can fall back.
+# CONSTRAINT: the test helper `_load_fn` extracts this function by scanning
+# for a line matching /^}$/ (see tests/test_pre_merge_nonblocking.bats). Keep
+# every AppleScript "end ..." line indented — an unindented bare `}` inside
+# the heredoc would truncate the extraction in tests.
 create_apple_note_issue() {
   local title="$1"
   local body="$2"

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -264,7 +264,7 @@ _format_issue_bullet() {
   _parse_issue_fields "${block}" title source location details
   [[ -n "${title}" ]] || return 0
 
-  printf -- '- **%s** (%s, `%s`): %s\n' "${title}" "${source}" "${location}" "${details}"
+  printf -- "- **%s** (%s, \`%s\`): %s\n" "${title}" "${source}" "${location}" "${details}"
 }
 
 # Post all parsed issue blocks as a single aggregated PR comment.

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -7,10 +7,17 @@
 # and other callers that need to create tracking issues from
 # Claude review output.
 #
+# FILING MODE (decided by repo + author, not by caller):
+#   - Personal repos:                gh issue create (as always)
+#   - beacon-biosignals, Andrew's own work:   private Apple Note
+#   - beacon-biosignals, teammate's work:     aggregated PR comment
+#
 # REQUIRED CALLER VARIABLES:
 #   REPO_OWNER  — GitHub repository owner (org or user)
 #   REPO_NAME   — GitHub repository name
-#   PR_NUMBER   — (optional) Pull request number; omit for non-PR contexts
+#   PR_NUMBER   — (optional) Pull request number; omit for non-PR contexts.
+#                 Also doubles as the "is this Andrew's own work" signal:
+#                 unset means a local commit-level review (always his own).
 #   PR_TITLE    — (optional) Pull request title; omit for non-PR contexts
 #
 # REQUIRED CALLER FUNCTIONS:
@@ -34,6 +41,41 @@ _LIB_REVIEW_ISSUES_LOADED=1
 is_security_critical() {
   local file="$1"
   echo "${file}" | grep -qE '(auth|oauth|jwt|password|session|login|register|payment|billing|stripe|paypal|checkout|transaction|db|database|model|migration|schema|security|crypto|encryption|secret|vault)'
+}
+
+# Corporate-org gate. Hardcoded single org for now; generalize to a
+# list/heuristic only if a second corporate org actually shows up.
+is_corporate_repo() {
+  [[ "${REPO_OWNER:-}" == "beacon-biosignals" ]]
+}
+
+# Memoized authenticated gh login. Returns 1 (and leaves the cache empty)
+# on failure so a later successful call isn't blocked by an earlier one.
+_GH_LOGIN_CACHE=""
+_cached_gh_login() {
+  if [[ -z "${_GH_LOGIN_CACHE:-}" ]]; then
+    _GH_LOGIN_CACHE=$(command gh api user -q .login 2>/dev/null) || return 1
+    [[ -n "${_GH_LOGIN_CACHE:-}" ]] || return 1
+  fi
+  echo "${_GH_LOGIN_CACHE}"
+}
+
+# Is the code under review Andrew's own? True when there's no PR_NUMBER
+# (commit-level review — always a local commit he's about to push).
+# Otherwise compares the PR author to the authenticated gh login.
+# Fails toward "not self" on any lookup error — the safest of the three
+# filing modes (visible only in-PR-context, no public issue, no silent drop).
+is_self_authored() {
+  [[ -z "${PR_NUMBER:-}" ]] && return 0
+
+  local pr_author
+  pr_author=$(command gh pr view "${PR_NUMBER}" --repo "${REPO_OWNER}/${REPO_NAME}" --json author -q .author.login 2>/dev/null) || return 1
+  [[ -n "${pr_author}" ]] || return 1
+
+  local my_login
+  my_login=$(_cached_gh_login) || return 1
+
+  [[ "${pr_author}" == "${my_login}" ]]
 }
 
 # Parse NON_BLOCKING_ISSUE blocks from Claude's analysis output.
@@ -110,8 +152,156 @@ needs_security_label() {
   is_security_critical "${path_only}"
 }
 
+# Extract TITLE/SOURCE/LOCATION/DETAILS fields from a single issue block.
+# Writes results into the four nameref args (caller-declared local vars).
+_parse_issue_fields() {
+  local block="$1"
+  local -n _pif_title="$2"
+  local -n _pif_source="$3"
+  local -n _pif_location="$4"
+  local -n _pif_details="$5"
+
+  _pif_title=$(echo "${block}" | { grep "^TITLE:" || true; } | { head -1 || true; } | sed 's/^TITLE: //')
+  _pif_source=$(echo "${block}" | { grep "^SOURCE:" || true; } | { head -1 || true; } | sed 's/^SOURCE: //')
+  _pif_location=$(echo "${block}" | { grep "^LOCATION:" || true; } | { head -1 || true; } | sed 's/^LOCATION: //')
+  # DETAILS may span multiple lines -- grab everything after the DETAILS: line
+  _pif_details=$(echo "${block}" | { awk '/^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+}
+
+# Write an issue body to the local pending-issues fallback dir.
+# Prints the path of the file it wrote.
+_write_pending_issue_file() {
+  local title="$1"
+  local body="$2"
+  local pending_dir="$3"
+
+  mkdir -p "${pending_dir}"
+  local slug
+  slug=$(echo "${title}" | { tr '[:upper:]' '[:lower:]' || true; } | { tr -cs 'a-z0-9' '-' || true; } | { sed 's/-*$//' || true; } | cut -c1-40)
+  # Use PR_NUMBER in filename when available, otherwise use date-based prefix
+  local file_prefix="${PR_NUMBER:-$(date +%Y%m%d)}"
+  local fallback_file="${pending_dir}/${file_prefix}-${slug}.md"
+  local slug_index=1
+  while [[ -f "${fallback_file}" ]]; do
+    slug_index=$((slug_index + 1))
+    fallback_file="${pending_dir}/${file_prefix}-${slug}-${slug_index}.md"
+  done
+  printf "%s\n" "${body}" >"${fallback_file}"
+  echo "${fallback_file}"
+}
+
+# Escape a string for embedding in an AppleScript double-quoted literal.
+_escape_for_applescript() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# Create a private note in the Notes.app "Tech Debt" folder via osascript.
+# Returns 1 (without touching Notes.app) when osascript is unavailable,
+# e.g. on Linux, so the caller can fall back.
+create_apple_note_issue() {
+  local title="$1"
+  local body="$2"
+
+  command -v osascript >/dev/null 2>&1 || return 1
+
+  local escaped_title escaped_body body_html
+  escaped_title=$(_escape_for_applescript "${title}")
+  escaped_body=$(_escape_for_applescript "${body}")
+  body_html="${escaped_body//$'\n'/<br>}"
+
+  osascript <<EOF
+tell application "Notes"
+  if not (exists folder "Tech Debt") then
+    make new folder with properties {name:"Tech Debt"}
+  end if
+  tell folder "Tech Debt"
+    make new note with properties {body:"<h1>${escaped_title}</h1>${body_html}"}
+  end tell
+end tell
+EOF
+}
+
+# Parse a single issue block and file it as a private Apple Note.
+# Falls back to the pending_dir local file when osascript is unavailable
+# or fails — never falls back to a public gh issue create for corporate repos.
+_process_issue_block_apple_note() {
+  local block="$1"
+  local pending_dir="$2"
+
+  [[ -n "${block}" ]] || return 0
+
+  local title source location details
+  _parse_issue_fields "${block}" title source location details
+  [[ -n "${title}" ]] || return 0
+
+  local hashtags="#tech-debt #${REPO_NAME}"
+  if needs_security_label "${location}"; then
+    hashtags="${hashtags} #security"
+  fi
+
+  local body
+  body=$(build_issue_body "${title}" "${source}" "${location}" "${details}")
+  body="${body}"$'\n\n'"${hashtags}"
+
+  if create_apple_note_issue "${title}" "${body}"; then
+    log_success "Filed private tech-debt note: ${title}"
+    log_success "  -> Notes.app / Tech Debt folder (${hashtags})"
+  else
+    local fallback_file
+    fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}")
+    log_warn "Could not create Apple Note automatically (osascript unavailable or failed)."
+    log_warn "  Saved to: ${fallback_file}"
+    log_warn "  File this privately (e.g. paste into Notes.app 'Tech Debt' folder) — do not create a public GitHub issue for this."
+  fi
+}
+
+# Format a single issue block as a markdown bullet for the aggregated PR comment.
+_format_issue_bullet() {
+  local block="$1"
+  [[ -n "${block}" ]] || return 0
+
+  local title source location details
+  _parse_issue_fields "${block}" title source location details
+  [[ -n "${title}" ]] || return 0
+
+  printf -- '- **%s** (%s, `%s`): %s\n' "${title}" "${source}" "${location}" "${details}"
+}
+
+# Post all parsed issue blocks as a single aggregated PR comment.
+# Used for beacon-biosignals PRs that aren't Andrew's own work — visible to
+# that PR's participants only, not announced org-wide.
+post_nonblocking_as_pr_comment() {
+  local parsed="$1"
+
+  if [[ -z "${PR_NUMBER:-}" ]]; then
+    log_warn "Skipping PR-comment filing: no PR_NUMBER in context"
+    return 0
+  fi
+
+  local comment_body="### Non-blocking review notes"$'\n\n'"Filed as a comment, not a tracking issue, because this isn't Andrew's PR."$'\n'
+  local current_block="" bullet
+  while IFS= read -r line; do
+    if [[ "${line}" == "---ISSUE---" ]]; then
+      bullet=$(_format_issue_bullet "${current_block}")
+      [[ -n "${bullet}" ]] && comment_body+="${bullet}"$'\n'
+      current_block=""
+    else
+      current_block+="${line}"$'\n'
+    fi
+  done <<<"${parsed}"
+  bullet=$(_format_issue_bullet "${current_block}")
+  [[ -n "${bullet}" ]] && comment_body+="${bullet}"$'\n'
+
+  if command gh pr comment "${PR_NUMBER}" --repo "${REPO_OWNER}/${REPO_NAME}" --body "${comment_body}" >/dev/null 2>&1; then
+    log_success "Posted non-blocking review notes as a PR comment on #${PR_NUMBER}"
+  else
+    log_warn "Could not post non-blocking review notes as a PR comment on #${PR_NUMBER}"
+  fi
+}
+
 # Create GitHub issues from parsed NON_BLOCKING_ISSUE blocks.
 # Best-effort: failures write a fallback file and print a warning.
+# Filing mode depends on repo + authorship — see file header.
 # Args: analysis_text (full Claude output)
 create_nonblocking_issues() {
   local analysis_text="$1"
@@ -127,21 +317,36 @@ create_nonblocking_issues() {
   parsed=$(parse_nonblocking_issues "${analysis_text}")
   [[ -n "${parsed}" ]] || return 0
 
-  # Ensure labels exist (idempotent)
-  command gh label create "tech-debt" --color "#e4e669" --description "Technical debt to address" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
-  command gh label create "security" --color "#d93f0b" --description "Security-related concern" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
+  if is_corporate_repo && ! is_self_authored; then
+    post_nonblocking_as_pr_comment "${parsed}"
+    return 0
+  fi
+
+  if ! is_corporate_repo; then
+    # Ensure labels exist (idempotent) — only needed for the gh-issue path.
+    command gh label create "tech-debt" --color "#e4e669" --description "Technical debt to address" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
+    command gh label create "security" --color "#d93f0b" --description "Security-related concern" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
+  fi
 
   # Process each block (separated by ---ISSUE--- sentinel).
   local current_block=""
   while IFS= read -r line; do
     if [[ "${line}" == "---ISSUE---" ]]; then
-      _process_issue_block "${current_block}" "${pending_dir}"
+      if is_corporate_repo; then
+        _process_issue_block_apple_note "${current_block}" "${pending_dir}"
+      else
+        _process_issue_block "${current_block}" "${pending_dir}"
+      fi
       current_block=""
     else
       current_block+="${line}"$'\n'
     fi
   done <<<"${parsed}"
-  _process_issue_block "${current_block}" "${pending_dir}"
+  if is_corporate_repo; then
+    _process_issue_block_apple_note "${current_block}" "${pending_dir}"
+  else
+    _process_issue_block "${current_block}" "${pending_dir}"
+  fi
 }
 
 # Parse a single issue block and create the GH issue (or fallback file).
@@ -151,13 +356,8 @@ _process_issue_block() {
 
   [[ -n "${block}" ]] || return 0
 
-  # Extract fields from block
   local title source location details
-  title=$(echo "${block}" | { grep "^TITLE:" || true; } | { head -1 || true; } | sed 's/^TITLE: //')
-  source=$(echo "${block}" | { grep "^SOURCE:" || true; } | { head -1 || true; } | sed 's/^SOURCE: //')
-  location=$(echo "${block}" | { grep "^LOCATION:" || true; } | { head -1 || true; } | sed 's/^LOCATION: //')
-  # DETAILS may span multiple lines -- grab everything after the DETAILS: line
-  details=$(echo "${block}" | { awk '/^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+  _parse_issue_fields "${block}" title source location details
 
   [[ -n "${title}" ]] || return 0
 
@@ -190,18 +390,8 @@ _process_issue_block() {
     rm -f "${gh_stderr_file}"
     [[ -n "${gh_err}" ]] && log_warn "  gh error: ${gh_err}"
     # Fallback: write to file
-    mkdir -p "${pending_dir}"
-    local slug
-    slug=$(echo "${title}" | { tr '[:upper:]' '[:lower:]' || true; } | { tr -cs 'a-z0-9' '-' || true; } | { sed 's/-*$//' || true; } | cut -c1-40)
-    # Use PR_NUMBER in filename when available, otherwise use date-based prefix
-    local file_prefix="${PR_NUMBER:-$(date +%Y%m%d)}"
-    local fallback_file="${pending_dir}/${file_prefix}-${slug}.md"
-    local slug_index=1
-    while [[ -f "${fallback_file}" ]]; do
-      slug_index=$((slug_index + 1))
-      fallback_file="${pending_dir}/${file_prefix}-${slug}-${slug_index}.md"
-    done
-    printf "%s\n" "${body}" >"${fallback_file}"
+    local fallback_file
+    fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}")
     log_warn "Could not create GitHub issue automatically."
     log_warn "  Saved to: ${fallback_file}"
     log_warn "  Run: gh issue create --repo ${REPO_OWNER}/${REPO_NAME} --title \"${title}\" --body-file ${fallback_file} --label \"${labels}\""

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -190,9 +190,15 @@ _write_pending_issue_file() {
   echo "${fallback_file}"
 }
 
-# Escape a string for embedding in an AppleScript double-quoted literal.
+# Escape a string for embedding in an AppleScript double-quoted literal that
+# is itself interpolated into an unquoted bash heredoc (create_apple_note_issue).
+# Two escaping layers are needed, in order:
+#   1. AppleScript string syntax: backslash and double-quote.
+#   2. Bash's unquoted-heredoc expansion: backslash-escape $ and ` too, so
+#      review-agent-supplied content (TITLE/DETAILS) can't trigger command
+#      substitution when bash reads the heredoc body before osascript sees it.
 _escape_for_applescript() {
-  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+  printf '%s' "$1" | sed "s/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g; s/\\\$/\\\\\$/g; s/\`/\\\\\`/g"
 }
 
 # Create a private note in the Notes.app "Tech Debt" folder via osascript.
@@ -263,6 +269,10 @@ _format_issue_bullet() {
   local title source location details
   _parse_issue_fields "${block}" title source location details
   [[ -n "${title}" ]] || return 0
+
+  # DETAILS may span multiple lines; collapse to one line so it stays a
+  # single markdown bullet instead of trailing lines reading as loose text.
+  details="${details//$'\n'/ }"
 
   printf -- "- **%s** (%s, \`%s\`): %s\n" "${title}" "${source}" "${location}" "${details}"
 }

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -49,12 +49,16 @@ is_corporate_repo() {
   [[ "${REPO_OWNER:-}" == "beacon-biosignals" ]]
 }
 
-# Memoized authenticated gh login, cached for the lifetime of this shell
-# process. A failed lookup leaves the cache empty so a later successful call
-# isn't blocked by an earlier one — but a successful lookup is never
-# invalidated, so switching gh accounts mid-process (e.g. `gh auth switch`)
-# won't be picked up. Not a concern in a hook process, which only lives for
-# one commit/merge.
+# Intended to memoize the authenticated gh login for the lifetime of this
+# shell process — but only actually caches when called without a subshell
+# (i.e. bare `_cached_gh_login`, then read `_GH_LOGIN_CACHE` directly).
+# Calling it via command substitution, as `is_self_authored` does
+# (`my_login=$(_cached_gh_login)`), runs the assignment in a subshell that
+# never writes back to the parent's `_GH_LOGIN_CACHE`, so `gh api user` is
+# re-run on every call. Currently harmless: `is_self_authored` only calls
+# this once per `create_nonblocking_issues` invocation. If a second call
+# site is ever added, either restructure to avoid the subshell or accept the
+# repeated `gh api user` calls.
 _GH_LOGIN_CACHE=""
 _cached_gh_login() {
   if [[ -z "${_GH_LOGIN_CACHE:-}" ]]; then

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -555,3 +555,40 @@ END_ISSUE"
 
   grep -q "issue create" "${GH_CALLS_FILE}"
 }
+
+# --- _escape_for_applescript ---
+
+@test "_escape_for_applescript: escapes backslash, quote, dollar, and backtick" {
+  _load_fn _escape_for_applescript
+  result=$(_escape_for_applescript "a\\b\"c\$d\`e")
+  [[ "${result}" == "a\\\\b\\\"c\\\$d\\\`e" ]]
+}
+
+# --- create_apple_note_issue: heredoc injection safety ---
+# Regression test for a real finding from pre-push whole-codebase review:
+# the unquoted `osascript <<EOF` heredoc lets bash expand $()/backticks in
+# review-agent-supplied TITLE/DETAILS before osascript ever sees them.
+
+@test "create_apple_note_issue: does not execute shell commands embedded in title/body" {
+  _load_fn _escape_for_applescript
+  _load_fn create_apple_note_issue
+
+  local marker="${MOCK_DIR}/should-not-exist"
+  local osascript_stdin="${MOCK_DIR}/osascript_stdin"
+
+  cat >"${MOCK_DIR}/osascript" <<EOF
+#!/usr/bin/env bash
+cat > "${osascript_stdin}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/osascript"
+
+  local malicious_title="Title \$(touch ${marker}) end"
+  local malicious_body="body \`touch ${marker}\` text"
+
+  create_apple_note_issue "${malicious_title}" "${malicious_body}"
+
+  [[ ! -f "${marker}" ]]
+  grep -q "\\\\\\\$(touch" "${osascript_stdin}"
+  grep -q "\\\\\`touch" "${osascript_stdin}"
+}

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -181,6 +181,8 @@ DETAILS: Tests failing."
   _load_fn is_security_critical
   _load_fn needs_security_label
   _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
@@ -220,6 +222,8 @@ END_ISSUE"
   _load_fn is_security_critical
   _load_fn needs_security_label
   _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
@@ -296,6 +300,8 @@ All review comments appear resolved."
   _load_fn is_security_critical
   _load_fn needs_security_label
   _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
@@ -463,6 +469,67 @@ END_ISSUE"
   [[ ! -f "${GH_CALLS_FILE}" ]] || ! grep -q "issue create" "${GH_CALLS_FILE}"
 }
 
+@test "create_nonblocking_issues: corporate + self-authored (PR context) files an Apple Note via a real is_self_authored lookup" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _escape_for_applescript
+  _load_fn create_apple_note_issue
+  _load_fn _process_issue_block_apple_note
+  _load_fn create_nonblocking_issues
+
+  # Unlike the PR_NUMBER="" case above, this exercises the actual
+  # `gh pr view` / `gh api user` comparison inside is_self_authored.
+  PR_NUMBER="10"
+  PR_TITLE="My own PR"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  OSASCRIPT_CALLS_FILE="${MOCK_DIR}/osascript_calls"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"pr view"*) echo "andrew" ;;
+  *"api user"*) echo "andrew" ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  cat >"${MOCK_DIR}/osascript" <<'EOF'
+#!/usr/bin/env bash
+echo "called" >> "${OSASCRIPT_CALLS_FILE}"
+cat >/dev/null
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/osascript"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  [[ -f "${OSASCRIPT_CALLS_FILE}" ]]
+  grep -q "pr view" "${GH_CALLS_FILE}"
+  run ! grep -q "issue create" "${GH_CALLS_FILE}"
+  run ! grep -q "pr comment" "${GH_CALLS_FILE}"
+}
+
 @test "create_nonblocking_issues: corporate + not-self posts a PR comment, not a gh issue" {
   _load_fn is_security_critical
   _load_fn needs_security_label
@@ -472,6 +539,7 @@ END_ISSUE"
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
   _load_fn _format_issue_bullet
   _load_fn post_nonblocking_as_pr_comment
   _load_fn create_nonblocking_issues
@@ -506,7 +574,61 @@ END_ISSUE"
   create_nonblocking_issues "${analysis}"
 
   grep -q "pr comment" "${GH_CALLS_FILE}"
-  ! grep -q "issue create" "${GH_CALLS_FILE}"
+  run ! grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "create_nonblocking_issues: corporate + not-self falls back to a pending file when gh pr comment fails" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _format_issue_bullet
+  _load_fn post_nonblocking_as_pr_comment
+  _load_fn create_nonblocking_issues
+
+  PR_NUMBER="42"
+  PR_TITLE="Teammate PR"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending-issues"
+
+  # Mock gh: author lookup succeeds (not-self), but `pr comment` itself fails
+  # (e.g. auth expired, rate limit) — the finding must not be silently lost.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view"*) echo "teammate"; exit 0 ;;
+  *"api user"*) echo "andrew"; exit 0 ;;
+  *"pr comment"*) exit 1 ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  # Assert on content, not just the filename shape, so this doesn't depend
+  # on how _write_pending_issue_file composes its prefix/slug.
+  local found=0
+  for f in "${PENDING_ISSUES_DIR}"/*; do
+    [[ -f "${f}" ]] || continue
+    grep -q "Fix the thing" "${f}" && found=1
+  done
+  [[ "${found}" -eq 1 ]]
 }
 
 @test "create_nonblocking_issues: personal repo files a gh issue regardless of authorship" {

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
-# Tests for non-blocking issue parsing and creation in pre-merge-review.sh
+# Tests for non-blocking issue parsing and creation in lib-review-issues.sh
 #
 # Run: bats ~/.claude/tests/test_pre_merge_nonblocking.bats
 
 bats_require_minimum_version 1.5.0
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${HOME}/.claude/hooks/lib-review-issues.sh"
 
 # Suppress log output in tests (exported so eval'd functions can call them)
 log_info() { :; }
@@ -21,7 +21,7 @@ export -f log_error
 # static analysis sees their use, then reassigned per-test without re-exporting.
 export PR_NUMBER="" PR_TITLE="" REPO_OWNER="" REPO_NAME=""
 # Variables used by create_nonblocking_issues tests; same pattern.
-export GH_CALLS_FILE="" PENDING_ISSUES_DIR=""
+export GH_CALLS_FILE="" PENDING_ISSUES_DIR="" OSASCRIPT_CALLS_FILE=""
 
 setup() {
   MOCK_DIR="$(mktemp -d)"
@@ -180,8 +180,10 @@ DETAILS: Tests failing."
 @test "create_nonblocking_issues: calls gh issue create for each parsed issue" {
   _load_fn is_security_critical
   _load_fn needs_security_label
+  _load_fn is_corporate_repo
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
+  _load_fn _parse_issue_fields
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -217,8 +219,11 @@ END_ISSUE"
 @test "create_nonblocking_issues: writes fallback file when gh fails" {
   _load_fn is_security_critical
   _load_fn needs_security_label
+  _load_fn is_corporate_repo
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -290,8 +295,10 @@ All review comments appear resolved."
 @test "create_nonblocking_issues: applies security label for auth path" {
   _load_fn is_security_critical
   _load_fn needs_security_label
+  _load_fn is_corporate_repo
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
+  _load_fn _parse_issue_fields
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -321,4 +328,230 @@ END_ISSUE"
   create_nonblocking_issues "${analysis}"
 
   grep -q "security" "${GH_CALLS_FILE}"
+}
+
+# --- is_corporate_repo ---
+
+@test "is_corporate_repo: true for beacon-biosignals" {
+  _load_fn is_corporate_repo
+  REPO_OWNER="beacon-biosignals"
+  is_corporate_repo
+}
+
+@test "is_corporate_repo: false for a personal repo" {
+  _load_fn is_corporate_repo
+  REPO_OWNER="andrewrich"
+  run ! is_corporate_repo
+}
+
+# --- is_self_authored ---
+
+@test "is_self_authored: true when PR_NUMBER is unset (commit-level review)" {
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  PR_NUMBER=""
+  is_self_authored
+}
+
+@test "is_self_authored: true when PR author matches the authenticated gh login" {
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  PR_NUMBER="10"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view"*) echo "andrew" ;;
+  *"api user"*) echo "andrew" ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  is_self_authored
+}
+
+@test "is_self_authored: false when PR author differs from the authenticated gh login" {
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  PR_NUMBER="10"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view"*) echo "teammate" ;;
+  *"api user"*) echo "andrew" ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  run ! is_self_authored
+}
+
+@test "is_self_authored: false on gh lookup failure (fail toward PR-comment path)" {
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  PR_NUMBER="10"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  run ! is_self_authored
+}
+
+# --- create_nonblocking_issues: corporate-repo dispatch ---
+
+@test "create_nonblocking_issues: corporate + self-authored files an Apple Note, not a gh issue" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _escape_for_applescript
+  _load_fn create_apple_note_issue
+  _load_fn _process_issue_block_apple_note
+  _load_fn create_nonblocking_issues
+
+  PR_NUMBER=""
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  OSASCRIPT_CALLS_FILE="${MOCK_DIR}/osascript_calls"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  cat >"${MOCK_DIR}/osascript" <<'EOF'
+#!/usr/bin/env bash
+echo "called" >> "${OSASCRIPT_CALLS_FILE}"
+cat >/dev/null
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/osascript"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  [[ -f "${OSASCRIPT_CALLS_FILE}" ]]
+  [[ ! -f "${GH_CALLS_FILE}" ]] || ! grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "create_nonblocking_issues: corporate + not-self posts a PR comment, not a gh issue" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_bullet
+  _load_fn post_nonblocking_as_pr_comment
+  _load_fn create_nonblocking_issues
+
+  PR_NUMBER="42"
+  PR_TITLE="Teammate PR"
+  REPO_OWNER="beacon-biosignals"
+  REPO_NAME="repo"
+
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"pr view"*) echo "teammate" ;;
+  *"api user"*) echo "andrew" ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  grep -q "pr comment" "${GH_CALLS_FILE}"
+  ! grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "create_nonblocking_issues: personal repo files a gh issue regardless of authorship" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn create_nonblocking_issues
+  _load_fn _process_issue_block
+
+  PR_NUMBER="42"
+  PR_TITLE="Teammate PR"
+  REPO_OWNER="andrewrich"
+  REPO_NAME="repo"
+
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # Mock gh: pr author differs from authenticated login, but personal repos
+  # never consult authorship — gh issue create should still fire.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"pr view"*) echo "teammate" ;;
+  *"api user"*) echo "andrew" ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  grep -q "issue create" "${GH_CALLS_FILE}"
 }


### PR DESCRIPTION
## Summary

- `create_nonblocking_issues` in `hooks/lib-review-issues.sh` now dispatches on repo + PR authorship instead of always running `gh issue create`.
- Personal repos: unchanged — `gh issue create` as before.
- `beacon-biosignals`, Andrew's own work (or no `PR_NUMBER`, i.e. the commit-level hook): files privately as an Apple Note via `osascript`, tagged `#tech-debt #<repo>` (+ `#security` where applicable). Falls back to the existing local `pending_dir` file when `osascript` is unavailable or fails.
- `beacon-biosignals`, someone else's PR: posts one aggregated markdown comment via `gh pr comment` instead of creating an issue or note — visible to that PR's participants only.
- Extracted shared helpers (`_parse_issue_fields`, `_write_pending_issue_file`) so the new Apple-Note and PR-comment paths reuse the existing field-parsing and fallback-file logic rather than duplicating it.
- Fixed `tests/test_pre_merge_nonblocking.bats`: `SCRIPT` still pointed at `pre-merge-review.sh` even though these functions were extracted to `lib-review-issues.sh`, so every test touching a lib function failed with "command not found". Added corporate-mode dispatch tests (self-authored → Apple Note, not-self → PR comment, personal repo unaffected regardless of authorship) and `is_corporate_repo`/`is_self_authored` unit tests.

## Notes

- This session runs in a Linux container without `osascript`, `gh`, `bats`, or `shellcheck` installed, and apt/pip installs were blocked by the sandbox's egress policy. I verified the logic by sourcing the library directly and re-running the exact `sed`-extraction + `eval` pattern `_load_fn` uses in the bats file (including under `bash -u` to catch the unset-variable issue that surfaced and was fixed in `_cached_gh_login`), with `gh`/`osascript` mocked. `shellcheck -S info` and a real `bats` run should still be done in a normal dev environment before merging.
- The one manual check from the plan — confirming a real note lands in Notes.app's "Tech Debt" folder with correct hashtags — needs to happen on a Mac; flagging it as a follow-up rather than something done here.

## Test plan

- [ ] `shellcheck -S info hooks/lib-review-issues.sh` clean
- [ ] `bats tests/test_pre_merge_nonblocking.bats` all green
- [ ] Manual on macOS: source the lib with `REPO_OWNER=beacon-biosignals REPO_NAME=test-repo` and no `PR_NUMBER`, call `create_nonblocking_issues` with a sample block, confirm the note lands in Notes.app "Tech Debt" with the right hashtags, then delete it


---
_Generated by [Claude Code](https://claude.ai/code/session_019Ubbd9gdHMPgBozATjHE4L)_