### PR TITLE
Settings: disable commit/PR attribution, enable remote control, bump humanizer

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,11 @@
     "BASH_ENV": "~/.config/bash/functions.sh",
     "CLAUDE_CODE_SHELL": "/opt/homebrew/bin/bash"
   },
-  "includeCoAuthoredBy": true,
+  "includeCoAuthoredBy": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {},
   "model": "sonnet",
   "hooks": {
@@ -124,5 +128,6 @@
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "useAutoModeDuringPlan": false,
-  "gitAttribution": true
+  "gitAttribution": true,
+  "remoteControlAtStartup": true
 }


### PR DESCRIPTION
## Summary
- Disable `includeCoAuthoredBy` and set the newer `attribution.commit`/`attribution.pr` fields to empty (belt-and-suspenders — both are independent toggles that land on "off"). Pre-existing `gitAttribution: true` (session/branch metadata) is unrelated and untouched.
- Enable `remoteControlAtStartup` — activates the existing companion-app remote-control pairing feature automatically at CLI startup instead of requiring manual invocation each session. No new capability, personal machine-local settings file.
- Bump `skills/humanizer` submodule to v2.9.1, pulling in 4 upstream commits (no-fabrication rule + invocation modes, packaging/portability fixes). Prompt-only skill, no executable interface, so this is additive guidance rather than a breaking change.

## Test plan
- [x] `settings.json` validated as well-formed JSON
- [x] Both local code-reviewer + adversarial-reviewer hooks passed on both commits (first attempt on the settings commit was correctly blocked by the adversarial reviewer pending more context on `attribution`/`remoteControlAtStartup`; addressed with a fuller commit message rather than bypassing)