### PR TITLE
fix(review): tolerate markdown-emphasized VERDICT lines in run-review.sh

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -127,6 +127,26 @@ log_success() { echo -e "${GREEN}[review]${NC} $*" >&2; }
 log_warn() { echo -e "${YELLOW}[review]${NC} $*" >&2; }
 log_error() { echo -e "${RED}[review]${NC} $*" >&2; }
 
+# Normalize an agent's VERDICT line into a bare token, tolerant of markdown
+# emphasis (**PASS**, `PASS`, _PASS_), case, and spacing that would defeat a
+# literal `grep "VERDICT: PASS"`. Echoes PASS | FAIL | REVISE | "" (unparseable).
+# Preserves the original "PASS anywhere wins" precedence. Transient markers such
+# as "VERDICT: FAIL (timeout)" still normalize to FAIL; callers that must
+# distinguish those re-inspect the raw output separately.
+parse_verdict() {
+  local _norm
+  _norm=$(printf '%s\n' "$1" | tr -d '*`_')
+  if printf '%s\n' "${_norm}" | grep -qiE 'VERDICT:[[:space:]]*PASS'; then
+    echo "PASS"
+  elif printf '%s\n' "${_norm}" | grep -qiE 'VERDICT:[[:space:]]*FAIL'; then
+    echo "FAIL"
+  elif printf '%s\n' "${_norm}" | grep -qiE 'VERDICT:[[:space:]]*REVISE'; then
+    echo "REVISE"
+  else
+    echo ""
+  fi
+}
+
 # --- Shared issue library (for --mode=codebase non-blocking issues) ---
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib-review-issues.sh
@@ -234,7 +254,9 @@ invoke_agent() {
   echo "${agent_output}"
 
   # Cache verdict if PASS
-  if echo "${agent_output}" | grep -q "VERDICT: PASS"; then
+  local _cache_verdict
+  _cache_verdict=$(parse_verdict "${agent_output}")
+  if [[ "${_cache_verdict}" == "PASS" ]]; then
     echo "PASS" >"${cache_file}"
     date -u +%Y-%m-%dT%H:%M:%SZ >>"${cache_file}"
   fi
@@ -523,7 +545,8 @@ ${file_diff}
       continue
     fi
 
-    if echo "${_rout}" | grep -qE "VERDICT: (FAIL|Revise)"; then
+    _chunk_verdict=$(parse_verdict "${_rout}")
+    if [[ "${_chunk_verdict}" == "FAIL" || "${_chunk_verdict}" == "REVISE" ]]; then
       if echo "${_rout}" | grep -q "SEVERITY: BLOCKING"; then
         ((blocking_count += 1))
         overall_verdict="FAIL"
@@ -814,11 +837,12 @@ ${DIFF}
 
   { printf '=== FULL-DIFF REVIEW ===\n%s\n' "${FULL_DIFF_OUTPUT}"; } >>"${REVIEW_LOG}" || true
 
-  if echo "${FULL_DIFF_OUTPUT}" | grep -q "VERDICT: PASS"; then
+  FULL_DIFF_VERDICT=$(parse_verdict "${FULL_DIFF_OUTPUT}")
+  if [[ "${FULL_DIFF_VERDICT}" == "PASS" ]]; then
     printf 'full-diff: PASS\n' >>"${REVIEW_LOG}" || true
     log_success "Full-diff review passed"
     exit 0
-  elif echo "${FULL_DIFF_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
+  elif [[ "${FULL_DIFF_VERDICT}" == "FAIL" || "${FULL_DIFF_VERDICT}" == "REVISE" ]]; then
     if echo "${FULL_DIFF_OUTPUT}" | grep -q "SEVERITY: BLOCKING"; then
       printf 'full-diff: FAIL (blocking)\n' >>"${REVIEW_LOG}" || true
       log_error "Full-diff review found blocking cross-file issues"
@@ -946,7 +970,8 @@ END_ISSUE"
   echo "${CODEBASE_OUTPUT}" >&2
 
   # Parse verdict and handle results
-  if echo "${CODEBASE_OUTPUT}" | grep -q "VERDICT: PASS"; then
+  CODEBASE_VERDICT=$(parse_verdict "${CODEBASE_OUTPUT}")
+  if [[ "${CODEBASE_VERDICT}" == "PASS" ]]; then
     echo "PASS" >"${CODEBASE_CACHE}"
     printf 'codebase: PASS\n' >>"${REVIEW_LOG}" || true
     log_success "Codebase review passed"
@@ -958,7 +983,7 @@ END_ISSUE"
     fi
 
     exit 0
-  elif echo "${CODEBASE_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
+  elif [[ "${CODEBASE_VERDICT}" == "FAIL" || "${CODEBASE_VERDICT}" == "REVISE" ]]; then
     if echo "${CODEBASE_OUTPUT}" | grep -q "SEVERITY: BLOCKING"; then
       printf 'codebase: FAIL (blocking)\n' >>"${REVIEW_LOG}" || true
       log_error "Codebase review found blocking issues"
@@ -1098,10 +1123,11 @@ if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
 fi
 
 # Parse verdict from code-reviewer output
-if echo "${CODE_REVIEWER_OUTPUT}" | grep -q "VERDICT: PASS"; then
-  CODE_REVIEWER_VERDICT="PASS"
-elif echo "${CODE_REVIEWER_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
-  CODE_REVIEWER_VERDICT="FAIL"
+CODE_REVIEWER_VERDICT=$(parse_verdict "${CODE_REVIEWER_OUTPUT}")
+if [[ "${CODE_REVIEWER_VERDICT}" == "PASS" ]]; then
+  : # already PASS
+elif [[ "${CODE_REVIEWER_VERDICT}" == "FAIL" || "${CODE_REVIEWER_VERDICT}" == "REVISE" ]]; then
+  CODE_REVIEWER_VERDICT="FAIL" # normalize REVISE -> FAIL for downstream contract
 else
   log_error "Could not parse code-reviewer verdict"
   log_error "BLOCKING: Cannot verify review result"
@@ -1113,10 +1139,11 @@ fi
 
 # Parse verdict from adversarial-reviewer output (when available)
 if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
-  if echo "${ADVERSARIAL_OUTPUT}" | grep -q "VERDICT: PASS"; then
-    ADVERSARIAL_VERDICT="PASS"
-  elif echo "${ADVERSARIAL_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise)"; then
-    ADVERSARIAL_VERDICT="FAIL"
+  ADVERSARIAL_VERDICT=$(parse_verdict "${ADVERSARIAL_OUTPUT}")
+  if [[ "${ADVERSARIAL_VERDICT}" == "PASS" ]]; then
+    : # already PASS
+  elif [[ "${ADVERSARIAL_VERDICT}" == "FAIL" || "${ADVERSARIAL_VERDICT}" == "REVISE" ]]; then
+    ADVERSARIAL_VERDICT="FAIL" # normalize REVISE -> FAIL for downstream contract
   else
     log_error "Could not parse adversarial-reviewer verdict"
     log_error "BLOCKING: Cannot verify adversarial review result"

--- a/tests/test_parse_verdict.bats
+++ b/tests/test_parse_verdict.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for the parse_verdict() helper in hooks/run-review.sh.
+#
+# Why this exists: the review gate previously matched verdicts with a literal
+# `grep "VERDICT: PASS"`, which failed to recognize markdown-emphasized verdicts
+# such as `VERDICT: **PASS**` that the (non-deterministic) reviewer models emit.
+# An unparseable PASS fell through to the else branch and blocked the commit
+# (fail-closed on a genuine pass). parse_verdict() normalizes emphasis, case,
+# and spacing while preserving the original "PASS anywhere wins" precedence and
+# the fail-closed "" result for genuinely unparseable output.
+#
+# Run: bats tests/test_parse_verdict.bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../hooks/run-review.sh"
+  # Source only the parse_verdict function (the script as a whole executes a
+  # full review when run). The function body's closing brace is at column 0.
+  eval "$(sed -n '/^parse_verdict() {/,/^}/p' "${SCRIPT}")"
+}
+
+@test "plain PASS" {
+  run parse_verdict "VERDICT: PASS"
+  [ "${output}" = "PASS" ]
+}
+
+@test "bold PASS (the original regression)" {
+  run parse_verdict "VERDICT: **PASS**"
+  [ "${output}" = "PASS" ]
+}
+
+@test "bold PASS with no space after colon" {
+  run parse_verdict "VERDICT:**PASS**"
+  [ "${output}" = "PASS" ]
+}
+
+@test "backtick-wrapped PASS" {
+  run parse_verdict 'VERDICT: `PASS`'
+  [ "${output}" = "PASS" ]
+}
+
+@test "underscore-italic PASS" {
+  run parse_verdict "VERDICT: _PASS_"
+  [ "${output}" = "PASS" ]
+}
+
+@test "lowercase verdict/pass" {
+  run parse_verdict "verdict: pass"
+  [ "${output}" = "PASS" ]
+}
+
+@test "plain FAIL" {
+  run parse_verdict "VERDICT: FAIL"
+  [ "${output}" = "FAIL" ]
+}
+
+@test "bold FAIL (chunked path was fail-open here)" {
+  run parse_verdict "VERDICT: **FAIL**"
+  [ "${output}" = "FAIL" ]
+}
+
+@test "transient FAIL with paren still normalizes to FAIL" {
+  run parse_verdict "VERDICT: FAIL (timeout)"
+  [ "${output}" = "FAIL" ]
+}
+
+@test "Revise maps to REVISE token" {
+  run parse_verdict "VERDICT: Revise"
+  [ "${output}" = "REVISE" ]
+}
+
+@test "verdict embedded in a multi-line review body" {
+  run parse_verdict $'# Code Review\n\nSome analysis here.\n\nVERDICT: **PASS**\n\nNo blocking issues.'
+  [ "${output}" = "PASS" ]
+}
+
+@test "PASS wins when it appears (precedence preserved)" {
+  # Pathological output mentioning FAIL in prose but verdict is PASS.
+  run parse_verdict $'I nearly wrote VERDICT: FAIL but reconsidered.\nVERDICT: PASS'
+  [ "${output}" = "PASS" ]
+}
+
+@test "unparseable output yields empty string (fail-closed)" {
+  run parse_verdict "This review has no verdict line at all."
+  [ "${output}" = "" ]
+}
+
+@test "empty input yields empty string" {
+  run parse_verdict ""
+  [ "${output}" = "" ]
+}


### PR DESCRIPTION
## Problem

The review gate matched verdicts with a literal `grep "VERDICT: PASS"`. When a (non-deterministic) reviewer model emits its verdict with markdown emphasis — e.g. `VERDICT: **PASS**` — that literal substring is absent, so the output matched neither the PASS nor the FAIL/Revise pattern and fell through to the `else` branch, which `exit 1`s with "Could not verify review result". Result: a commit that **actually passed review** was blocked.

The chunked path had the inverse, more dangerous failure: a bolded `VERDICT: **FAIL**` matched nothing and was silently treated as a pass (fail-**open**).

This was hit in practice on a normal commit — the adversarial reviewer returned `VERDICT: **PASS**` and the commit was blocked until a retry happened to emit an unbolded verdict.

## Fix

Add a `parse_verdict()` helper that:
- strips markdown emphasis (`**`, `` ` ``, `_`),
- matches case-insensitively with flexible spacing,
- preserves the original **"PASS anywhere wins"** precedence,
- returns `""` (fail-closed) for genuinely unparseable output.

All six verdict-parse sites now route through it:
- `invoke_agent` PASS-cache
- chunked per-file FAIL detection *(fixes the fail-open bolded-FAIL case)*
- full-diff, codebase, code-reviewer, and adversarial-reviewer verdicts

Transient markers (`VERDICT: FAIL (timeout|agent error)`) still normalize to `FAIL` and are distinguished by the callers' separate raw-output checks, which are left untouched.

## Testing

- New `tests/test_parse_verdict.bats` — 14 cases: plain/bold/backtick/italic/lowercase PASS, bold FAIL, transient FAIL, Revise, multi-line bodies, PASS precedence, and fail-closed empty cases. All pass.
- Existing `tests/test_run_review_message_file.bats` still passes (7/7).
- `shellcheck -S info` clean for the changed code (two pre-existing info findings at lines 77/153 are outside this change).
- **Self-test:** the commit-msg and pre-push reviews that gated this branch ran the *modified* `run-review.sh` and parsed their own reviewers' verdicts correctly.

## Not included / notes

- Pre-existing failure in `tests/test_run_review_identity.bats` ("log header fields appear before VERDICT output") reproduces on the unmodified script and is unrelated to this change (tracked separately).
- Known minor edge (non-blocking, not fixed): a space *before* the colon (`VERDICT :PASS`) still wouldn't match; models don't emit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
