### PR TITLE
fix(review): preflight stdin drain; chore: tui + superpowers v6.2.0

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -189,7 +189,10 @@ fi
 # CLIs in the test suite exit with configured codes; those must not trip
 # this preflight. See hooks/tests/run-review-test.sh.
 _preflight_rc=0
-timeout 5 "${CLAUDE_CLI}" --version >/dev/null 2>&1 || _preflight_rc=$?
+# Redirect stdin from /dev/null: the review diff arrives on this script's stdin
+# (DIFF=$(cat) below), and a CLI/wrapper that reads stdin on --version would
+# otherwise drain it, leaving DIFF empty ("No staged changes to review").
+timeout 5 "${CLAUDE_CLI}" --version </dev/null >/dev/null 2>&1 || _preflight_rc=$?
 if [[ ${_preflight_rc} -eq 124 ]]; then
   log_error "Claude CLI did not respond to --version within 5s: ${CLAUDE_CLI}"
   log_error "CLI may be hung. Diagnose:"

--- a/settings.json
+++ b/settings.json
@@ -122,6 +122,7 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "medium",
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",
   "verbose": true,

--- a/tests/test_run_review_identity.bats
+++ b/tests/test_run_review_identity.bats
@@ -26,6 +26,9 @@ setup() {
   export MOCK_DIR
   cat >"${MOCK_DIR}/claude" <<'EOF'
 #!/usr/bin/env bash
+# Short-circuit the --version preflight WITHOUT consuming stdin, so the piped
+# review diff survives for the actual review invocation.
+[[ "$1" == "--version" ]] && { echo "mock 0.0.0"; exit 0; }
 cat > /dev/null
 echo "VERDICT: PASS"
 echo "No blocking issues found."


### PR DESCRIPTION
Two independent, low-risk changes (one commit each).

## 1. fix(review): preflight no longer consumes the review diff from stdin

`run-review.sh` reads the diff to review from its own stdin (`DIFF=$(cat)`). The `claude --version` readiness preflight ran with that stdin still attached, so a CLI/wrapper that reads stdin on `--version` would drain the piped diff — leaving `DIFF` empty and short-circuiting to "No staged changes to review" with no review performed.

Fix: redirect the preflight's stdin from `/dev/null`. Also short-circuit `--version` in the identity test's mock claude (matching the `message-file` test's mock) so both doubles model a real CLI that doesn't read stdin on `--version`.

This resolves the pre-existing failure in `tests/test_run_review_identity.bats` — "log header fields appear before VERDICT output" (#4) — which was surfaced while reviewing the verdict-parser PR (#197). Identity suite now passes **6/6**; `shellcheck -S info` clean for the changed code.

## 2. chore(config): add tui:fullscreen and bump superpowers to v6.2.0

- `settings.json`: add `"tui": "fullscreen"` (written by the CLI Settings panel; keeps the tracked file in sync with the deployed config).
- `superpowers-marketplace`: `d038aff → e4b6482` (superpowers v6.2.0), a one-commit **forward** bump (verified not a downgrade). `skills/humanizer` was already at v2.9.1 on `main`, so it's not included.

Config/pointer changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
