### PR TITLE
fix(guards): reject pr-0, catch newline-chained gh api merge, skip issue filing when Issues disabled

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -391,6 +391,35 @@ create_nonblocking_issues() {
   fi
 }
 
+# Does REPO_OWNER/REPO_NAME have GitHub Issues enabled? Cached for the
+# lifetime of this shell process — a single review run can produce many
+# NON_BLOCKING_ISSUE findings, and re-probing the API for every one would be
+# wasteful. When Issues are disabled, `gh issue create` fails loudly on
+# every single finding (30 stderr warnings observed in one push in the
+# field); checking this once lets callers skip straight to the
+# fallback-file path instead of attempting (and failing) the API call.
+# See #180.
+#
+# Fails OPEN: only an explicit "false" from a successful API lookup is
+# treated as disabled. Any other outcome (network error, auth failure,
+# empty response, rate limit) is treated as enabled, so a transient lookup
+# failure never silently suppresses issue filing — it just falls through
+# to the existing `gh issue create` failure/fallback handling, same as
+# before this change.
+_HAS_ISSUES_CACHE=""
+_repo_has_issues_enabled() {
+  if [[ -z "${_HAS_ISSUES_CACHE:-}" ]]; then
+    local result
+    result=$(command gh api "repos/${REPO_OWNER}/${REPO_NAME}" --jq '.has_issues' 2>/dev/null) || true
+    if [[ "${result}" == "false" ]]; then
+      _HAS_ISSUES_CACHE="false"
+    else
+      _HAS_ISSUES_CACHE="true"
+    fi
+  fi
+  [[ "${_HAS_ISSUES_CACHE}" == "true" ]]
+}
+
 # Parse a single issue block and create the GH issue (or fallback file).
 _process_issue_block() {
   local block="$1"
@@ -413,23 +442,33 @@ _process_issue_block() {
   local body
   body=$(build_issue_body "${title}" "${source}" "${location}" "${details}")
 
-  # Attempt to create GitHub issue.
+  # Attempt to create GitHub issue — but only if the repo actually has
+  # Issues enabled (#180). Repos with Issues disabled make `gh issue create`
+  # fail loudly on every finding; skip straight to the fallback-file path
+  # instead so a review with many findings doesn't spam stderr.
   # Use a temp file for stderr so gh warnings/upgrade notices don't contaminate
   # issue_url (same pattern as _fetch_pr_json).
-  local issue_url gh_stderr_file
+  local issue_url gh_stderr_file gh_err="" created=false
   gh_stderr_file=$(mktemp)
-  if issue_url=$(command gh issue create \
-    --repo "${REPO_OWNER}/${REPO_NAME}" \
-    --title "${title}" \
-    --body "${body}" \
-    --label "${labels}" 2>"${gh_stderr_file}"); then
-    rm -f "${gh_stderr_file}"
+  if _repo_has_issues_enabled; then
+    if issue_url=$(command gh issue create \
+      --repo "${REPO_OWNER}/${REPO_NAME}" \
+      --title "${title}" \
+      --body "${body}" \
+      --label "${labels}" 2>"${gh_stderr_file}"); then
+      created=true
+    else
+      gh_err=$(cat "${gh_stderr_file}")
+    fi
+  else
+    gh_err="GitHub Issues are disabled for ${REPO_OWNER}/${REPO_NAME}"
+  fi
+  rm -f "${gh_stderr_file}"
+
+  if [[ "${created}" == true ]]; then
     log_success "Created tracking issue: ${title}"
     log_success "  -> ${issue_url}"
   else
-    local gh_err
-    gh_err=$(cat "${gh_stderr_file}")
-    rm -f "${gh_stderr_file}"
     [[ -n "${gh_err}" ]] && log_warn "  gh error: ${gh_err}"
     # Fallback: write to file
     log_warn "Could not create GitHub issue automatically."

--- a/hooks/merge-lock.sh
+++ b/hooks/merge-lock.sh
@@ -128,7 +128,7 @@ case "${1:-help}" in
         echo "Error: empty PR number in list" >&2
         exit 1
       fi
-      if [[ ! "${_entry}" =~ ^[0-9]+$ ]]; then
+      if [[ ! "${_entry}" =~ ^[0-9]+$ ]] || [[ "${_entry}" -le 0 ]]; then
         echo "Error: invalid PR number: ${_entry}" >&2
         exit 1
       fi

--- a/scripts/hook-block-api-merge.sh
+++ b/scripts/hook-block-api-merge.sh
@@ -38,8 +38,18 @@ cmd=$(printf '%s\n' "${input}" | jq -r '.tool_input.command // empty')
 #      `gh ...` substitution does (and must still be blocked).
 # Net: `git commit -m "... gh api ..."` is exempted, but
 # `git diff && gh api .../merge` is NOT (the gh after && is a real call).
+# `git diff` followed by a literal-newline-chained `gh api .../merge` (no
+# leading shell operator on its own line) is ALSO not exempted (#137): an
+# unindented line 2+ that starts with `gh` is a real statement, not quoted
+# argument text. Indented lines (e.g. inside a heredoc body) don't match,
+# so the exemption for quoted commit-message text is preserved. Line 1 is
+# excluded from this check (via `tail -n +2`) because for this exemption
+# block the primary verb is `git`, not `gh`, so line 1 never legitimately
+# starts with `gh` anyway — but excluding it keeps the check symmetric
+# with the gh-pr|issue-create exemption below.
 if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*(commit|log|show|diff)([[:space:]]|$)' \
-  && ! printf '%s\n' "${cmd}" | grep -qE '[;&|(`][[:space:]]*gh[[:space:]]+'; then
+  && ! printf '%s\n' "${cmd}" | grep -qE '[;&|(`][[:space:]]*gh[[:space:]]+' \
+  && ! printf '%s\n' "${cmd}" | tail -n +2 | grep -qE '^gh[[:space:]]+'; then
   exit 0
 fi
 
@@ -55,8 +65,14 @@ fi
 #      so only chained follow-on gh calls match the negation regex.
 # Net: `gh pr create --body "... gh api graphql --input ..."` is exempted,
 # but `gh pr create --body "..." && gh api .../merge` is NOT.
+# `gh pr create ...` followed by a literal-newline-chained `gh api .../merge`
+# is ALSO not exempted (#137). Line 1 (the primary `gh pr|issue ...`
+# invocation itself, which legitimately starts with `gh`) is excluded from
+# the unindented-line check via `tail -n +2`, so only genuine follow-on
+# lines starting with `gh` at column 0 trip the negation.
 if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*(pr|issue)[[:space:]]+(create|edit|comment)([[:space:]]|$)' \
-  && ! printf '%s\n' "${cmd}" | grep -qE '[;&|(`][[:space:]]*gh[[:space:]]+'; then
+  && ! printf '%s\n' "${cmd}" | grep -qE '[;&|(`][[:space:]]*gh[[:space:]]+' \
+  && ! printf '%s\n' "${cmd}" | tail -n +2 | grep -qE '^gh[[:space:]]+'; then
   exit 0
 fi
 

--- a/scripts/tests/test-hook-block-api-merge.sh
+++ b/scripts/tests/test-hook-block-api-merge.sh
@@ -179,6 +179,32 @@ check "Not exempt: gh pr create && gh api merge chain" 2 "${inp}"
 inp="$(make_input 'gh pr create --body "$(gh api repos/o/r/pulls/1/merge)"')"
 check "Not exempt: gh pr create body with \$(gh api merge)" 2 "${inp}"
 
+# Regression (#137): a literal-newline-chained gh api .../merge call must
+# still be blocked even though it has no preceding shell-operator character
+# on its own line. Previously the negation regex only fired on
+# `[;&|(`]` immediately before gh, so `git diff\ngh api .../merge` slipped
+# through the git-verb exemption (line 1 matches the primary verb check,
+# line 2's unindented `gh api ...` has no operator prefix).
+multiline_cmd="$(printf 'git diff\ngh api repos/o/r/pulls/1/merge --method PUT\n')"
+inp="$(make_input "${multiline_cmd}")"
+check "Not exempt (#137): newline-chained git diff / gh api merge" 2 "${inp}"
+
+multiline_cmd2="$(printf 'git log --oneline -5\ngh api repos/o/r/pulls/1/merge\n')"
+inp="$(make_input "${multiline_cmd2}")"
+check "Not exempt (#137): newline-chained git log / gh api merge" 2 "${inp}"
+
+# Same bypass shape for the gh pr|issue create exemption block.
+multiline_cmd3="$(printf 'gh pr create --title t --body b\ngh api repos/o/r/pulls/1/merge\n')"
+inp="$(make_input "${multiline_cmd3}")"
+check "Not exempt (#137): newline-chained gh pr create / gh api merge" 2 "${inp}"
+
+# Indented heredoc-body line must remain exempt (no false positive introduced).
+# Reuses the pre-existing ${cmd_multiline} built above (line ~159, the
+# "git commit with indented gh api in heredoc body" case) — not a new or
+# undefined variable.
+inp="$(make_input "${cmd_multiline}")"
+check "Still exempt (#137 regression guard): indented heredoc gh api example" 0 "${inp}"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]

--- a/tests/test_merge_lock_batch_auth.bats
+++ b/tests/test_merge_lock_batch_auth.bats
@@ -77,3 +77,17 @@ lock_file() {
   [ ! -f "$(lock_file 100)" ]
   [ ! -f "$(lock_file 553)" ]
 }
+
+@test "pr-0 is rejected as an invalid PR number" {
+  run bash "${SCRIPT}" auth 0 "ok"
+  [ "${status}" -ne 0 ]
+  [ ! -f "$(lock_file 0)" ]
+}
+
+@test "pr-0 in a batch rejects the entire batch" {
+  run bash "${SCRIPT}" auth "100,0,553" "ok"
+  [ "${status}" -ne 0 ]
+  [ ! -f "$(lock_file 100)" ]
+  [ ! -f "$(lock_file 0)" ]
+  [ ! -f "$(lock_file 553)" ]
+}

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -186,6 +186,7 @@ DETAILS: Tests failing."
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
+  _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -228,6 +229,7 @@ END_ISSUE"
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
   _load_fn _write_pending_issue_file
+  _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -269,6 +271,7 @@ END_ISSUE"
   _load_fn needs_security_label
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
+  _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -305,6 +308,7 @@ All review comments appear resolved."
   _load_fn parse_nonblocking_issues
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
+  _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -641,6 +645,7 @@ END_ISSUE"
   _load_fn build_issue_body
   _load_fn _parse_issue_fields
   _load_fn _write_pending_issue_file
+  _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
 
@@ -713,4 +718,143 @@ EOF
   [[ ! -f "${marker}" ]]
   grep -q "\\\\\\\$(touch" "${osascript_stdin}"
   grep -q "\\\\\`touch" "${osascript_stdin}"
+}
+
+# --- _repo_has_issues_enabled / _process_issue_block gh-issue-create guard ---
+# Regression tests for #180: a repo with GitHub Issues disabled made every
+# non-blocking finding attempt (and fail) `gh issue create`, producing up
+# to 30 noisy stderr warnings per push. The guard checks
+# `gh api repos/{owner}/{repo} --jq '.has_issues'` once per run (cached)
+# and skips straight to the fallback-file path when it's explicitly false.
+
+@test "_process_issue_block: skips gh issue create when GitHub Issues are disabled" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _repo_has_issues_enabled
+  _load_fn create_nonblocking_issues
+  _load_fn _process_issue_block
+
+  PR_NUMBER="55"
+  PR_TITLE="Test PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending-issues"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # Mock gh: the has_issues probe explicitly reports issues disabled;
+  # `gh issue create` would fail loudly if it were ever invoked.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"api repos/"*) echo "false"; exit 0 ;;
+  *"issue create"*) echo "gh error: repository has disabled issues" >&2; exit 1 ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Something to fix later.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  # NOTE: intentionally not `! grep -q ...` (or `run ! grep -q ...`) as a
+  # standalone statement. `create_nonblocking_issues` calls functions that
+  # use `if` internally, which — due to a well-known bash quirk — leaves
+  # `errexit` semantics unreliable for the rest of this test body: an
+  # intermediate failing statement no longer aborts execution the way a
+  # fresh shell would. Bats only reliably observes the exit status of the
+  # test body's FINAL statement, so both conditions are folded into one.
+  local issue_create_called=0
+  grep -q "issue create" "${GH_CALLS_FILE}" && issue_create_called=1
+
+  local found=0
+  for f in "${PENDING_ISSUES_DIR}/55-"*; do [[ -f "${f}" ]] && found=1; done
+
+  [[ "${issue_create_called}" -eq 0 && "${found}" -eq 1 ]]
+}
+
+@test "_process_issue_block: caches the has_issues check across multiple findings in one run" {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _repo_has_issues_enabled
+  _load_fn create_nonblocking_issues
+  _load_fn _process_issue_block
+
+  PR_NUMBER="55"
+  PR_TITLE="Test PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending-issues"
+  API_CALLS_FILE="${MOCK_DIR}/api_calls"
+  export API_CALLS_FILE
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"api repos/"*) echo x >> "${API_CALLS_FILE}"; echo "false"; exit 0 ;;
+esac
+exit 1
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: First finding
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: First.
+END_ISSUE
+
+NON_BLOCKING_ISSUE:
+TITLE: Second finding
+SOURCE: code-reviewer
+LOCATION: general
+DETAILS: Second.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local api_call_count
+  api_call_count=$(wc -l <"${API_CALLS_FILE}")
+  [[ "${api_call_count}" -eq 1 ]]
+}
+
+@test "_repo_has_issues_enabled: fails open (treats as enabled) when the probe errors or is ambiguous" {
+  _load_fn _repo_has_issues_enabled
+
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+
+  # Mock gh: api call fails outright (network error, auth issue, etc.) —
+  # must NOT be mistaken for an explicit "issues disabled" response.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  _repo_has_issues_enabled
 }


### PR DESCRIPTION
## Summary
- #114: `merge-lock` now rejects `pr-0` as an invalid PR number (numeric guard requires `-gt 0`)
- #137: extends the blocked-pattern regex in `hook-block-api-merge.sh` to catch a newline-chained `gh api ... merge` call, not just one following a shell metacharacter
- #180: `_process_issue_block` skips `gh issue create` (and goes straight to the fallback-file path) when the target repo has GitHub Issues disabled, avoiding a burst of stderr warnings per finding; probe result is cached per-run via `_repo_has_issues_enabled`

PR 2 of the [open-issues triage plan](docs/plans/2026-07-28-open-issues-triage.md).

## Test plan
- [x] Full bats suite (143 tests): passes modulo 7 pre-existing failures on `main` (unrelated CHANGES_REQUESTED/authorization messaging tests)
- [x] `scripts/tests/test-hook-block-api-merge.sh`: 55/55 passing (new #137 regression tests included)
- [x] New `_repo_has_issues_enabled`/`_process_issue_block` tests verified to fail against pre-fix code and pass against the fix
- [x] `shellcheck -S info` clean (no new findings beyond pre-existing SC2016 info notices already present in the file)
- [x] Local pre-push review (code + codebase) passed with two non-blocking warnings, both reviewed and addressed as false-positive / accepted-low-risk (see PR discussion)

https://claude.ai/code/session_014Wk62aZhGqHtREYwJkSeRa