### PR TITLE
fix(ci): serialize claude-review-haiku after claude-review to avoid comment race (#162)

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -1,11 +1,11 @@
 name: Claude Blocking Review
 
-# Two parallel jobs run the SAME reusable review workflow, same PR, same
-# BLOCK/PASS policy — the only difference is `model`. `claude-review` uses
-# the reusable workflow's default (Sonnet); `claude-review-haiku` overrides
-# to Haiku. Both are CONFIGURED identically and intended to gate equally,
-# but as of this writing only `claude-review / run-review` is wired into
-# main's branch protection as a required status check (verify with `gh api
+# Two jobs run the SAME reusable review workflow, same PR, same BLOCK/PASS
+# policy — the only difference is `model`. `claude-review` uses the reusable
+# workflow's default (Sonnet); `claude-review-haiku` overrides to Haiku.
+# Both are CONFIGURED identically and intended to gate equally, but as of
+# this writing only `claude-review / run-review` is wired into main's
+# branch protection as a required status check (verify with `gh api
 # repos/<owner>/<repo>/branches/main/protection --jq
 # '.required_status_checks.contexts'`). `claude-review-haiku` runs the
 # identical policy and can still fail its own job/exit 1 on VERDICT: BLOCK,
@@ -13,6 +13,15 @@ name: Claude Blocking Review
 # live A/B comparison of Haiku's verdicts against Sonnet's, run in
 # production but not (yet) enforced. Add it to required_status_checks once
 # the comparison shows its verdicts are trustworthy enough to gate on.
+#
+# `claude-review-haiku` declares `needs: claude-review` with `if: always()`
+# so the two jobs run sequentially instead of racing to post/update the
+# same PR comment marker (see issue #162). `if: always()` is required
+# alongside `needs:` because GitHub Actions otherwise skips a dependent job
+# when its `needs:` job fails — and `claude-review` "fails" (exits 1) on
+# VERDICT: BLOCK, which is a normal, expected outcome, not an error that
+# should cancel the Haiku A/B run. Serializing changes only *when*
+# claude-review-haiku starts, not *whether* it runs.
 
 on:
   pull_request:
@@ -33,6 +42,8 @@ jobs:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   claude-review-haiku:
+    needs: claude-review
+    if: always()
     uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
     with:
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
PR 5 of the open-issues triage plan (`docs/plans/2026-07-28-open-issues-triage.md`, Priority 5) — fixes **#162**: `claude-review` and `claude-review-haiku` both call the same external reusable workflow and can race when posting/updating the shared PR comment marker.

- Added `needs: claude-review` to `claude-review-haiku` to serialize the two jobs.
- Also added `if: always()`, which is required alongside `needs:` — GitHub Actions otherwise implicitly skips a dependent job when its `needs:` job fails, and `claude-review` intentionally exits 1 on `VERDICT: BLOCK` (a normal outcome, not an error). Without `if: always()`, the fix would have silently disabled the Haiku A/B comparison on every blocked PR — a behavior regression beyond what the issue asked for.
- Lightly reflowed the pre-existing header comment (added in PR #210, issue #165) since it described the jobs as "parallel," which is no longer accurate, and added a new paragraph documenting the `needs`/`if: always()` rationale so a future maintainer doesn't strip it out without understanding why it's there.

## Test plan
- [x] No test suite covers `.github/workflows/` files in this repo
- [x] YAML validated with `yamllint` (clean) and Ruby's YAML parser
- [x] Spec-compliance review: ✅ compliant — confirmed `needs:` alone would cause skip-on-failure (verified GHA semantics), confirmed `if: always()` correctly counteracts it while preserving serialization
- [x] Code-quality review: Approve, no issues
- [x] Local pre-push review (full-diff + codebase modes): PASS

https://claude.ai/code/session_014Wk62aZhGqHtREYwJkSeRa