### PR TITLE
fix(review): correct CODE_REVIEWER_AGENT default to match installed agent

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -121,7 +121,7 @@ fi
 # ambiguous bare names, so every commit's code-reviewer pass silently errored
 # (non-blocking, but useless). adversarial-reviewer stays a bare name since it is
 # still unique (lives only in the local code-critic marketplace, see CUSTOM_AGENTS.md).
-CODE_REVIEWER_AGENT=$(git config --get review.codeReviewerAgent 2>/dev/null || echo "comprehensive-review:comprehensive-review-code-reviewer")
+CODE_REVIEWER_AGENT=$(git config --get review.codeReviewerAgent 2>/dev/null || echo "comprehensive-review:code-reviewer")
 
 # --- Colors ---
 RED='\033[0;31m'

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -1133,11 +1133,61 @@ assert_contains \
   "${invocation_args}"
 
 # =========================================================
+# TEST 22: CODE_REVIEWER_AGENT default resolves to the actually-installed
+# fully-qualified agent name (issue #209)
+#
+# The hardcoded default (used when review.codeReviewerAgent git config is
+# unset) previously doubled the plugin name — "comprehensive-review:
+# comprehensive-review-code-reviewer" — which does not match any installed
+# agent, so run-review.sh's code-reviewer pass silently errored on every
+# commit. Assert the --agent value that actually reaches the CLI invocation
+# matches the real installed agent ID: "comprehensive-review:code-reviewer".
+# =========================================================
+echo ""
+echo "=== Test 22: CODE_REVIEWER_AGENT default matches installed agent ID (issue #209) ==="
+
+setup_repo
+stage_small_change
+
+MOCK22_DIR="${TMPDIR_TEST}/mock22"
+mkdir -p "${MOCK22_DIR}"
+MOCK22_ARGS_FILE="${MOCK22_DIR}/invocation-args.txt"
+rm -f "${MOCK22_ARGS_FILE}"
+cat >"${MOCK22_DIR}/claude" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "--version" ]]; then
+  echo "mock-claude 0.0.0-test"
+  exit 0
+fi
+printf '%s\n' "\$*" >>"${MOCK22_ARGS_FILE}"
+echo "VERDICT: PASS"
+echo ""
+echo "No blocking issues found."
+exit 0
+EOF
+chmod +x "${MOCK22_DIR}/claude"
+
+TEST22_LOG="${TMPDIR_TEST}/test22-review.log"
+rm -f "${TEST22_LOG}"
+
+cd "${REPO_DIR}"
+git config --unset review.codeReviewerAgent 2>/dev/null || true
+REVIEW_LOG="${TEST22_LOG}" CLAUDE_CLI="${MOCK22_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || true
+cd - >/dev/null
+
+invocation_args22="$(cat "${MOCK22_ARGS_FILE}" 2>/dev/null || echo "")"
+
+assert_contains \
+  "default CODE_REVIEWER_AGENT resolves to installed agent ID (issue #209)" \
+  "--agent comprehensive-review:code-reviewer " \
+  "${invocation_args22}"
+
+# =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 39 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 40 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Fixes #209: `CODE_REVIEWER_AGENT` defaulted to `comprehensive-review:comprehensive-review-code-reviewer`, a doubled/wrong plugin-agent name that doesn't match any installed agent. Corrected to `comprehensive-review:code-reviewer`, verified against the actually-installed `comprehensive-review` plugin's `agents/code-reviewer.md`.
- This bug caused every chunked-mode code-reviewer invocation to silently error, and combined with #200's fail-closed fix, could block commits where 0/N files were successfully reviewed.
- Adds Test 22 (`hooks/tests/run-review-test.sh`), following the Test 21 pattern: a mock CLI captures invocation argv and asserts the default `--agent` value resolves to the real installed agent ID.

## Test plan
- [x] Full test suite run on this branch and independently verified against `main`: identical pre-existing chunked-mode failures on both, zero regressions, Test 22 passes cleanly (net +1 passing assertion)
- [x] `shellcheck -S info` clean on both changed files (only pre-existing info-level notices, unchanged from `main`)
- [x] Spec-compliance review (independent subagent): PASS — cross-checked new default against live installed plugin files, confirmed Test 22 exercises the real `invoke_agent` code path, confirmed no other tracked-file occurrences of the wrong name remain
- [x] Code-quality review (independent subagent): APPROVE — no blocking or important issues
- [x] Live confirmation: this commit's own pre-commit hook invoked code-reviewer via the newly-fixed default and passed (`.git/last-review-result.log`)

Closes #209

https://claude.ai/code/session_014Wk62aZhGqHtREYwJkSeRa