### PR TITLE
fix(hardening): scope merge-lock batch-auth locals, guard empty-array iteration in install.sh

### DIFF
--- a/hooks/merge-lock.sh
+++ b/hooks/merge-lock.sh
@@ -105,6 +105,39 @@ list_locks() {
   fi
 }
 
+authorize_batch() {
+  local pr_arg="$1"
+  local reason="$2"
+
+  # Parse comma-separated list into validated PR numbers.
+  local _pr_raw
+  IFS=',' read -r -a _pr_raw <<<"${pr_arg}"
+  local _pr_list=()
+  local _entry
+  for _entry in "${_pr_raw[@]}"; do
+    # Trim leading/trailing whitespace.
+    _entry="${_entry#"${_entry%%[![:space:]]*}"}"
+    _entry="${_entry%"${_entry##*[![:space:]]}"}"
+    if [[ -z "${_entry}" ]]; then
+      echo "Error: empty PR number in list" >&2
+      exit 1
+    fi
+    if [[ ! "${_entry}" =~ ^[0-9]+$ ]] || [[ "${_entry}" -le 0 ]]; then
+      echo "Error: invalid PR number: ${_entry}" >&2
+      exit 1
+    fi
+    _pr_list+=("${_entry}")
+  done
+
+  # Shared timestamp so all TTLs align.
+  local _ts
+  _ts=$(date +%s)
+  local _pr
+  for _pr in "${_pr_list[@]}"; do
+    create_merge_lock "${_pr}" "${reason}" "${_ts}"
+  done
+}
+
 case "${1:-help}" in
   authorize | auth)
     if [[ -z "${2:-}" ]]; then
@@ -117,29 +150,7 @@ case "${1:-help}" in
       exit 1
     fi
 
-    # Parse comma-separated list into validated PR numbers.
-    IFS=',' read -r -a _pr_raw <<<"$2"
-    _pr_list=()
-    for _entry in "${_pr_raw[@]}"; do
-      # Trim leading/trailing whitespace.
-      _entry="${_entry#"${_entry%%[![:space:]]*}"}"
-      _entry="${_entry%"${_entry##*[![:space:]]}"}"
-      if [[ -z "${_entry}" ]]; then
-        echo "Error: empty PR number in list" >&2
-        exit 1
-      fi
-      if [[ ! "${_entry}" =~ ^[0-9]+$ ]] || [[ "${_entry}" -le 0 ]]; then
-        echo "Error: invalid PR number: ${_entry}" >&2
-        exit 1
-      fi
-      _pr_list+=("${_entry}")
-    done
-
-    # Shared timestamp so all TTLs align.
-    _ts=$(date +%s)
-    for _pr in "${_pr_list[@]}"; do
-      create_merge_lock "${_pr}" "$3" "${_ts}"
-    done
+    authorize_batch "$2" "$3"
     ;;
   check)
     if [[ -z "${2:-}" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ _is_excluded() {
 
 _is_submodule_path() {
   local file="$1"
-  for sm_path in "${_SUBMODULE_ROOTS[@]}"; do
+  for sm_path in "${_SUBMODULE_ROOTS[@]+"${_SUBMODULE_ROOTS[@]}"}"; do
     case "${file}" in
       "${sm_path}"/*) return 0 ;;
       *) ;;


### PR DESCRIPTION
## Summary
- Fixes #91: `install.sh`'s `_is_submodule_path()` iterated `"${_SUBMODULE_ROOTS[@]}"` without an empty-array guard, which errors ("unbound variable") under `set -u` on Bash <4.4 (macOS system bash is 3.2). Applies the same guarded-expansion idiom already used in `scripts/update-tools.sh`.
- Fixes #115: `hooks/merge-lock.sh`'s batch-auth logic (`authorize|auth` case block) declared its working variables without `local`, risking caller-environment pollution if the script is ever sourced. Extracts the logic verbatim into a new `authorize_batch()` function with all variables properly scoped.

Both were previously deferred as low-value/hypothetical; revisited and fixed at the user's request.

## Test plan
- [x] Full bats suite run before/after: 18 pre-existing failures identical on both (unrelated `local -n` incompatibility with macOS system bash 3.2 in other test files), zero regressions
- [x] `tests/test_merge_lock_batch_auth.bats` (dedicated harness for #115's code path): 10/10 pass, unchanged
- [x] `shellcheck -S info` clean on both changed files
- [x] Spec-compliance review (independent subagent): PASS — confirmed guard pattern matches existing repo convention, confirmed `exit 1` inside the new function still terminates the whole script (no subshell), confirmed all original validation logic preserved unchanged
- [x] Code-quality review (independent subagent): APPROVE — minimal, idiomatic, no globals leaked
- [x] Pre-push full-diff + codebase review: both PASS

Closes #91
Closes #115

https://claude.ai/code/session_014Wk62aZhGqHtREYwJkSeRa