### PR TITLE
fix(review): restore correct CODE_REVIEWER_AGENT default

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -119,9 +119,13 @@ fi
 # to override). The bare name "code-reviewer" broke once a second installed plugin
 # also shipped an agent literally named "code-reviewer" — Claude CLI refuses
 # ambiguous bare names, so every commit's code-reviewer pass silently errored
-# (non-blocking, but useless). adversarial-reviewer stays a bare name since it is
-# still unique (lives only in the local code-critic marketplace, see CUSTOM_AGENTS.md).
-CODE_REVIEWER_AGENT=$(git config --get review.codeReviewerAgent 2>/dev/null || echo "comprehensive-review:code-reviewer")
+# (non-blocking, but useless). The installed agent ID doubles the plugin name —
+# comprehensive-review:comprehensive-review-code-reviewer — per the
+# comprehensive-review plugin's agents/code-reviewer.md frontmatter; verify with
+# `claude --agent bogus -p` (its "Available agents" error lists the real IDs).
+# adversarial-reviewer stays a bare name since it is still unique (lives only in
+# the local code-critic marketplace, see CUSTOM_AGENTS.md).
+CODE_REVIEWER_AGENT=$(git config --get review.codeReviewerAgent 2>/dev/null || echo "comprehensive-review:comprehensive-review-code-reviewer")
 
 # --- Colors ---
 RED='\033[0;31m'

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -1134,14 +1134,16 @@ assert_contains \
 
 # =========================================================
 # TEST 22: CODE_REVIEWER_AGENT default resolves to the actually-installed
-# fully-qualified agent name (issue #209)
+# fully-qualified agent name (issue #209, and its regression in #212)
 #
-# The hardcoded default (used when review.codeReviewerAgent git config is
-# unset) previously doubled the plugin name — "comprehensive-review:
-# comprehensive-review-code-reviewer" — which does not match any installed
-# agent, so run-review.sh's code-reviewer pass silently errored on every
-# commit. Assert the --agent value that actually reaches the CLI invocation
-# matches the real installed agent ID: "comprehensive-review:code-reviewer".
+# The real installed agent ID doubles the plugin name — "comprehensive-review:
+# comprehensive-review-code-reviewer" — per the comprehensive-review plugin's
+# agents/code-reviewer.md frontmatter. #212 mistakenly "fixed" the default to
+# the bare-looking "comprehensive-review:code-reviewer", which does not match
+# any installed agent, so run-review.sh's code-reviewer pass silently errored
+# on every commit again. Assert the --agent value that actually reaches the
+# CLI invocation matches the real installed agent ID (verify with
+# `claude --agent bogus -p`, which lists installed agents in its error).
 # =========================================================
 echo ""
 echo "=== Test 22: CODE_REVIEWER_AGENT default matches installed agent ID (issue #209) ==="
@@ -1179,7 +1181,7 @@ invocation_args22="$(cat "${MOCK22_ARGS_FILE}" 2>/dev/null || echo "")"
 
 assert_contains \
   "default CODE_REVIEWER_AGENT resolves to installed agent ID (issue #209)" \
-  "--agent comprehensive-review:code-reviewer " \
+  "--agent comprehensive-review:comprehensive-review-code-reviewer " \
   "${invocation_args22}"
 
 # =========================================================

--- a/scripts/known-runtime.txt
+++ b/scripts/known-runtime.txt
@@ -48,3 +48,7 @@ settings.local.json
 policy-limits.json
 daemon.log
 .last-update-result.json
+downloads
+image-cache
+remote-settings.json
+.claude.json.backup


### PR DESCRIPTION
## Summary
- Reverts the `CODE_REVIEWER_AGENT` default in `hooks/run-review.sh` introduced by #209/#212, which changed it to `comprehensive-review:code-reviewer` — a name that doesn't match any installed agent.
- The real installed agent ID is `comprehensive-review:comprehensive-review-code-reviewer`: the `comprehensive-review@claude-code-workflows` plugin's agent frontmatter names itself `comprehensive-review-code-reviewer` as of v1.3.1, and Claude Code always prefixes `pluginName:` onto that field.
- #212 was authored against a stale 1.2.1 install of that plugin (pre-rename bare `code-reviewer` name) on a second machine, which had drifted from this machine's 1.3.1 install. That drift is why the "fix" broke local code-reviewer passes here — every commit since has silently failed with "agent error: 1".
- Both machines are now pinned to matching plugin versions (`comprehensive-review` 1.3.1, `superpowers` 6.2.0 — the latter also incidentally shipped its own stale `code-reviewer` agent that collided with this one).
- `hooks/tests/run-review-test.sh` Test 22 updated to assert the real installed ID instead of the pre-rename one.

## Test plan
- [x] Reproduced the failure directly against the installed CLI (`--agent comprehensive-review:code-reviewer` → not found; correct name confirmed via `claude --agent bogus -p`'s "Available agents" listing)
- [x] Verified the corrected agent name invokes successfully against the real `comprehensive-review` plugin (exit 0)
- [x] Full local test suite: 40/40 assertions passing (`bash hooks/tests/run-review-test.sh`)
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) passed clean on this change
- [x] Pre-push full-diff + codebase review passed clean

[skip-claude-review: session-limited CLAUDE_CODE_OAUTH_TOKEN (personal smartwatermelon account) caused execution failure, not a content block; Analyze + CodeQL pass, and this diff passed local code-reviewer + adversarial-reviewer twice]
