### PR TITLE
chore: remove humanizer submodule, superseded by personify

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "plugins/marketplaces/superpowers-marketplace"]
 	path = plugins/marketplaces/superpowers-marketplace
 	url = git@github.com:obra/superpowers-marketplace.git
-[submodule "skills/humanizer"]
-	path = skills/humanizer
-	url = https://github.com/blader/humanizer

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ command (via `_claude_update()`). It:
 ### Submodules
 
 - **plugins/marketplaces/superpowers-marketplace** — obra/superpowers-marketplace
-- **skills/humanizer** — blader/humanizer
 
 ## Installed Plugins
 
@@ -114,8 +113,6 @@ from the tracked default.
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
 │       └── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
-├── skills/
-│   └── humanizer                         # Git submodule → blader/humanizer
 ├── settings.json                         # enabledPlugins and hook configuration
 │                                          # (notable keys documented in docs/INFRASTRUCTURE.md § Settings Rationale)
 ├── plugins/installed_plugins.json        # Runtime state (not tracked)
@@ -152,4 +149,3 @@ See `CLAUDE.md` for protocol documentation.
 - Main config: [CLAUDE.md](./CLAUDE.md)
 - Superpowers marketplace: <https://github.com/obra/superpowers-marketplace>
 - claude-code-workflows: <https://github.com/wshobson/agents>
-- Humanizer skill: <https://github.com/blader/humanizer>


### PR DESCRIPTION
## Summary
- Removes the `skills/humanizer` git submodule (tracked directly against `blader/humanizer`), which is superseded by Andrew's own `smartwatermelon/personify` skill.
- Deinit submodule, drop `.gitmodules` entry, remove stale README references (submodule list, directory tree, reference links).

## Test plan
- [x] `git status` clean, `git ls-files -s | grep humanizer` empty
- [x] Local pre-commit and pre-push reviews (code-reviewer, adversarial-reviewer, full-diff, codebase review) all PASS
- [x] Non-blocking finding auto-filed as #221 for a historical design doc (docs/plans/2026-04-03-symlink-reconciliation-design.md) - left untouched intentionally, it documents a past migration and isn't live config

Claude-Session: https://claude.ai/code/session_015tBbkwMgags2VubfNpYRRQ