### PR TITLE
chore: register personify marketplace and plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ command (via `_claude_update()`). It:
 
 ## Installed Plugins
 
-Plugins are sourced from four marketplaces. Enabled state is tracked in `settings.json`.
+Plugins are sourced from five marketplaces. Enabled state is tracked in `settings.json`.
 
 ### From superpowers-marketplace
 
@@ -83,6 +83,10 @@ Plugins are sourced from four marketplaces. Enabled state is tracked in `setting
 ### From claude-code-plugins
 
 - **frontend-design** ✓ — production-grade frontend UI generation
+
+### From personify
+
+- **personify** ✓ — strips AI-writing tells from prose before it's sent, published, or shipped; replaces the retired blader/humanizer submodule
 
 ## Per-Machine Notes
 

--- a/settings.json
+++ b/settings.json
@@ -86,7 +86,8 @@
     "react-native-3d@smartwatermelon-marketplace": false,
     "frontend-design@claude-code-plugins": false,
     "ci-workflows@smartwatermelon-marketplace": true,
-    "apple-notes@apple-notes-mcp": false
+    "apple-notes@apple-notes-mcp": false,
+    "personify@personify": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
@@ -111,6 +112,12 @@
       "source": {
         "source": "git",
         "url": "https://github.com/smartwatermelon/smartwatermelon-marketplace.git"
+      }
+    },
+    "personify": {
+      "source": {
+        "source": "github",
+        "repo": "smartwatermelon/personify"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Registers the `smartwatermelon/personify` marketplace and installs `personify@personify` (enabled) in settings.json, via `claude plugin marketplace add` / `claude plugin install`.
- Replaces the retired `blader/humanizer` submodule (removed in #222).
- Updates README's Installed Plugins section (four marketplaces to five, new "From personify" subsection).

## Test plan
- [x] Local pre-commit and pre-push reviews (code-reviewer, adversarial-reviewer, full-diff, codebase review) all PASS
- [x] Non-blocking finding auto-filed as #223 — pre-existing `claude-code-plugins` marketplace-key mismatch, unrelated to this diff

Claude-Session: https://claude.ai/code/session_015tBbkwMgags2VubfNpYRRQ