### PR TITLE
docs: add personify to README plugin-tree diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ from the tracked default.
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
 │       ├── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
-│       └── personify                     # Plugin marketplace → smartwatermelon/personify
+│       └── personify                     # Plugin marketplace (runtime-installed, not a submodule)
 ├── settings.json                         # enabledPlugins and hook configuration
 │                                          # (notable keys documented in docs/INFRASTRUCTURE.md § Settings Rationale)
 ├── plugins/installed_plugins.json        # Runtime state (not tracked)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ from the tracked default.
 │       ├── claude-code-plugins           # Plugin marketplace
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
-│       └── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
+│       ├── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
+│       └── personify                     # Plugin marketplace → smartwatermelon/personify
 ├── settings.json                         # enabledPlugins and hook configuration
 │                                          # (notable keys documented in docs/INFRASTRUCTURE.md § Settings Rationale)
 ├── plugins/installed_plugins.json        # Runtime state (not tracked)


### PR DESCRIPTION
## Summary
- #222/#224 removed the humanizer submodule and registered personify, but the ASCII plugin-tree diagram in README.md was never updated to match — it still showed the old (pre-personify) marketplace layout.
- Clarifies in the diagram comment that personify is runtime-installed via `extraKnownMarketplaces` (settings.json), not a git submodule like superpowers-marketplace.

## Test plan
- [x] Diagram now lists `personify` alongside the other four marketplaces, consistent with the prose section above it and with `settings.json`'s `extraKnownMarketplaces`/`enabledPlugins`
- [x] Confirmed `personify` exists on disk under the deployed `~/.claude/plugins/marketplaces/` (matches the diagram's stated `~/.claude/` scope)
- [x] Pre-commit/pre-push local reviews passed (docs-only, markdownlint path)