### PR TITLE
feat: register pr-review marketplace and plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ command (via `_claude_update()`). It:
 
 ## Installed Plugins
 
-Plugins are sourced from five marketplaces. Enabled state is tracked in `settings.json`.
+Plugins are sourced from six marketplaces. Enabled state is tracked in `settings.json`.
 
 ### From superpowers-marketplace
 
@@ -87,6 +87,10 @@ Plugins are sourced from five marketplaces. Enabled state is tracked in `setting
 ### From personify
 
 - **personify** ✓ — strips AI-writing tells from prose before it's sent, published, or shipped; replaces the retired blader/humanizer submodule
+
+### From pr-review
+
+- **pr-review** ✓ — deep-dive review of a teammate's GitHub pull request, staged as a pending review for explicit approval before anything is posted
 
 ## Per-Machine Notes
 
@@ -117,7 +121,8 @@ from the tracked default.
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
 │       ├── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
-│       └── personify                     # Plugin marketplace (runtime-installed, not a submodule)
+│       ├── personify                     # Plugin marketplace (runtime-installed, not a submodule)
+│       └── pr-review                     # Plugin marketplace (runtime-installed, not a submodule)
 ├── settings.json                         # enabledPlugins and hook configuration
 │                                          # (notable keys documented in docs/INFRASTRUCTURE.md § Settings Rationale)
 ├── plugins/installed_plugins.json        # Runtime state (not tracked)
@@ -154,3 +159,5 @@ See `CLAUDE.md` for protocol documentation.
 - Main config: [CLAUDE.md](./CLAUDE.md)
 - Superpowers marketplace: <https://github.com/obra/superpowers-marketplace>
 - claude-code-workflows: <https://github.com/wshobson/agents>
+- Personify skill: <https://github.com/smartwatermelon/personify>
+- pr-review skill: <https://github.com/smartwatermelon/pr-review>

--- a/settings.json
+++ b/settings.json
@@ -87,7 +87,8 @@
     "frontend-design@claude-code-plugins": false,
     "ci-workflows@smartwatermelon-marketplace": true,
     "apple-notes@apple-notes-mcp": false,
-    "personify@personify": true
+    "personify@personify": true,
+    "pr-review@pr-review": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
@@ -118,6 +119,12 @@
       "source": {
         "source": "github",
         "repo": "smartwatermelon/personify"
+      }
+    },
+    "pr-review": {
+      "source": {
+        "source": "github",
+        "repo": "smartwatermelon/pr-review"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Moves the `pr-review` skill out of the standalone `~/.claude/skills/pr-review` copy into its own shareable, installable repo (`smartwatermelon/pr-review`, mirroring `personify`'s structure), installed via `claude plugin marketplace add` + `claude plugin install`.
- Registers `pr-review@pr-review` in `settings.json`'s `enabledPlugins`/`extraKnownMarketplaces`, and documents it in README.md (marketplace count, plugin section, tree diagram, reference link).
- Backfills the "Personify skill" reference link in README.md's Reference section, which #222/#224 never added.

## Test plan
- [x] `claude plugin list` shows `personify@personify` and `pr-review@pr-review` both installed
- [x] `settings.json` valid JSON; `pr-review` entry mirrors `personify`'s structure exactly
- [x] Standalone `~/.claude/skills/pr-review` removed — superseded by the plugin install
- [x] Local pre-commit/pre-push reviews (code-reviewer, adversarial-reviewer, full-diff, codebase review) passed