### PR TITLE
chore: point superpowers-marketplace submodule at smartwatermelon fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "plugins/marketplaces/superpowers-marketplace"]
 	path = plugins/marketplaces/superpowers-marketplace
-	url = git@github.com:obra/superpowers-marketplace.git
+	url = git@github.com:smartwatermelon/superpowers-marketplace.git

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ command (via `_claude_update()`). It:
 
 ### Submodules
 
-- **plugins/marketplaces/superpowers-marketplace** — obra/superpowers-marketplace
+- **plugins/marketplaces/superpowers-marketplace** — smartwatermelon/superpowers-marketplace (fork of obra/superpowers-marketplace, forced SessionStart hook removed)
 
 ## Installed Plugins
 
@@ -116,7 +116,7 @@ from the tracked default.
 │       ├── claude-code-plugins           # Plugin marketplace
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
-│       └── superpowers-marketplace       # Git submodule → obra/superpowers-marketplace
+│       └── superpowers-marketplace       # Git submodule → smartwatermelon/superpowers-marketplace
 ├── settings.json                         # enabledPlugins and hook configuration
 │                                          # (notable keys documented in docs/INFRASTRUCTURE.md § Settings Rationale)
 ├── plugins/installed_plugins.json        # Runtime state (not tracked)
@@ -151,5 +151,5 @@ See `CLAUDE.md` for protocol documentation.
 ## Reference
 
 - Main config: [CLAUDE.md](./CLAUDE.md)
-- Superpowers marketplace: <https://github.com/obra/superpowers-marketplace>
+- Superpowers marketplace: <https://github.com/smartwatermelon/superpowers-marketplace> (fork of obra/superpowers-marketplace)
 - claude-code-workflows: <https://github.com/wshobson/agents>

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -51,6 +51,7 @@ fi
 _info "Updating submodules..."
 
 if git -C "${REPO_DIR}" submodule status --quiet 2>/dev/null; then
+  git -C "${REPO_DIR}" submodule sync
   git -C "${REPO_DIR}" submodule update --remote --merge
   _ok "Submodules updated"
 else


### PR DESCRIPTION
## Summary
- Repoints the `plugins/marketplaces/superpowers-marketplace` submodule at `smartwatermelon/superpowers-marketplace`, a fork with the superpowers plugin's forced SessionStart hook removed (that hook injected the full `using-superpowers` SKILL.md body into every session's context, on top of the normal skill listing).
- Updates README references and fixes a related bug in `scripts/update-tools.sh` (missing `git submodule sync` before `update --remote --merge`, which would've silently kept fetching from the old URL) — both caught by pre-push review.

## Related PRs (part of the same chain, not yet merged)
- smartwatermelon/superpowers#1 — removes the hook in the plugin repo itself
- smartwatermelon/superpowers-marketplace#1 — points the marketplace's superpowers entry at that fork

https://claude.ai/code/session_215f11d6-fd80-488b-9ae8-2e0fc0f51f9d