### PR TITLE
chore: repoint claude-code-workflows marketplace at trimmed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ See `CLAUDE.md` for protocol documentation.
 
 - Main config: [CLAUDE.md](./CLAUDE.md)
 - Superpowers marketplace: <https://github.com/obra/superpowers-marketplace>
-- claude-code-workflows: <https://github.com/wshobson/agents>
+- claude-code-workflows: <https://github.com/smartwatermelon/claude-code-workflows-agents> (fork of wshobson/agents)

--- a/settings.json
+++ b/settings.json
@@ -105,7 +105,7 @@
     "claude-code-workflows": {
       "source": {
         "source": "git",
-        "url": "https://github.com/wshobson/agents.git"
+        "url": "https://github.com/smartwatermelon/claude-code-workflows-agents.git"
       }
     },
     "smartwatermelon-marketplace": {


### PR DESCRIPTION
## Summary
- Points `extraKnownMarketplaces.claude-code-workflows.source.url` at `smartwatermelon/claude-code-workflows-agents` (a private fork of `wshobson/agents` with comprehensive-review's agent descriptions trimmed — PR smartwatermelon/claude-code-workflows-agents#3) instead of upstream.
- Updates README's claude-code-workflows reference to match.
- Filed #230 for a follow-up doc mention in docs/CUSTOM_AGENTS.md (non-blocking, caught by pre-push review).

## Related
- smartwatermelon/claude-code-workflows-agents#3 (the trim itself, must merge for the fork's `main` to have the fix — this PR's fork URL has no `ref` pin, so it tracks `main`)

https://claude.ai/code/session_215f11d6-fd80-488b-9ae8-2e0fc0f51f9d