### PR TITLE
docs: replace blanket private-repo rule with org-based visibility defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Before declaring work done, output the full Completion Verification template fro
 
 - **Never `git add .`** — Add files individually
 - **Never `--no-verify`** — Blocked by hooks; human must commit manually in emergencies
-- **Always PRIVATE repos** — Never create public repos without explicit permission
+- **Repo visibility defaults by org, not a blanket rule**: `smartwatermelon` hierarchy defaults to **public** unless there's an actual privacy or security reason to keep something private (GitHub imposes real collaborator/Actions-minute limits on private repos that make defaulting private counterproductive there). `nightowlstudiollc` is commercial software and defaults to **private**, except website/client work, which is public by standard practice. If genuinely unsure which default applies to a specific repo (e.g., it touches credentials or unreleased commercial work), ask rather than assume either default.
 - Prefer `git mv` / `git rm` over bare `mv` / `rm`
 - Never commit code that doesn't compile
 - Remote origin uses SSH (`git@github.com:...`) — HTTPS will fail with auth errors


### PR DESCRIPTION
## Summary
Replaces the "Always PRIVATE repos" Git Rule with org-based defaults: `smartwatermelon` defaults public (no privacy/security reason to default private, and GitHub's private-repo limits make it counterproductive there), `nightowlstudiollc` defaults private as commercial software (except client/website work, public by standard practice).

Prompted by three smartwatermelon forks getting created private today under the old blanket rule, with no actual privacy/security need — reverted to public and corrected the rule that caused it.

https://claude.ai/code/session_215f11d6-fd80-488b-9ae8-2e0fc0f51f9d