### PR TITLE
chore: sync superpowers-marketplace submodule and plugin registration

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -67,7 +67,6 @@
     "command": "~/.claude/scripts/status-line.sh"
   },
   "enabledPlugins": {
-    "superpowers@superpowers-marketplace": true,
     "comprehensive-review@claude-code-workflows": true,
     "git-pr-workflows@claude-code-workflows": false,
     "tdd-workflows@claude-code-workflows": false,
@@ -88,7 +87,8 @@
     "ci-workflows@smartwatermelon-marketplace": true,
     "apple-notes@apple-notes-mcp": false,
     "personify@personify": true,
-    "pr-review@pr-review": true
+    "pr-review@pr-review": true,
+    "superpowers@superpowers-marketplace": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {


### PR DESCRIPTION
## Summary
- Advances the `superpowers-marketplace` submodule to the already-merged stale-pin fix commit (superpowers-marketplace#2)
- Reorders the `enabledPlugins` key that `claude plugin uninstall`/`install` touched while force-refreshing a stale plugin cache

## Context
Verifying the prior session's context-window-harmonization work found the installed plugin cache was still serving the pre-fork `obra` content (SessionStart hook intact) despite the fork/PR chain being merged — `claude plugin marketplace update` didn't refresh it since the version string was unchanged, so I uninstalled/reinstalled the plugin to force a fresh pull. This PR captures the resulting repo-state changes.

## Test plan
- [x] Confirmed `hooks/hooks.json` no longer present in the refreshed plugin cache
- [x] Confirmed `gitCommitSha` in `installed_plugins.json` matches the fork's merged commit
- [x] Confirmed `using-superpowers` skill still present for manual/lazy invocation