### PR TITLE
perf: make merge-gate model inheritance explicit, disable global always-thinking

### DIFF
--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -787,6 +787,21 @@ ${INLINE_COMMENTS_FORMATTED}
 ${PR_DIFF}
 \`\`\`"
 
+# --- Model selection ---
+# Intentionally inherits the calling session's active model by default (no
+# --model flag) rather than pinning to Haiku like run-review.sh's commit-time
+# review. This gate runs once per merge attempt (low frequency) and is the last
+# line of defense before code lands, so it should get the strongest model the
+# human is already paying for in that session, not the cheapest one. Override
+# via git config review.mergeModel if a fixed model is ever preferred over
+# inheritance (e.g. to decouple this gate from whatever the interactive
+# session happens to be running).
+MERGE_REVIEW_MODEL=$(git config --get review.mergeModel 2>/dev/null || echo "")
+MERGE_MODEL_ARGS=()
+if [[ -n "${MERGE_REVIEW_MODEL}" ]]; then
+  MERGE_MODEL_ARGS=(--model "${MERGE_REVIEW_MODEL}")
+fi
+
 # --- Call Claude CLI ---
 PROMPT_SIZE=${#FULL_PROMPT}
 PROMPT_LINES=$(echo "${FULL_PROMPT}" | wc -l)
@@ -796,7 +811,7 @@ log_info "Analyzing review comments..."
 # Unset CLAUDECODE so this can be invoked from within a Claude Code session.
 # Claude CLI 2.1.50+ refuses to start if CLAUDECODE is set (anti-nesting check).
 # Safe here because --no-session-persistence + piped input = non-interactive child process.
-ANALYSIS_TEXT=$(echo "${FULL_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" -p --tools "" --no-session-persistence 2>&1) || {
+ANALYSIS_TEXT=$(echo "${FULL_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" -p "${MERGE_MODEL_ARGS[@]}" --tools "" --no-session-persistence 2>&1) || {
   EXIT_CODE=$?
   if [[ ${EXIT_CODE} -eq 124 ]]; then
     log_error "Analysis timed out after ${TIMEOUT_SECONDS}s"

--- a/settings.json
+++ b/settings.json
@@ -135,7 +135,7 @@
       "Use the /copy command to copy Claude's output with no hard line-breaks or injected characters"
     ]
   },
-  "alwaysThinkingEnabled": true,
+  "alwaysThinkingEnabled": false,
   "effortLevel": "medium",
   "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,


### PR DESCRIPTION
## Summary
- `pre-merge-review.sh` now documents its intentional lack of a `--model` flag (inherits
  the calling session's model — appropriate for a low-frequency, high-stakes gate) and
  exposes a `review.mergeModel` git-config override, so a future edit doesn't accidentally
  pin it to the same cheap model used for per-commit review.
- `alwaysThinkingEnabled` flipped from a global `true` to `false` — extended thinking is
  now opt-in per repo (via local `.claude/settings.json`) rather than forced on every
  session including docs-only repos with nothing to debug.

Two of three findings from evaluating this environment against Anthropic's
[model/effort](https://claude.com/blog/claude-model-and-effort-level-in-claude-code) and
[steering](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more)
guidance. The other three (larger) findings are tracked as issues:
smartwatermelon/claude-config#235, smartwatermelon/github-workflows#89,
smartwatermelon/claude-wrapper#57 — see smartwatermelon/dev-env
`docs/plans/2026-07-31-cost-perf-followups.md` for full analysis.

## Test plan
- [x] `shellcheck -S info` on `pre-merge-review.sh` (pre-existing SC1091 only, unrelated to this change)
- [x] `python3 -c "import json; json.load(open('settings.json'))"` — valid JSON
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Local pre-push review (full-diff + codebase): PASS

Claude-Session: https://claude.ai/code/session_017PUAfxBAZPUSyt3nYzwqcq