### PR TITLE
fix: batch close 8 issues (adversarial model, plugin refs, --learn categorization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ command (via `_claude_update()`). It:
 
 ## Installed Plugins
 
-Plugins are sourced from six marketplaces. Enabled state is tracked in `settings.json`.
+Plugins are sourced from seven marketplaces (six `extraKnownMarketplaces` entries plus the `superpowers-marketplace` submodule). Enabled state is tracked in `settings.json`.
 
 ### From superpowers-marketplace
 
@@ -80,7 +80,7 @@ Plugins are sourced from six marketplaces. Enabled state is tracked in `settings
 - **code-critic** ✓ — adversarial code review agent
 - **react-native-3d** — 3D rendering with React Three Fiber, expo-gl, Three.js (disabled on some machines — see [Per-Machine Notes](#per-machine-notes))
 
-### From claude-code-plugins
+### From claude-plugins-official
 
 - **frontend-design** ✓ — production-grade frontend UI generation
 
@@ -117,7 +117,6 @@ from the tracked default.
 ├── plugins/
 │   └── marketplaces/
 │       ├── claude-code-workflows         # Plugin marketplace
-│       ├── claude-code-plugins           # Plugin marketplace
 │       ├── claude-plugins-official       # Plugin marketplace
 │       ├── smartwatermelon-marketplace   # Personal marketplace (git submodule source)
 │       ├── superpowers-marketplace       # Git submodule → smartwatermelon/superpowers-marketplace

--- a/docs/CUSTOM_AGENTS.md
+++ b/docs/CUSTOM_AGENTS.md
@@ -6,7 +6,7 @@ This document explains how to manage custom agents that are not part of external
 
 ## Problem
 
-Custom agents stored in the wshobson/agents marketplace (`~/.claude/agents/plugins/`) get overwritten when the package updates, because they're treated as part of that package.
+Custom agents stored in the wshobson/agents marketplace (now forked as smartwatermelon/claude-code-workflows-agents) (`~/.claude/agents/plugins/`) get overwritten when the package updates, because they're treated as part of that package.
 
 ## Solution
 

--- a/docs/plans/2026-04-03-symlink-reconciliation-design.md
+++ b/docs/plans/2026-04-03-symlink-reconciliation-design.md
@@ -41,7 +41,6 @@ Submodule directories are symlinked as **directory-level symlinks**, not per-fil
 
 Current submodules:
 - `plugins/marketplaces/superpowers-marketplace`
-- `skills/humanizer`
 
 ### Pre-flight: Reconcile local modifications
 

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -33,7 +33,8 @@ set -euo pipefail
 #   review.maxLines        - Max lines for full review (default: 1000)
 #   review.skipThreshold   - Skip AI review beyond this (default: 2500)
 #   review.chunkSize       - Max lines per file in chunked mode (default: 800)
-#   review.model           - Claude model ID (default: haiku for commits, sonnet for full-diff/codebase)
+#   review.model           - Claude model ID for code-reviewer (default: haiku for commits, sonnet for full-diff/codebase)
+#   review.adversarialModel - Claude model ID for adversarial-reviewer (default: claude-sonnet-4-6, always, regardless of mode)
 #
 # EXAMPLES:
 #   git config --global review.maxLines 2000
@@ -100,6 +101,10 @@ fi
 # --- Model selection ---
 # Priority: git config review.model > mode-based default > CLI default
 # Haiku for commit-level (small diffs, fast feedback); Sonnet for branch/codebase analysis.
+# This REVIEW_MODEL / CODE_REVIEWER_MODEL_ARGS pair governs code-reviewer (and,
+# in full-diff/codebase mode, the single reviewer invocation issued there —
+# see ADVERSARIAL_MODEL_ARGS below for why those specific call sites use the
+# adversarial model instead).
 REVIEW_MODEL=$(git config --get review.model 2>/dev/null || echo "")
 if [[ -z "${REVIEW_MODEL}" ]]; then
   case "${REVIEW_MODE}" in
@@ -109,10 +114,19 @@ if [[ -z "${REVIEW_MODEL}" ]]; then
     *)        REVIEW_MODEL="" ;;
   esac
 fi
-MODEL_ARGS=()
+CODE_REVIEWER_MODEL_ARGS=()
 if [[ -n "${REVIEW_MODEL}" ]]; then
-  MODEL_ARGS=(--model "${REVIEW_MODEL}")
+  CODE_REVIEWER_MODEL_ARGS=(--model "${REVIEW_MODEL}")
 fi
+
+# adversarial-reviewer gets its own model, independent of REVIEW_MODE.
+# code-reviewer's mechanical issue-spotting is a legitimate Haiku task, but
+# adversarial-reviewer's assume-wrong-until-proven reasoning benefits from a
+# bigger model even on the highest-frequency path (commit mode) — see issue
+# #235. Override via `git config review.adversarialModel <model-id>`.
+ADVERSARIAL_MODEL=$(git config --get review.adversarialModel 2>/dev/null || echo "")
+[[ -n "${ADVERSARIAL_MODEL}" ]] || ADVERSARIAL_MODEL="claude-sonnet-4-6"
+ADVERSARIAL_MODEL_ARGS=(--model "${ADVERSARIAL_MODEL}")
 
 # --- Reviewer agent selection ---
 # Pinned to a fully-qualified plugin:agent name (git config review.codeReviewerAgent
@@ -206,10 +220,16 @@ fi
 unset _preflight_rc
 
 # --- Agent invocation function ---
+# $1 = agent name, $2 = prompt, $3 = cache file, $4... = model args array
+# (e.g. "${CODE_REVIEWER_MODEL_ARGS[@]}" or "${ADVERSARIAL_MODEL_ARGS[@]}",
+# possibly empty). Per-call model args replace the old shared global
+# MODEL_ARGS so each reviewer can be pinned to its own model (issue #235).
 invoke_agent() {
   local agent_name="$1"
   local prompt="$2"
   local cache_file="$3"
+  shift 3
+  local -a model_args=("$@")
 
   # Check cache first
   if [[ -f "${cache_file}" ]]; then
@@ -237,7 +257,7 @@ invoke_agent() {
   local exit_code=0
   # Use || to prevent set -e from propagating if the CLI exits non-zero.
   # exit_code is then set to the actual failure code for the handler below.
-  agent_output=$(echo "${prompt}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "${agent_name}" -p "${MODEL_ARGS[@]}" --tools "" --no-session-persistence 2>&1) || exit_code=$?
+  agent_output=$(echo "${prompt}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "${agent_name}" -p "${model_args[@]}" --tools "" --no-session-persistence 2>&1) || exit_code=$?
 
   # Handle timeout - BLOCK commit (strict mode)
   if [[ ${exit_code} -eq 124 ]]; then
@@ -538,7 +558,7 @@ ${file_diff}
     # output on agent error is normalized here so the aggregate loop can
     # treat it uniformly.
     (
-      _fout=$(invoke_agent "${CODE_REVIEWER_AGENT}" "${file_prompt}" "${file_cache}") || true
+      _fout=$(invoke_agent "${CODE_REVIEWER_AGENT}" "${file_prompt}" "${file_cache}" "${CODE_REVIEWER_MODEL_ARGS[@]}") || true
       [[ -n "${_fout}" ]] || _fout="VERDICT: FAIL (agent error: invoke_agent produced no output)"
       {
         printf '%s\n' "${file}"
@@ -842,10 +862,8 @@ fi
 if [[ "${REVIEW_MODE}" == "full-diff" ]]; then
   log_info "Full-diff review: analyzing complete feature branch diff"
   log_info "Diff size: ${DIFF_LINES} lines"
-  if [[ -n "${REVIEW_MODEL}" ]]; then
-    log_info "Model: ${REVIEW_MODEL}"
-    printf 'model: %s\n' "${REVIEW_MODEL}" >>"${REVIEW_LOG}" || true
-  fi
+  log_info "Model: ${ADVERSARIAL_MODEL}"
+  printf 'model: %s\n' "${ADVERSARIAL_MODEL}" >>"${REVIEW_LOG}" || true
 
   FULL_DIFF_CACHE="${CACHE_DIR}/full-diff-${DIFF_HASH}"
 
@@ -899,7 +917,7 @@ Review diff:
 ${DIFF}
 \`\`\`"
 
-  FULL_DIFF_OUTPUT=$(invoke_agent "adversarial-reviewer" "${FULL_DIFF_PROMPT}" "${FULL_DIFF_CACHE}") || true
+  FULL_DIFF_OUTPUT=$(invoke_agent "adversarial-reviewer" "${FULL_DIFF_PROMPT}" "${FULL_DIFF_CACHE}" "${ADVERSARIAL_MODEL_ARGS[@]}") || true
 
   [[ -n "${FULL_DIFF_OUTPUT}" ]] || FULL_DIFF_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
 
@@ -937,10 +955,8 @@ fi
 if [[ "${REVIEW_MODE}" == "codebase" ]]; then
   log_info "Codebase review: analyzing diff with full codebase tool access"
   log_info "Diff size: ${DIFF_LINES} lines | Timeout: ${TIMEOUT_SECONDS}s"
-  if [[ -n "${REVIEW_MODEL}" ]]; then
-    log_info "Model: ${REVIEW_MODEL}"
-    printf 'model: %s\n' "${REVIEW_MODEL}" >>"${REVIEW_LOG}" || true
-  fi
+  log_info "Model: ${ADVERSARIAL_MODEL}"
+  printf 'model: %s\n' "${ADVERSARIAL_MODEL}" >>"${REVIEW_LOG}" || true
 
   CODEBASE_CACHE="${CACHE_DIR}/codebase-${DIFF_HASH}"
 
@@ -1023,7 +1039,7 @@ END_ISSUE"
   # Matches the pattern used for the parallel code-reviewer/adversarial
   # invocations (_cr_out/_ar_out). Issue #89.
   _codebase_err=$(mktemp)
-  CODEBASE_OUTPUT=$(echo "${CODEBASE_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "adversarial-reviewer" -p "${MODEL_ARGS[@]}" --allowedTools "Read,Grep,Glob" --no-session-persistence 2>"${_codebase_err}") || codebase_exit=$?
+  CODEBASE_OUTPUT=$(echo "${CODEBASE_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" --agent "adversarial-reviewer" -p "${ADVERSARIAL_MODEL_ARGS[@]}" --allowedTools "Read,Grep,Glob" --no-session-persistence 2>"${_codebase_err}") || codebase_exit=$?
   if [[ -s "${_codebase_err}" ]]; then
     cat "${_codebase_err}" >&2
   fi
@@ -1187,9 +1203,9 @@ if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
   # error/timeout)"). `|| true` on the wait calls suppresses propagation of
   # the subshell's exit status; the same empty-output guard below handles
   # any silent failure.
-  (invoke_agent "${CODE_REVIEWER_AGENT}" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}" >"${_cr_out}") &
+  (invoke_agent "${CODE_REVIEWER_AGENT}" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}" "${CODE_REVIEWER_MODEL_ARGS[@]}" >"${_cr_out}") &
   _cr_pid=$!
-  (invoke_agent "adversarial-reviewer" "${AGENT_PROMPT}" "${ADVERSARIAL_CACHE}" >"${_ar_out}") &
+  (invoke_agent "adversarial-reviewer" "${AGENT_PROMPT}" "${ADVERSARIAL_CACHE}" "${ADVERSARIAL_MODEL_ARGS[@]}" >"${_ar_out}") &
   _ar_pid=$!
   wait "${_cr_pid}" || true
   wait "${_ar_pid}" || true
@@ -1199,7 +1215,7 @@ if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
   unset _cr_out _ar_out _cr_pid _ar_pid
 else
   # Serial path (no adversarial): only code-reviewer runs.
-  CODE_REVIEWER_OUTPUT=$(invoke_agent "${CODE_REVIEWER_AGENT}" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}") || true
+  CODE_REVIEWER_OUTPUT=$(invoke_agent "${CODE_REVIEWER_AGENT}" "${AGENT_PROMPT}" "${CODE_REVIEWER_CACHE}" "${CODE_REVIEWER_MODEL_ARGS[@]}") || true
 fi
 
 # Guard: invoke_agent may exit 0 but produce no output (silent agent failure).

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -24,6 +24,9 @@
 #   20. "VERDICT: Revise" is treated as blocking FAIL in codebase mode (issue #173); also
 #       covers issue #159 (model logging in full-diff/codebase modes)
 #   21. review.model git config overrides the default model passed to the CLI (issue #160)
+#   22. CODE_REVIEWER_AGENT default resolves to the installed agent ID (issue #209)
+#   23. review.adversarialModel overrides adversarial-reviewer's model independently
+#       of review.model / REVIEW_MODE (issue #235)
 
 set -euo pipefail
 
@@ -1185,11 +1188,70 @@ assert_contains \
   "${invocation_args22}"
 
 # =========================================================
+# TEST 23: review.adversarialModel git config overrides the adversarial-
+# reviewer model independently of review.model / REVIEW_MODE (issue #235)
+#
+# adversarial-reviewer previously rode the same REVIEW_MODEL as code-reviewer
+# via a shared MODEL_ARGS global (Haiku on commit-mode, the highest-frequency
+# path). run-review.sh now resolves a separate ADVERSARIAL_MODEL_ARGS,
+# defaulting to claude-sonnet-4-6 regardless of mode, overridable via
+# `git config review.adversarialModel`. invoke_agent() takes model args as a
+# per-call parameter instead of reading a shared global, so this test asserts
+# (a) code-reviewer still gets the mode-based default (Haiku, unaffected by
+# the adversarialModel override) and (b) adversarial-reviewer gets the
+# configured override, in the same commit-mode run.
+# =========================================================
+echo ""
+echo "=== Test 23: review.adversarialModel overrides adversarial-reviewer model independently (issue #235) ==="
+
+setup_repo
+stage_small_change
+
+MOCK23_DIR="${TMPDIR_TEST}/mock23"
+mkdir -p "${MOCK23_DIR}"
+MOCK23_ARGS_FILE="${MOCK23_DIR}/invocation-args.txt"
+rm -f "${MOCK23_ARGS_FILE}"
+cat >"${MOCK23_DIR}/claude" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "--version" ]]; then
+  echo "mock-claude 0.0.0-test"
+  exit 0
+fi
+printf '%s\n' "\$*" >>"${MOCK23_ARGS_FILE}"
+echo "VERDICT: PASS"
+echo ""
+echo "No blocking issues found."
+exit 0
+EOF
+chmod +x "${MOCK23_DIR}/claude"
+
+TEST23_LOG="${TMPDIR_TEST}/test23-review.log"
+rm -f "${TEST23_LOG}"
+
+cd "${REPO_DIR}"
+git config review.adversarialModel "some-adversarial-model-id"
+REVIEW_LOG="${TEST23_LOG}" CLAUDE_CLI="${MOCK23_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || true
+git config --unset review.adversarialModel 2>/dev/null || true
+cd - >/dev/null
+
+invocation_args23="$(cat "${MOCK23_ARGS_FILE}" 2>/dev/null || echo "")"
+
+assert_contains \
+  "configured review.adversarialModel reaches the adversarial-reviewer CLI invocation (issue #235)" \
+  "--agent adversarial-reviewer -p --model some-adversarial-model-id" \
+  "${invocation_args23}"
+
+assert_contains \
+  "code-reviewer still uses its own mode-based default model, unaffected by review.adversarialModel (issue #235)" \
+  "--agent comprehensive-review:comprehensive-review-code-reviewer -p --model claude-haiku-4-5-20251001" \
+  "${invocation_args23}"
+
+# =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 40 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 42 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -166,10 +166,12 @@ _append_known_runtime_entry() {
   else
     # Section header missing (shouldn't happen with the shipped file) —
     # append a fresh section at the end rather than dropping the entry.
+    # Propagate a write failure (e.g. disk full) instead of returning 0
+    # implicitly, so the caller's success count stays accurate.
     {
       printf '\n%s\n' "${header}"
       printf '%s\n' "${name}"
-    } >> "${KNOWN_RUNTIME_FILE}"
+    } >> "${KNOWN_RUNTIME_FILE}" || return 1
   fi
 }
 

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -97,6 +97,82 @@ else
   _warn "known-runtime.txt not found at ${KNOWN_RUNTIME_FILE}"
 fi
 
+# Classify a basename as directory-like or file-like for --learn section
+# placement. No extension (and doesn't start with '.') => directory-like;
+# has an extension or starts with '.' => file-like. This is a heuristic
+# (matches the existing known-runtime.txt convention: dotfiles and
+# extensioned names live under "# Files", bare names under "# Directories"),
+# not a filesystem stat. The current caller always passes an already-
+# basenamed value, so the internal basename call below is a forward-
+# compatibility guard (not required for today's correctness) against a
+# future caller passing a full path.
+_entry_section() {
+  local name
+  name="$(basename "$1")"
+  case "${name}" in
+    .*) echo "Files" ;;
+    *.*) echo "Files" ;;
+    *) echo "Directories" ;;
+  esac
+}
+
+# Insert a new entry under its section header (# Directories or # Files) in
+# KNOWN_RUNTIME_FILE, preserving existing structure. The entry is placed at
+# the END of its section (immediately before the next blank line, next
+# section header, or EOF) rather than right after the header line, so
+# repeated --learn runs append in natural order instead of reversing it.
+# Appends a fresh section (with a preceding blank line) if the target
+# header can't be found, so --learn never loses an entry even in a
+# malformed file. Returns non-zero (and leaves the original file untouched)
+# if the awk/mv rewrite fails, cleaning up its temp file either way.
+# Not designed for concurrent invocation (single-user local maintenance
+# tool, invoked interactively) — no file locking around the grep-then-awk
+# read/rewrite. `awk -v var="${val}"` passes ${val} as a single argv
+# element; it is not re-parsed as awk source, so entry/header values
+# containing quotes or other shell metacharacters are safe as-is.
+_append_known_runtime_entry() {
+  local name="$1"
+  [[ -n "${name}" ]] || return 1
+  local section
+  section="$(_entry_section "${name}")"
+  local header="# ${section}"
+
+  if grep -qxF "${header}" "${KNOWN_RUNTIME_FILE}"; then
+    # in_section tracks whether we're inside the target section. On the
+    # first line that ends the section (blank line, another '#' header, or
+    # EOF via END{}) while still in_section, emit the new entry BEFORE that
+    # boundary line — this lands it at the end of the target section's
+    # existing entries, not before them.
+    if awk -v header="${header}" -v entry="${name}" '
+        function flush_if_needed() {
+          if (in_section && !done) { print entry; done = 1 }
+        }
+        {
+          if ($0 == header) { in_section = 1 }
+          else if (in_section && (($0 ~ /^#/) || ($0 ~ /^[[:space:]]*$/))) {
+            flush_if_needed()
+            in_section = 0
+          }
+          print
+        }
+        END { flush_if_needed() }
+      ' "${KNOWN_RUNTIME_FILE}" > "${KNOWN_RUNTIME_FILE}.tmp" \
+      && mv "${KNOWN_RUNTIME_FILE}.tmp" "${KNOWN_RUNTIME_FILE}"; then
+      return 0
+    else
+      rm -f "${KNOWN_RUNTIME_FILE}.tmp"
+      return 1
+    fi
+  else
+    # Section header missing (shouldn't happen with the shipped file) —
+    # append a fresh section at the end rather than dropping the entry.
+    {
+      printf '\n%s\n' "${header}"
+      printf '%s\n' "${name}"
+    } >> "${KNOWN_RUNTIME_FILE}"
+  fi
+}
+
 _is_known_runtime() {
   local name="$1"
 
@@ -184,11 +260,31 @@ if [[ "${unknown_count}" -gt 0 ]]; then
 
     if [[ "${#_new_entries[@]}" -eq 0 ]]; then
       _ok "No new entries to learn (already recorded)"
-    elif printf '%s\n' "${_new_entries[@]}" >> "${KNOWN_RUNTIME_FILE}"; then
-      _ok "Added ${#_new_entries[@]} entries to $(basename "${KNOWN_RUNTIME_FILE}")"
-      _info "Review and commit: git -C ${REPO_DIR} diff scripts/known-runtime.txt"
     else
-      _warn "Failed to write to ${KNOWN_RUNTIME_FILE}"
+      # Stop at the first write failure rather than continuing through the
+      # rest of _new_entries: this is a local, single-user maintenance tool
+      # (no concurrent writers to race against), so a failure here almost
+      # always means a real problem with KNOWN_RUNTIME_FILE (permissions,
+      # disk full) that will just repeat for every remaining entry. Halting
+      # early keeps the failure mode simple: either all attempted entries up
+      # to the failure landed, or none did if the very first write fails.
+      _learn_added_count=0
+      _learn_failed_entry=""
+      for _new in "${_new_entries[@]}"; do
+        if _append_known_runtime_entry "${_new}"; then
+          _learn_added_count=$((_learn_added_count + 1))
+        else
+          _learn_failed_entry="${_new}"
+          break
+        fi
+      done
+      if [[ -n "${_learn_failed_entry}" ]]; then
+        _warn "Failed to write entry '${_learn_failed_entry}' to ${KNOWN_RUNTIME_FILE} — stopped (${_learn_added_count} entries were added before the failure)"
+      fi
+      if [[ "${_learn_added_count}" -gt 0 ]]; then
+        _ok "Added ${_learn_added_count} entries to $(basename "${KNOWN_RUNTIME_FILE}") (categorized by type)"
+        _info "Review and commit: git -C ${REPO_DIR} diff scripts/known-runtime.txt"
+      fi
     fi
   else
     _info "Evaluate the items above, then run:"

--- a/settings.json
+++ b/settings.json
@@ -83,7 +83,7 @@
     "team-collaboration@claude-code-workflows": false,
     "code-critic@smartwatermelon-marketplace": true,
     "react-native-3d@smartwatermelon-marketplace": false,
-    "frontend-design@claude-code-plugins": false,
+    "frontend-design@claude-plugins-official": false,
     "ci-workflows@smartwatermelon-marketplace": true,
     "apple-notes@apple-notes-mcp": false,
     "personify@personify": true,
@@ -119,13 +119,15 @@
       "source": {
         "source": "github",
         "repo": "smartwatermelon/personify"
-      }
+      },
+      "autoUpdate": true
     },
     "pr-review": {
       "source": {
         "source": "github",
         "repo": "smartwatermelon/pr-review"
-      }
+      },
+      "autoUpdate": true
     }
   },
   "spinnerTipsOverride": {


### PR DESCRIPTION
## Summary

Batch PR closing out a round of GitHub issue triage. Five independent fixes plus one settings change and one invalid-issue closure, all on one branch.

### Settings: enable autoUpdate for personify/pr-review marketplaces
`settings.json` now sets `"autoUpdate": true` for the `personify` and `pr-review` entries under `extraKnownMarketplaces`.

### Closes #223, Closes #233 — stale `claude-code-plugins` marketplace reference
`frontend-design` actually lives under the `claude-plugins-official` marketplace (confirmed via `~/.claude/plugins/known_marketplaces.json` and the on-disk marketplace directory listing — no `claude-code-plugins` directory exists anywhere). Renamed the `enabledPlugins` key in `settings.json`, fixed the README section heading and directory-tree diagram (which had a stale duplicate `claude-code-plugins` entry alongside the real `claude-plugins-official`), and corrected the marketplace count (six `extraKnownMarketplaces` entries + the `superpowers-marketplace` submodule = seven sources).

### Closes #235 — differentiate adversarial-reviewer's model from code-reviewer's
`hooks/run-review.sh` previously computed one `REVIEW_MODEL` and applied it to both `code-reviewer` and `adversarial-reviewer` via a shared `MODEL_ARGS` global. `code-reviewer`'s mechanical issue-spotting is a legitimate Haiku task, but `adversarial-reviewer`'s assume-wrong-until-proven reasoning was riding the same Haiku default on commit-mode (the highest-frequency path). Added a `review.adversarialModel` git-config override (default `claude-sonnet-4-6`, always, independent of `REVIEW_MODE`), left `code-reviewer`'s mode-based default untouched, and refactored `invoke_agent()` to take model args as a per-call parameter instead of a shared global. Added Test 23 to `hooks/tests/run-review-test.sh` (42/42 assertions pass).

### Closes #230 — stale wshobson/agents reference
`docs/CUSTOM_AGENTS.md` now notes that wshobson/agents is forked as `smartwatermelon/claude-code-workflows-agents` (the actual source per `settings.json`'s `claude-code-workflows` marketplace entry).

### Closes #221 — stale submodule reference in design doc
Removed the already-deleted `skills/humanizer` submodule from the "Current submodules" list in `docs/plans/2026-04-03-symlink-reconciliation-design.md` — only `plugins/marketplaces/superpowers-marketplace` remains, matching `.gitmodules`.

### Closes #215, Closes #217 — `--learn` degrading known-runtime.txt structure
`scripts/update-tools.sh --learn` previously appended new entries as a flat dump at the bottom of `known-runtime.txt`, losing the `# Directories`/`# Files` section structure over repeated runs. It now classifies each entry (no extension => directory-like, has an extension or leading dot => file-like) and inserts it at the end of the matching section, preserving structure and natural append order across repeated runs. Verified by simulating `--learn` runs (including repeated runs) against a scratch copy of `known-runtime.txt`.

### Closes #218 — BASH_DEFAULT_TIMEOUT_MS is a real override, not a no-op
Verified against the official docs (https://code.claude.com/docs/en/env-vars) that `BASH_DEFAULT_TIMEOUT_MS` defaults to 120000ms (2 min), not 300000ms as the issue assumed. `settings.json`'s `"BASH_DEFAULT_TIMEOUT_MS": "300000"` is a meaningful 5-minute override and was left unchanged. Closing as invalid/resolved based on this verified fact — no code change for this issue.

## Test plan

- [x] `hooks/tests/run-review-test.sh` — 42/42 assertions pass
- [x] `tests/*.bats` — 129/135 pass; the 6 failures (test_pre_merge_changes_requested.bats, test_pre_merge_early_auth.bats) are pre-existing on `main`, confirmed unrelated to this diff
- [x] `scripts/tests/*.sh` — all pass
- [x] `test-pre-merge-review.sh` — 43/43 pass
- [x] `shellcheck -S info` on `hooks/run-review.sh`, `scripts/update-tools.sh`, `hooks/tests/run-review-test.sh` — clean (2 pre-existing info findings on untouched lines)
- [x] Manually simulated `--learn` runs (single and repeated) against a scratch `known-runtime.txt` to confirm categorization and stable ordering
- [x] Pre-commit code-reviewer + adversarial-reviewer hooks passed on every commit
- [x] Pre-push full-diff + codebase review passed

[skip-claude-review: remote Claude GitHub Action failed with CLAUDE_OUTCOME=failure on both claude-review and claude-review-haiku (no verdict rendered) — consistent with OAuth session-token exhaustion, not a finding about this diff. All local pre-commit/pre-push code-reviewer and adversarial-reviewer passes succeeded per the test plan above.]
