### PR TITLE
chore(ci): drop no-op gh pr review --approve step

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -91,5 +91,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Removes the `gh pr review --approve` line from `dependabot-auto-merge.yml`.

No repo in either org currently requires an approving review
(`required_approving_review_count` is 0 fleet-wide, confirmed by audit
in smartwatermelon/dev-env#21), so this step has never done anything —
`gh pr merge --auto` already merges once required status checks pass.
Auto-merge behavior is unchanged; this only removes dead weight and
the associated `pull-requests: write` usage for the approve call.

Part of the fleet-wide remediation tracked in smartwatermelon/dev-env#21.
This PR is not merged automatically — merge requires separate explicit
authorization, same as any other PR.
