### PR TITLE
fix: address 6 tracked tech-debt issues (#92, #104, #116, #168, #172, #244)

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -25,9 +25,9 @@ Many protocols are enforced by git hooks and scripts:
 | Deployment safety | deploy-commons.sh | `~/.claude/lib/deploy-commons.sh` |
 | Branch cleanup | audit-branches.sh | `~/.claude/scripts/audit-branches.sh` |
 
-**Key Point**: If hooks block an operation, it means a protocol was violated. `--no-verify` is BLOCKED by Claude Code hooks. Emergency bypass (human only): Human must run commit manually.
+**Key Point**: If hooks block an operation, it means a protocol was violated. `--no-verify` is BLOCKED by Claude Code hooks. Emergency override (human only): Human must run commit manually.
 
-**When a hook blocks your commit**: Go back and rework the code — do not ask the human to override. See CODE-REVIEW.md § "When Reviews Find Issues — Rework, Don't Override" for the full escalation ladder. Only after 3+ genuine rework attempts with no viable path forward should you present the findings and ask if the human wants to bypass.
+**When a hook blocks your commit**: Go back and rework the code — do not ask the human to override. See CODE-REVIEW.md § "When Reviews Find Issues — Rework, Don't Override" for the full escalation ladder. Only after 3+ genuine rework attempts with no viable path forward should you present the findings and ask if the human wants to override.
 
 ---
 

--- a/hooks/lib-review-context.sh
+++ b/hooks/lib-review-context.sh
@@ -65,7 +65,7 @@ round_history_key() {
   local changed_files="$1"
   local branch hash
   branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
-  hash=$(printf '%s\n%s\n' "${branch}" "$(printf '%s\n' "${changed_files}" | sort)" \
+  hash=$(printf '%s\n%s\n' "${branch}" "$(sort <<<"${changed_files}")" \
     | shasum -a 256 2>/dev/null | awk '{print $1}')
   printf '%s\n' "${hash:-noround}"
 }

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -1524,8 +1524,10 @@ fi
 if [[ "${ADVERSARIAL_VERDICT}" == "FAIL" ]]; then
   # Transient infrastructure failures (timeout, CLI crash) produce "VERDICT: FAIL (timeout)"
   # or "VERDICT: FAIL (agent error: N)" with no SEVERITY: BLOCKING — treat as non-blocking,
-  # consistent with how code-reviewer handles the same case.
-  if echo "${ADVERSARIAL_OUTPUT}" | grep -qE "VERDICT: FAIL \((timeout|agent error)"; then
+  # consistent with how code-reviewer handles the same case. Also matches a
+  # "Revise (...)" form in case a future synthetic transient error is ever
+  # phrased that way instead of "FAIL (...)" (#172).
+  if echo "${ADVERSARIAL_OUTPUT}" | grep -qE "VERDICT: (FAIL|Revise) \((timeout|agent error)"; then
     log_warn "adversarial-reviewer timed out or errored — non-blocking (infrastructure failure)"
   elif echo "${ADVERSARIAL_OUTPUT}" | grep -q "SEVERITY: BLOCKING"; then
     # Symmetric with the code-reviewer gate above: only a BLOCKING severity

--- a/scripts/known-runtime.txt
+++ b/scripts/known-runtime.txt
@@ -25,7 +25,6 @@ paste-cache
 pending-issues
 plans
 projects
-review-cache
 sessions
 session-env
 shell-snapshots

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -50,7 +50,7 @@ fi
 
 _info "Updating submodules..."
 
-if git -C "${REPO_DIR}" submodule status --quiet 2>/dev/null; then
+if git -C "${REPO_DIR}" config --file .gitmodules --get-regexp path >/dev/null 2>&1; then
   git -C "${REPO_DIR}" submodule sync
   git -C "${REPO_DIR}" submodule update --remote --merge
   _ok "Submodules updated"

--- a/tests/test_merge_lock_batch_auth.bats
+++ b/tests/test_merge_lock_batch_auth.bats
@@ -6,10 +6,13 @@ SCRIPT="${BATS_TEST_DIRNAME}/../hooks/merge-lock.sh"
 
 setup() {
   TMP_HOME="$(mktemp -d)"
+  readonly TMP_HOME
   export HOME="${TMP_HOME}"
 }
 
 teardown() {
+  # TMP_HOME is readonly so a test can't reassign it out from under teardown,
+  # even if it reassigns HOME mid-test (see #116).
   rm -rf "${TMP_HOME}"
 }
 


### PR DESCRIPTION
## Summary

Batch fix for six tracked, still-valid tech-debt issues found during a full audit of open issues in this repo.

- **#92** — `scripts/update-tools.sh` used `git submodule status --quiet` to detect submodule presence, but that command returns exit 0 even with zero submodules, making the else-branch dead code. Switched to `git config --file .gitmodules --get-regexp path`.
- **#104** — Aligned "bypass" → "override" terminology in `docs/INFRASTRUCTURE.md` to match the canonical wording already used in `docs/CODE-REVIEW.md`'s "Rework, Don't Override" section. (Left the two named incident titles — "File-Backed GraphQL Mutation Bypass", "Global Flag Prefix Bypass" — as-is; those describe blocked bypass *attempts*, a different concept from the human-authorized override escape hatch.)
- **#116** — `tests/test_merge_lock_batch_auth.bats` teardown relied on a mutable `TMP_HOME`; made it `readonly` so a future test can't reassign `HOME` mid-test and leave teardown pointed at a stale directory.
- **#168** — Removed the dead `review-cache` entry from `scripts/known-runtime.txt`. Confirmed no code in this repo creates `~/.claude/review-cache` (the actual review cache lives at `.git/claude-review-cache` per repo).
- **#172** — Broadened the adversarial-reviewer transient-failure bypass regex in `hooks/run-review.sh` to also match a `Revise (...)` verdict form, not just `FAIL (...)`, in case a future synthetic transient error is phrased that way.
- **#244** — Fixed `round_history_key` in `hooks/lib-review-context.sh` to use `sort <<<"${changed_files}"` instead of `printf '%s\n' | sort`, avoiding a spurious trailing blank-line entry in the sorted input to the hash.

## Issues closed separately (not part of this diff)

- **#169** — Investigated: `policy-limits.json` is *not* dead. It's now present at `~/.claude/policy-limits.json`, created by the Claude Code runtime itself. Closing with an explanation; no code change needed.
- **#175** — Process/documentation note about submodule diffs not being reviewable from the parent repo alone. No code fix applies; closing as acknowledged.
- **#240, #241, #242, #243** — Stale reviewer-disagreement logs from the in-progress `clear_round_feedback` fix cycle. That function is now defined at `hooks/lib-review-context.sh:131` and used at three call sites in `hooks/run-review.sh`; the underlying bug these disagreements tracked has since landed (see `7b4a6c3`). Closing as resolved.

## Test plan

- [x] `shellcheck -S info` on all modified `.sh` files — no new warnings introduced (verified against the pre-change baseline)
- [x] `bats tests/test_merge_lock_batch_auth.bats` — 10/10 pass
- [x] `bash hooks/tests/run-review-test.sh` — 49/49 assertions pass
- [x] `bats tests/*.bats` — same pre-existing failures present on `main` (12 failures, environment-dependent, unrelated to this change) confirmed via `git stash` comparison
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Pre-push full-diff + codebase review: PASS