### PR TITLE
fix(hooks): allow read-only git worktree subcommands

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
-# Hook: Block git worktree commands
+# Hook: Block mutating git worktree subcommands
 #
 # Purpose:
 #   git worktree creates and manages multiple working trees from a single repo.
 #   CC add-on skills occasionally attempt to use worktrees for task isolation,
 #   but this conflicts with the project workflow and causes problems.
 #
+#   Only MUTATING subcommands are blocked (add, remove, prune, move, lock,
+#   unlock, repair) plus bare `git worktree` with no subcommand (ambiguous,
+#   blocked conservatively) and any unrecognized/future subcommand (fail
+#   closed). Read-only/inspection subcommands (list, --help, -h) are allowed
+#   through, since they don't create or mutate worktree state and are needed
+#   for observability: e.g. auditing stale `.claude/worktrees/agent-*`
+#   directories left behind by Agent-tool `isolation: "worktree"` subagents
+#   after their branch merges. Previously this hook blocked the entire
+#   `git worktree` family unconditionally, which made `git worktree list`
+#   itself blocked and prevented that audit.
+#
 #   Both the Bash-level `git worktree` command and the EnterWorktree built-in
-#   tool are blocked. This script handles the Bash layer.
+#   tool are blocked. This script handles the Bash layer only; EnterWorktree
+#   is blocked separately by hook-block-enter-worktree.sh.
 #
 # Called by: hook-block-all.sh (PreToolUse Bash hook chain)
 
@@ -16,19 +28,50 @@ set -euo pipefail
 input=$(cat)
 cmd=$(printf '%s\n' "${input}" | jq -r '.tool_input.command // empty')
 
-# Match: git [optional-flags] worktree [subcommand]
+# Match: git [optional-flags] worktree [subcommand-token]
 # Requires `git` to appear as a command (at start of string or after shell operators &&, ||, ;, |).
 # Handles interposed flags: git -C /path worktree add, git --no-pager worktree list, etc.
 # The group (-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)* matches zero or more
 # flag groups before `worktree`. Each group is a token starting with `-`, optionally followed by
 # a non-flag value token. This prevents matching subcommands like `grep` (which don't start with
-# `-`), so `git grep worktree` is NOT blocked.
-if printf '%s\n' "${cmd}" | grep -qE '(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]|$)'; then
+# `-`), so `git grep worktree` is NOT matched here.
+#
+# Capture group 2 grabs the token immediately following `worktree` (the subcommand), if any, so
+# we can branch on it below. Bare `git worktree` with nothing after it yields an empty capture.
+worktree_re='(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+([^[:space:]|;&]+))?'
+
+if [[ "${cmd}" =~ ${worktree_re} ]]; then
+  subcmd="${BASH_REMATCH[5]}"
+
+  case "${subcmd}" in
+    # Read-only / inspection: allow through.
+    list | --help | -h)
+      exit 0
+      ;;
+    # Mutating subcommands: always blocked. `repair` can rewrite worktree
+    # administrative files, so it's treated as mutating despite sounding
+    # read-only.
+    add | remove | prune | move | lock | unlock | repair)
+      ;;
+    # Bare `git worktree` (no subcommand) is ambiguous; block conservatively.
+    "")
+      ;;
+    # Unrecognized/future subcommand: fail closed.
+    *)
+      ;;
+  esac
+
   printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
     >>"${HOME}/.claude/blocked-commands.log"
-  printf '🛑 BLOCKED: git worktree commands are forbidden.\n' >&2
+  if [[ -n "${subcmd}" ]]; then
+    printf '🛑 BLOCKED: git worktree %s is forbidden.\n' "${subcmd}" >&2
+  else
+    printf '🛑 BLOCKED: git worktree (no subcommand) is forbidden.\n' >&2
+  fi
   printf '\n' >&2
   printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
+  printf '\n' >&2
+  printf '(Read-only inspection via "git worktree list" / "--help" is allowed.)\n' >&2
   printf '\n' >&2
   printf 'For task isolation, work directly on a feature branch instead:\n' >&2
   printf '  git checkout -b claude/<description>\n' >&2

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -37,43 +37,52 @@ cmd=$(printf '%s\n' "${input}" | jq -r '.tool_input.command // empty')
 # `-`), so `git grep worktree` is NOT matched here.
 #
 # Capture group 2 grabs the token immediately following `worktree` (the subcommand), if any, so
-# we can branch on it below. Bare `git worktree` with nothing after it yields an empty capture.
+# we can classify it below. Bare `git worktree` with nothing after it yields an empty capture.
+#
+# IMPORTANT: a compound command can contain MULTIPLE `git worktree` invocations
+# (e.g. `git worktree list && git worktree add /tmp/wt`). Matching only the
+# first occurrence and branching on it would let a read-only invocation at the
+# start mask a mutating one later in the same command string. So every
+# occurrence in the string is enumerated with `grep -oE`, and the whole
+# command is blocked if ANY occurrence is not read-only.
 worktree_re='(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+([^[:space:]|;&]+))?'
 
-if [[ "${cmd}" =~ ${worktree_re} ]]; then
-  subcmd="${BASH_REMATCH[5]}"
+mapfile -t matches < <(printf '%s\n' "${cmd}" | grep -oE "${worktree_re}" || true)
+
+for match in "${matches[@]}"; do
+  # Re-extract the subcommand token from this specific match (last
+  # whitespace-delimited field; empty if the match was bare `git worktree`).
+  subcmd=""
+  if [[ "${match}" =~ worktree[[:space:]]+([^[:space:]]+)$ ]]; then
+    subcmd="${BASH_REMATCH[1]}"
+  fi
 
   case "${subcmd}" in
-    # Read-only / inspection: allow through.
+    # Read-only / inspection: this occurrence is fine, keep checking others.
     list | --help | -h)
-      exit 0
+      continue
       ;;
-    # Mutating subcommands: always blocked. `repair` can rewrite worktree
+    # Mutating subcommands, bare `git worktree`, or any unrecognized/future
+    # subcommand: block the whole command. `repair` can rewrite worktree
     # administrative files, so it's treated as mutating despite sounding
-    # read-only.
-    add | remove | prune | move | lock | unlock | repair)
-      ;;
-    # Bare `git worktree` (no subcommand) is ambiguous; block conservatively.
-    "")
-      ;;
-    # Unrecognized/future subcommand: fail closed.
+    # read-only. Bare `git worktree` (no subcommand) is ambiguous and blocked
+    # conservatively. Unknown subcommands fail closed.
     *)
+      printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
+        >>"${HOME}/.claude/blocked-commands.log"
+      if [[ -n "${subcmd}" ]]; then
+        printf '🛑 BLOCKED: git worktree %s is forbidden.\n' "${subcmd}" >&2
+      else
+        printf '🛑 BLOCKED: git worktree (no subcommand) is forbidden.\n' >&2
+      fi
+      printf '\n' >&2
+      printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
+      printf '\n' >&2
+      printf '(Read-only inspection via "git worktree list" / "--help" is allowed.)\n' >&2
+      printf '\n' >&2
+      printf 'For task isolation, work directly on a feature branch instead:\n' >&2
+      printf '  git checkout -b claude/<description>\n' >&2
+      exit 2
       ;;
   esac
-
-  printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
-    >>"${HOME}/.claude/blocked-commands.log"
-  if [[ -n "${subcmd}" ]]; then
-    printf '🛑 BLOCKED: git worktree %s is forbidden.\n' "${subcmd}" >&2
-  else
-    printf '🛑 BLOCKED: git worktree (no subcommand) is forbidden.\n' >&2
-  fi
-  printf '\n' >&2
-  printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
-  printf '\n' >&2
-  printf '(Read-only inspection via "git worktree list" / "--help" is allowed.)\n' >&2
-  printf '\n' >&2
-  printf 'For task isolation, work directly on a feature branch instead:\n' >&2
-  printf '  git checkout -b claude/<description>\n' >&2
-  exit 2
-fi
+done

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -26,23 +26,43 @@ make_input() {
 
 echo "=== hook-block-git-worktree tests ==="
 
-# Should BLOCK (exit 2)
+# Should BLOCK (exit 2) — mutating subcommands, bare worktree, unknown subcommands
 inp="$(make_input 'git worktree add /tmp/wt feature')"
 check "git worktree add" 2 "${inp}"
-inp="$(make_input 'git worktree list')"
-check "git worktree list" 2 "${inp}"
 inp="$(make_input 'git worktree remove /tmp/wt')"
 check "git worktree remove" 2 "${inp}"
 inp="$(make_input 'git worktree prune')"
 check "git worktree prune" 2 "${inp}"
+inp="$(make_input 'git worktree move /tmp/wt /tmp/wt2')"
+check "git worktree move" 2 "${inp}"
+inp="$(make_input 'git worktree lock /tmp/wt')"
+check "git worktree lock" 2 "${inp}"
+inp="$(make_input 'git worktree unlock /tmp/wt')"
+check "git worktree unlock" 2 "${inp}"
+inp="$(make_input 'git worktree repair')"
+check "git worktree repair" 2 "${inp}"
+inp="$(make_input 'git worktree')"
+check "bare git worktree (no subcommand)" 2 "${inp}"
+inp="$(make_input 'git worktree unknownfuturesubcommand')"
+check "git worktree unknown subcommand (fail closed)" 2 "${inp}"
 inp="$(make_input 'git -C /some/path worktree add /tmp/wt')"
 check "git -C /path worktree add" 2 "${inp}"
-inp="$(make_input 'git --no-pager worktree list')"
-check "git --no-pager worktree list" 2 "${inp}"
+inp="$(make_input 'git --no-pager worktree add /tmp/wt')"
+check "git --no-pager worktree add" 2 "${inp}"
 inp="$(make_input 'cd /repo && git worktree add /tmp/wt')"
-check "chained: cd && git worktree" 2 "${inp}"
+check "chained: cd && git worktree add" 2 "${inp}"
 
-# Should PASS (exit 0)
+# Should PASS (exit 0) — read-only/inspection subcommands
+inp="$(make_input 'git worktree list')"
+check "git worktree list" 0 "${inp}"
+inp="$(make_input 'git worktree --help')"
+check "git worktree --help" 0 "${inp}"
+inp="$(make_input 'git worktree -h')"
+check "git worktree -h" 0 "${inp}"
+inp="$(make_input 'git -C /some/path worktree list')"
+check "git -C /path worktree list (interposed flag)" 0 "${inp}"
+inp="$(make_input 'cd /repo && git worktree list')"
+check "chained: cd && git worktree list" 0 "${inp}"
 inp="$(make_input 'git commit -m msg')"
 check "git commit" 0 "${inp}"
 inp="$(make_input 'git checkout -b worktree-fix')"
@@ -52,13 +72,21 @@ check "echo about worktree" 0 "${inp}"
 inp="$(make_input 'brew update')"
 check "unrelated command" 0 "${inp}"
 
-# Additional operator-chaining BLOCK cases
+# Additional operator-chaining cases (read-only allowed through even when chained)
 inp="$(make_input 'ls; git worktree list')"
-check "chained: ; git worktree" 2 "${inp}"
+check "chained: ; git worktree list" 0 "${inp}"
 inp="$(make_input 'true || git worktree list')"
-check "chained: || git worktree" 2 "${inp}"
+check "chained: || git worktree list" 0 "${inp}"
+inp="$(make_input 'echo x | git worktree list')"
+check "chained: | git worktree list" 0 "${inp}"
+
+# Additional operator-chaining BLOCK cases (mutating still blocked when chained)
+inp="$(make_input 'ls; git worktree add /tmp/wt')"
+check "chained: ; git worktree add" 2 "${inp}"
+inp="$(make_input 'true || git worktree prune')"
+check "chained: || git worktree prune" 2 "${inp}"
 inp="$(make_input 'echo x | git worktree add')"
-check "chained: | git worktree" 2 "${inp}"
+check "chained: | git worktree add" 2 "${inp}"
 
 # False-positive guard: git grep searching for "worktree" string
 inp="$(make_input 'git grep worktree')"

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -92,6 +92,20 @@ check "chained: | git worktree add" 2 "${inp}"
 inp="$(make_input 'git grep worktree')"
 check "git grep worktree (not blocked)" 0 "${inp}"
 
+# Multi-invocation compound commands: a read-only occurrence must not mask a
+# mutating one elsewhere in the same command string (regression for the
+# single-match bypass caught in PR review — see smartwatermelon/claude-config#268).
+inp="$(make_input 'git worktree list && git worktree add /tmp/wt')"
+check "compound: list && add (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree list | git worktree add /tmp/wt')"
+check "compound: list | add (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree add /tmp/wt && git worktree list')"
+check "compound: add && list, mutating first (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree list ; git worktree remove /tmp/wt')"
+check "compound: list ; remove (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree list && git worktree --help')"
+check "compound: list && --help, both read-only (must pass)" 0 "${inp}"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]


### PR DESCRIPTION
## Summary
- `hook-block-git-worktree.sh` previously blocked the entire `git worktree` command family unconditionally, including read-only/inspection subcommands like `list` and `--help`.
- This made it impossible to audit stale `.claude/worktrees/agent-*` directories left behind by Agent-tool `isolation: "worktree"` subagents after their branch merges — the coordinating session couldn't even run `git worktree list` to see what was there.
- Narrows the block to mutating subcommands only: add/remove/prune/move/lock/unlock/repair (repair can rewrite worktree administrative files, so treated as mutating). Bare `git worktree` (no subcommand) and any unrecognized/future subcommand are still blocked (fail closed). `list`, `--help`, and `-h` are now allowed through.
- The Bash-level regex now captures the subcommand token following `worktree` and branches on it, while preserving the existing command-chaining (`&&`, `||`, `;`, `|`) and interposed-flag (`-C /path`, `--no-pager`) handling.
- EnterWorktree (the built-in tool) is unaffected — that's blocked separately by `hook-block-enter-worktree.sh`.

Addresses smartwatermelon/dotfiles#154

## Test plan
Existing test suite `scripts/tests/test-hook-block-git-worktree.sh` was extended to cover the new subcommand-aware behavior — 28/28 passing:
- Mutating subcommands (add/remove/prune/move/lock/unlock/repair) → blocked, including with interposed flags (`-C`, `--no-pager`) and command chaining (`&&`, `;`, `||`, `|`)
- Bare `git worktree` and unknown/future subcommands → blocked (fail closed)
- `list`, `--help`, `-h` → allowed, including with interposed flags and chaining
- False-positive guard preserved: `git grep worktree` not blocked
- `shellcheck -S info` clean on both changed files
- Local pre-commit (code-reviewer + adversarial-reviewer) and pre-push (full-diff + codebase review) hooks: PASS

Note: pre-push codebase review flagged one non-blocking design gap (single-match regex could theoretically let a piped `list` then a mutating subcommand bypass the block) — filed separately as #267, not fixed here to keep this PR focused on the read-only-observability fix.

Also worth flagging directly: while writing this PR body, the new hook itself false-positived on this very text (prose mentioning a mutating subcommand tripped the block on the `gh pr create` call), since the regex scans the whole command string rather than parsing actual shell tokens. This is a pre-existing class of false positive from the original hook too (any string containing "git worktree list" would have been blocked before this change as well) — just more visible now since it's classifying rather than blanket-blocking. Not fixed in this PR; worth a follow-up issue if it becomes a recurring nuisance.
