### PR TITLE
fix(scripts): unset CDPATH to avoid breaking dirname+pwd path resolution

### DIFF
--- a/scripts/hook-block-all.sh
+++ b/scripts/hook-block-all.sh
@@ -3,6 +3,7 @@
 # Keeps settings.json clean by consolidating block checks
 
 set -euo pipefail
+unset CDPATH
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/tests/test-hook-block-api-merge.sh
+++ b/scripts/tests/test-hook-block-api-merge.sh
@@ -2,6 +2,7 @@
 # Tests for hook-block-api-merge.sh
 
 set -euo pipefail
+unset CDPATH
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-api-merge.sh"
 pass=0

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -2,6 +2,7 @@
 # Tests for hook-block-git-worktree.sh
 
 set -euo pipefail
+unset CDPATH
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-git-worktree.sh"
 pass=0

--- a/scripts/tests/test-hook-check-commit-message.sh
+++ b/scripts/tests/test-hook-check-commit-message.sh
@@ -2,6 +2,7 @@
 # Tests for hook-check-commit-message.sh
 
 set -euo pipefail
+unset CDPATH
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-check-commit-message.sh"
 pass=0


### PR DESCRIPTION
## Summary
- `hook-block-all.sh` and three `scripts/tests/*.sh` files resolve their own script directory via `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` (or the equivalent `HOOK=` form).
- When `CDPATH` is set in the environment (as it is in this user's `bash/env.sh`) and the script is invoked with a relative path, `cd` on the relative `dirname` output resolves via `CDPATH` and — per POSIX — prints the resolved absolute path to stdout as a side effect. That extra line corrupts the `$(...)` capture, producing a two-line string instead of a clean path, which breaks the resulting variable when used as a command (typically surfacing as an unrelated-looking exit 127).
- `scripts/tests/test-post-push-status.sh` already guarded against this with `unset CDPATH`. This PR applies the same guard to the other three affected test scripts, plus `hook-block-all.sh` for consistency (not currently exploitable in production since `settings.json` always invokes it with an absolute path, but it uses the same fragile idiom).

Fixes #270

## Test plan
- Ran the full test suite both with and without `CDPATH` set, using relative invocation paths from the repo root:
  - `test-hook-block-api-merge.sh`: 55/55 passed in both cases
  - `test-hook-block-git-worktree.sh`: 33/33 passed in both cases
  - `test-hook-check-commit-message.sh`: 25/25 passed in both cases
  - `test-post-push-status.sh`: 17/17 passed (already immune, unchanged)
- Confirmed `hook-block-all.sh` still resolves and dispatches correctly under `CDPATH` with a relative invocation.
- `shellcheck -S info` clean on all four changed files (pre-existing SC2016 info-level notices on unrelated single-quoted test fixtures, not touched by this diff).
- Local pre-commit (code-reviewer + adversarial-reviewer) and pre-push (full-diff + codebase review) hooks: PASS.

Note: the pre-push codebase review flagged that three other scripts (`hooks/run-review.sh`, `hooks/pre-merge-review.sh`, `install.sh`) use the same vulnerable idiom without the guard — filed separately as #271, out of scope here since this PR's issue was scoped to the test scripts specifically.
