### PR TITLE
fix(scripts): unset CDPATH in remaining dirname+pwd path resolution scripts

### DIFF
--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+unset CDPATH
 
 # =========================================================
 # pre-merge-review.sh — Analyze PR reviews before merge

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+unset CDPATH
 
 # =========================================================
 # run-review.sh — Automated code review via Claude CLI

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ if [ -z "${BASH_VERSION:-}" ]; then
 fi
 
 set -euo pipefail
+unset CDPATH
 
 # ~/Developer/claude-config/install.sh
 # Idempotent symlink installer for Claude Code configuration.


### PR DESCRIPTION
## Summary
- Completes the CDPATH guard sweep started in #270 / PR #272. That PR covered `hook-block-all.sh` and three test scripts; this PR covers the three remaining scripts flagged by pre-push whole-codebase review as using the same vulnerable `cd "$(dirname "${BASH_SOURCE[0]}")" && pwd` idiom without the guard: `install.sh` (`REPO_DIR`), `hooks/run-review.sh` (`_LIB_DIR`), and `hooks/pre-merge-review.sh` (`_LIB_DIR`).
- A `CDPATH` export (as in this user's `bash/env.sh`) makes `cd` on a relative directory print an extra line to stdout when resolved via `CDPATH`, corrupting the `$(...)` capture in these path-resolution one-liners.
- `unset CDPATH` is added immediately after `set -euo pipefail` in each file (after the bash re-exec guard in `install.sh`, since `set -euo pipefail` itself comes after that guard).

Fixes #271

## Test plan
- Verified all three affected variables (`REPO_DIR`, `_LIB_DIR` x2) resolve to a single clean absolute path under `CDPATH` with relative invocation, both before (broken, two-line output) and after (fixed) the change.
- Ran the full existing test suite (`scripts/tests/*.sh`): 135/135 passing, no regressions.
- `bash -n` syntax check clean on all three modified files.
- `shellcheck -S info` clean relative to pre-existing baseline (pre-existing SC1091/SC2249 notices unrelated to this change, confirmed present on unmodified files too).
- Local pre-commit (code-reviewer + adversarial-reviewer) and pre-push (full-diff + codebase review) hooks: PASS.

Note: the pre-push codebase review explicitly checked other candidate scripts (`hooks/merge-lock.sh`, sourced library files) and confirmed they're not currently affected (they use `${HOME}`-prefixed absolute paths or are sourced after the parent already unset `CDPATH`). It filed a preemptive, non-blocking follow-up as #274 in case `merge-lock.sh` ever grows dirname-based resolution — not fixed here, out of scope.
