### PR TITLE
fix(scripts): unset CDPATH in merge-lock.sh for consistency

### DIFF
--- a/hooks/merge-lock.sh
+++ b/hooks/merge-lock.sh
@@ -2,6 +2,7 @@
 # ~/.claude/hooks/merge-lock.sh
 # Merge authorization lock - requires human to authorize before agent can merge
 set -euo pipefail
+unset CDPATH
 
 LOCK_DIR="${HOME}/.claude/merge-locks"
 LOCK_TTL_SECONDS=1800 # 30 minutes


### PR DESCRIPTION
## Summary
- Completes the CDPATH guard sweep (#270, #271) by adding `unset CDPATH` to `hooks/merge-lock.sh` for consistency with every other script in the repo.
- Not currently exploitable here: the script only uses `${HOME}`-prefixed absolute paths (`LOCK_DIR="${HOME}/.claude/merge-locks"`), never `dirname`-based resolution, so `CDPATH` can't currently corrupt any path in this file.
- Preemptive/future-proofing per the pre-push review's own recommendation on PR #275: if `dirname`-based resolution is ever added later, the missing guard would silently bite without this.

Fixes #274

## Test plan
- `bash -n hooks/merge-lock.sh` — syntax OK
- `shellcheck -S info hooks/merge-lock.sh` — clean
- Smoke-tested `hooks/merge-lock.sh status <pr>` still runs correctly after the change
- Local pre-commit (code-reviewer + adversarial-reviewer) and pre-push (full-diff + codebase review) hooks: PASS. The codebase review confirmed this brings the entire repo into consistent alignment — no scripts using dirname-based path resolution remain unguarded.
