### PR TITLE
docs: ungate PR creation, require proactive surfacing and claim verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ before merge.
   turn/response that follows its creation — never left for the user to
   discover by asking. State repo, PR number, URL, and one line on what it
   addresses.
-- Merge requires: CI green + prior `merge-lock auth <PR#> "ok"` from the user
+- Merge requires: CI green + prior `merge-lock.sh authorize <PR#> "ok"` from the user
   (30 min TTL). This step is unchanged and still technically enforced by
   merge-lock.sh's PreToolUse hooks.
 - Only allowed merge command: `gh pr merge <number> --squash --delete-branch`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ Before declaring work done, output the full Completion Verification template fro
 - Merging to main
 - Irreversible operations (schema changes, data deletion, public APIs)
 - Creating public GitHub repositories
-- Setting `STRICT_PREPUSH=0` for a specific push when local review is genuinely blocking — ask in that specific conversation; never set it without asking, and never treat a past instance of permission as standing/reusable authorization for future pushes. Details: `docs/HUMAN-BYPASS.md`
+- Setting `STRICT_PREPUSH=0` for a specific push when local review is genuinely blocking — ask in that specific conversation; never set it without asking, and never treat a past instance of permission as standing/reusable authorization for future pushes. Details: `~/.claude/docs/HUMAN-BYPASS.md`
 
 ### Verification Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,19 @@ On main? Stop. Create a branch. Do not proceed.
 
 Use specialized agents proactively, not as a last resort. See `~/.claude/docs/REFERENCE.md` for the agent table.
 
+**Dispatching investigation-only agents:** when a task is explicitly
+read-only/triage-only, state the boundary as an unambiguous negative
+constraint, not a soft description of intent:
+
+  "Do not call Edit, Write, git commit, git push, or gh pr create under any
+  circumstance — not even for changes that look small, obvious, or clearly
+  in-scope. If you find a fix worth making, report it in your findings; do
+  not make it."
+
+Soft phrasing ("read-only investigation", "just triage") leaves room for an
+agent to conclude a specific action falls outside the restriction because it
+seemed like an obvious win. The explicit-negative form doesn't.
+
 ---
 
 ### Protocol 3: Keep Tests in Sync
@@ -115,6 +128,13 @@ After committing, verify the hook ran: `head -6 $(git rev-parse --git-dir)/last-
 
 **Push only after both reviewers are clean.** Full checklists: `~/.claude/docs/CHECKLISTS.md`
 
+**Verifying agent claims:** any agent statement of the form "I did X" or "X
+is now true" — especially a claim that a human already authorized or
+reviewed something — must be checked against live `gh`/`git` state before
+being acted on or relayed to the user. This applies to sub-agent self-reports
+and to your own prior claims within a session. Do not propagate an
+unverified claim into a summary presented as fact.
+
 ---
 
 ### Protocol 5: Post-Push CI/CD Monitoring
@@ -131,24 +151,26 @@ Full procedure: `~/.claude/docs/CHECKLISTS.md` (Post-Push Procedure)
 
 ### Protocol 6: PR Lifecycle
 
-**Creating a PR and merging a PR are ALWAYS two separate turns requiring two separate explicit authorizations.**
+Agents may investigate, fix, commit, push, and open PRs autonomously as part of
+normal work — no checkpoint required before PR creation. The only hard stop is
+before merge.
 
-```
-Step 1: gh pr create → report PR URL → STOP. Wait.
-Step 2: CI runs → report CI status → STOP. Wait.
-Step 3: Human says "merge it" for that specific PR → gh pr merge → STOP.
-Step 4: Post-merge cleanup → return to clean main.
-```
+- Any newly created PR MUST be proactively surfaced to the user in the same
+  turn/response that follows its creation — never left for the user to
+  discover by asking. State repo, PR number, URL, and one line on what it
+  addresses.
+- Merge requires: CI green + prior `merge-lock auth <PR#> "ok"` from the user
+  (30 min TTL). This step is unchanged and still technically enforced by
+  merge-lock.sh's PreToolUse hooks.
+- Only allowed merge command: `gh pr merge <number> --squash --delete-branch`.
+- Post-merge cleanup (switch to main, pull, delete local branch, `git status`
+  check) still applies after every merge.
 
-"Merge it" does not authorize skipping CI, review, or the merge-lock.
-
-**Only allowed merge command:** `gh pr merge <number> --squash --delete-branch` (routes through pre-merge-review.sh)
-
-PR merge requires prior `merge-lock auth <PR#> "ok"` from the user; wait for explicit approval before merging.
+"Merge it" does not authorize skipping CI, review, or the merge-lock. The allowed merge command routes through pre-merge-review.sh.
 
 If `gh pr merge` fails: report the failure, ask the human to merge manually. Never use REST API, GraphQL, or workarounds. These are blocked by hooks. Enforcement details: `~/.claude/docs/INFRASTRUCTURE.md`
 
-**Post-merge cleanup (Step 4):** After a successful merge, leave the workspace clean on main:
+**Post-merge cleanup:** After a successful merge, leave the workspace clean on main:
 
 ```bash
 git switch main
@@ -222,6 +244,7 @@ Before declaring work done, output the full Completion Verification template fro
 - Merging to main
 - Irreversible operations (schema changes, data deletion, public APIs)
 - Creating public GitHub repositories
+- Setting `STRICT_PREPUSH=0` for a specific push when local review is genuinely blocking — ask in that specific conversation; never set it without asking, and never treat a past instance of permission as standing/reusable authorization for future pushes. Details: `docs/HUMAN-BYPASS.md`
 
 ### Verification Discipline
 

--- a/docs/HUMAN-BYPASS.md
+++ b/docs/HUMAN-BYPASS.md
@@ -1,6 +1,6 @@
 # Human Bypass Guide
 
-This document explains how YOU (the human operator) can bypass the hardened review hooks when legitimately needed. These bypasses are **not available to the Claude Code agent**.
+This document explains how YOU (the human operator) can bypass the hardened review hooks when legitimately needed. These bypasses are **not available to the Claude Code agent** — with one caveat: `STRICT_PREPUSH=0` (see [section 3](#3-skipping-local-pre-push-review-with-strict_prepush0)) is not technically hook-blocked for the agent the way `--no-verify` is. The rule keeping it human-only is behavioral, not enforced — the agent must ask your permission before setting it, every time, with no standing authorization.
 
 ---
 
@@ -10,6 +10,7 @@ This document explains how YOU (the human operator) can bypass the hardened revi
 |-----------|---------------|
 | Commit without review | `git commit --no-verify -m "message"` |
 | Push without checks | `git push --no-verify` |
+| Skip local pre-push review | `STRICT_PREPUSH=0 git push` (human-run; agent must ask permission first) |
 | Commit to main (emergency) | `git commit --no-verify -m "message"` (on main branch) |
 | Authorize PR merge | `~/.claude/hooks/merge-lock.sh authorize <PR#> "reason"` |
 | View blocked attempts | `~/.claude/scripts/blocked-audit.sh` |
@@ -47,7 +48,31 @@ git push --no-verify
 - Pushing to a branch that doesn't need Protocol 4 checks
 - Emergency deployments
 
-### 3. Authorizing PR Merges
+### 3. Skipping Local Pre-Push Review with STRICT_PREPUSH=0
+
+```bash
+# In your terminal
+STRICT_PREPUSH=0 git push
+```
+
+**What this gates:** the pre-push hook (`git/hooks/pre-push` in dotfiles) runs four non-interactive blocking review paths when a push happens inside Claude Code non-interactively (`CLAUDECODE=1`, stdin not a tty): the Semgrep supply-chain scan, Semgrep static analysis, the full-diff/codebase review, and a Protocol-4-equivalent PR-iteration checkpoint. `STRICT_PREPUSH=0` opts the push out of all four at once.
+
+**How it differs from `--no-verify`:** `--no-verify` is hook-blocked for the agent — a Claude Code `PreToolUse` hook intercepts and refuses the command before it runs. `STRICT_PREPUSH=0` is **not** currently intercepted by any hook. Nothing technically stops the agent from setting this environment variable and pushing. The distinction matters: everywhere else in this doc, "not available to the agent" is a technical fact. Here it is not.
+
+**The rule, because enforcement is behavioral, not technical:**
+
+- The agent must never set `STRICT_PREPUSH=0` on its own initiative.
+- The agent may ask you for permission to use it for a specific push, in the moment, when there's a concrete reason (e.g., a known-flaky check, an emergency, a push where local review genuinely doesn't apply).
+- Permission is per-push. A "yes" earlier in this conversation — or in a past conversation — does not carry forward. The agent must ask again next time, even if the situation looks identical.
+- If the agent sets `STRICT_PREPUSH=0` without asking, or claims you already authorized it when you didn't say so in the current exchange, that is a protocol violation worth calling out immediately.
+
+**When to use:**
+
+- You've reviewed the push yourself and judge local review unnecessary or redundant
+- A local review path is broken or timing out for reasons unrelated to the actual change
+- Emergency pushes where the four-check pipeline would cost time you don't have
+
+### 4. Authorizing PR Merges
 
 The agent cannot merge PRs without your authorization:
 
@@ -69,7 +94,7 @@ The agent cannot merge PRs without your authorization:
 3. You run the authorize command
 4. You tell the agent to proceed with merge
 
-### 4. Viewing Blocked Attempts
+### 5. Viewing Blocked Attempts
 
 See what the agent tried to bypass:
 
@@ -87,7 +112,7 @@ See what the agent tried to bypass:
 ~/.claude/scripts/blocked-audit.sh clear
 ```
 
-### 5. Committing Directly to Main
+### 6. Committing Directly to Main
 
 The agent is double-blocked from committing to main:
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -112,7 +112,7 @@ running underneath it has previously caused the classifier to override Plan Mode
 conflicting "execute immediately" behavior (see upstream Claude Code changelog).
 Keeping this `false` means every action during planning stays gated on an explicit
 human decision, consistent with this config's broader preference for explicit
-checkpoints (Protocol 6's two-step PR authorization, etc.) over auto-approval.
+checkpoints (Protocol 6's merge-lock authorization, etc.) over auto-approval.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves a 2026-08-10 incident where a background triage fork exceeded its mandate and opened 9 unrequested PRs. Investigation determined the root cause was **not** the absence of a PR-creation gate — the user explicitly decided PR creation should stay ungated, since it's cheap and reversible, unlike merge. The actual causes were: soft/ambiguous scope instructions given to investigation-only forks, no requirement to proactively surface newly-created PRs to the user, and blind trust of agent self-reports about authorization state.

## Changes

1. **Protocol 6 (PR Lifecycle) rewritten.** Drops the old 4-step "Step 1/2/3/4, STOP. Wait." gate that required separate authorization before PR creation. Agents may now investigate, fix, commit, push, and open PRs autonomously as normal work. The only hard stop remains before merge (CI green + `merge-lock auth <PR#> "ok"`, unchanged and still enforced by `merge-lock.sh`'s PreToolUse hooks). New requirement: any newly created PR must be proactively surfaced to the user in the same turn it's created (repo, PR number, URL, one-line description) — never left for the user to discover by asking.

2. **Protocol 2 (Use Local Agents Aggressively): explicit-negative scope phrasing.** Adds guidance that read-only/triage-only agent dispatches must state the boundary as an unambiguous negative constraint ("Do not call Edit, Write, git commit, git push, or gh pr create under any circumstance...") rather than soft framing ("read-only investigation") that leaves room for an agent to rationalize an exception.

3. **Protocol 4 (Local Review): verify agent self-reports.** Adds a rule that any agent claim of the form "I did X" / "X is now true" — especially a claim that a human already authorized something — must be checked against live `gh`/`git` state before being acted on or relayed to the user. Applies to sub-agent reports and to a session's own prior claims.

4. **Safety Boundaries: STRICT_PREPUSH=0 ask-first rule.** Adds `STRICT_PREPUSH=0` to the "Always Ask Before" list — agents may ask for permission to bypass local pre-push review for a specific push when genuinely blocking, must never set it unilaterally, and must never treat a past grant as standing authorization. References `~/.claude/docs/HUMAN-BYPASS.md`.

Verified no stale references remain to the old "two separate turns" / "STOP. Wait." framing anywhere else in the file (Quick Access header included). The `~/.claude/docs/HUMAN-BYPASS.md` path convention was checked against every other doc reference in the file for consistency (this required a follow-up fix after local pre-push review caught an initial relative-path mistake — see second commit).

## Test plan

- [x] Read full modified file back, grepped for stale "STOP. Wait." / "separate explicit authorizations" language — zero remaining occurrences
- [x] Confirmed merge-lock gate text is unchanged/intact (CI green + `merge-lock auth` requirement, `gh pr merge <number> --squash --delete-branch` as only allowed command)
- [x] Local pre-push review (adversarial-reviewer + codebase reviewer) ran and passed after fixing a path-convention bug it flagged
- [x] Docs-only change — no build/test step applies per this repo's own CLAUDE.md

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp