### PR TITLE
docs(human-bypass): document STRICT_PREPUSH=0 as user-only escape hatch

### DIFF
--- a/docs/HUMAN-BYPASS.md
+++ b/docs/HUMAN-BYPASS.md
@@ -1,6 +1,6 @@
 # Human Bypass Guide
 
-This document explains how YOU (the human operator) can bypass the hardened review hooks when legitimately needed. These bypasses are **not available to the Claude Code agent**.
+This document explains how YOU (the human operator) can bypass the hardened review hooks when legitimately needed. These bypasses are **not available to the Claude Code agent** — with one caveat: `STRICT_PREPUSH=0` (see [section 3](#3-skipping-local-pre-push-review-with-strict_prepush0)) is not technically hook-blocked for the agent the way `--no-verify` is. The rule keeping it human-only is behavioral, not enforced — the agent must ask your permission before setting it, every time, with no standing authorization.
 
 ---
 
@@ -10,6 +10,7 @@ This document explains how YOU (the human operator) can bypass the hardened revi
 |-----------|---------------|
 | Commit without review | `git commit --no-verify -m "message"` |
 | Push without checks | `git push --no-verify` |
+| Skip local pre-push review | `STRICT_PREPUSH=0 git push` (human-run; agent must ask permission first) |
 | Commit to main (emergency) | `git commit --no-verify -m "message"` (on main branch) |
 | Authorize PR merge | `~/.claude/hooks/merge-lock.sh authorize <PR#> "reason"` |
 | View blocked attempts | `~/.claude/scripts/blocked-audit.sh` |
@@ -47,7 +48,31 @@ git push --no-verify
 - Pushing to a branch that doesn't need Protocol 4 checks
 - Emergency deployments
 
-### 3. Authorizing PR Merges
+### 3. Skipping Local Pre-Push Review with STRICT_PREPUSH=0
+
+```bash
+# In your terminal
+STRICT_PREPUSH=0 git push
+```
+
+**What this gates:** the pre-push hook (`git/hooks/pre-push` in dotfiles) runs four non-interactive blocking review paths when a push happens inside Claude Code non-interactively (`CLAUDECODE=1`, stdin not a tty): the Semgrep supply-chain scan, Semgrep static analysis, the full-diff/codebase review, and a Protocol-4-equivalent PR-iteration checkpoint. `STRICT_PREPUSH=0` opts the push out of all four at once.
+
+**How it differs from `--no-verify`:** `--no-verify` is hook-blocked for the agent — a Claude Code `PreToolUse` hook intercepts and refuses the command before it runs. `STRICT_PREPUSH=0` is **not** currently intercepted by any hook. Nothing technically stops the agent from setting this environment variable and pushing. The distinction matters: everywhere else in this doc, "not available to the agent" is a technical fact. Here it is not.
+
+**The rule, because enforcement is behavioral, not technical:**
+
+- The agent must never set `STRICT_PREPUSH=0` on its own initiative.
+- The agent may ask you for permission to use it for a specific push, in the moment, when there's a concrete reason (e.g., a known-flaky check, an emergency, a push where local review genuinely doesn't apply).
+- Permission is per-push. A "yes" earlier in this conversation — or in a past conversation — does not carry forward. The agent must ask again next time, even if the situation looks identical.
+- If the agent sets `STRICT_PREPUSH=0` without asking, or claims you already authorized it when you didn't say so in the current exchange, that is a protocol violation worth calling out immediately.
+
+**When to use:**
+
+- You've reviewed the push yourself and judge local review unnecessary or redundant
+- A local review path is broken or timing out for reasons unrelated to the actual change
+- Emergency pushes where the four-check pipeline would cost time you don't have
+
+### 4. Authorizing PR Merges
 
 The agent cannot merge PRs without your authorization:
 
@@ -69,7 +94,7 @@ The agent cannot merge PRs without your authorization:
 3. You run the authorize command
 4. You tell the agent to proceed with merge
 
-### 4. Viewing Blocked Attempts
+### 5. Viewing Blocked Attempts
 
 See what the agent tried to bypass:
 
@@ -87,7 +112,7 @@ See what the agent tried to bypass:
 ~/.claude/scripts/blocked-audit.sh clear
 ```
 
-### 5. Committing Directly to Main
+### 6. Committing Directly to Main
 
 The agent is double-blocked from committing to main:
 


### PR DESCRIPTION
## Summary
- Companion to smartwatermelon/dotfiles#167.
- Adds a caveat to the intro: `STRICT_PREPUSH=0` is the one bypass in this doc that is *not* technically hook-blocked for the agent (unlike `--no-verify`, which is intercepted by a PreToolUse hook).
- Adds a Quick Reference row for `STRICT_PREPUSH=0 git push`.
- Inserts new section 3 ("Skipping Local Pre-Push Review with STRICT_PREPUSH=0") explaining what it gates (the four non-interactive review paths in the dotfiles pre-push hook: Semgrep SCA, Semgrep static analysis, full-diff/codebase review, Protocol 4 checkpoint), how it differs from `--no-verify`, and the behavioral rule: agent asks permission per-push, never assumes standing authorization.
- Renumbers old sections 3-5 to 4-6 accordingly.

## Test plan
- [x] Read full file back to confirm formatting/cross-references (fixed an anchor link that pointed at the wrong section number)
- [x] Local pre-push review (full-diff + codebase review): PASS
- [x] Confirmed no other doc in the repo references HUMAN-BYPASS.md section numbers that would break from the renumbering

## Note
The pre-push codebase reviewer filed two non-blocking issues (#290, #291) referencing a plan file (`vivid-petting-reddy.md`) not part of this task's scope — that plan apparently also calls for a CLAUDE.md addition documenting the STRICT_PREPUSH rule for agents directly (not just in HUMAN-BYPASS.md). That's out of scope for this PR since the task specification was explicitly doc-only (HUMAN-BYPASS.md + pre-push comments), but flagging for awareness — worth a follow-up PR if desired.

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp