### PR TITLE
docs: note external drift risk for STRICT_PREPUSH hook description

### DIFF
--- a/docs/HUMAN-BYPASS.md
+++ b/docs/HUMAN-BYPASS.md
@@ -57,6 +57,8 @@ STRICT_PREPUSH=0 git push
 
 **What this gates:** the pre-push hook (`git/hooks/pre-push` in dotfiles) runs four non-interactive blocking review paths when a push happens inside Claude Code non-interactively (`CLAUDECODE=1`, stdin not a tty): the Semgrep supply-chain scan, Semgrep static analysis, the full-diff/codebase review, and a Protocol-4-equivalent PR-iteration checkpoint. `STRICT_PREPUSH=0` opts the push out of all four at once.
 
+> **Drift risk:** the hook this section describes lives in an external dotfiles repo, not in this one — this repo has no version control over it and can't detect if it changes. This description reflects `git/hooks/pre-push` as of dotfiles commit `05c56a61bc0105e84aeb07b85bd944c2ed9cbe33` (2026-08-11). If actual behavior doesn't match what's described here, check `~/.config/git/hooks/pre-push` (symlinked to the dotfiles repo) directly rather than trusting this doc.
+
 **How it differs from `--no-verify`:** `--no-verify` is hook-blocked for the agent — a Claude Code `PreToolUse` hook intercepts and refuses the command before it runs. `STRICT_PREPUSH=0` is **not** currently intercepted by any hook. Nothing technically stops the agent from setting this environment variable and pushing. The distinction matters: everywhere else in this doc, "not available to the agent" is a technical fact. Here it is not.
 
 **The rule, because enforcement is behavioral, not technical:**


### PR DESCRIPTION
## Summary
- `docs/HUMAN-BYPASS.md` describes `STRICT_PREPUSH=0` behavior that's actually implemented in the dotfiles repo's `git/hooks/pre-push`, external to and unversioned by this repo.
- Adds a drift-risk callout pinning the description to dotfiles commit `05c56a61bc0105e84aeb07b85bd944c2ed9cbe33` (2026-08-11) and pointing readers to the live hook (`~/.config/git/hooks/pre-push`) if actual behavior ever diverges.

## Test plan
- [x] Doc-only change; markdown-only pre-commit path ran (code review correctly skipped)
- [x] Pre-push Semgrep + full-diff/codebase review both passed (VERDICT: PASS, no blocking issues)

Closes #291