### PR TITLE
fix(merge-lock): purge expired locks on list/status/check

### DIFF
--- a/hooks/merge-lock.sh
+++ b/hooks/merge-lock.sh
@@ -35,6 +35,27 @@ create_merge_lock() {
   echo -e "${GREEN}[merge-lock]${NC} Lock file: ${lock_file}"
 }
 
+purge_expired_locks() {
+  local now
+  now=$(date +%s)
+  local lock_file
+  for lock_file in "${LOCK_DIR}"/*.lock; do
+    [[ ! -f "${lock_file}" ]] && continue
+
+    local timestamp
+    timestamp=$(grep "^TIMESTAMP=" "${lock_file}" | cut -d= -f2)
+    [[ -z "${timestamp}" ]] && continue
+
+    local age=$((now - timestamp))
+    if [[ ${age} -gt ${LOCK_TTL_SECONDS} ]]; then
+      local pr
+      pr=$(grep "^PR_NUMBER=" "${lock_file}" | cut -d= -f2 || true)
+      rm -f "${lock_file}"
+      echo -e "${YELLOW}[merge-lock]${NC} Purged expired lock for PR #${pr:-?}"
+    fi
+  done
+}
+
 check_merge_lock() {
   local pr_number="$1"
   local lock_file="${LOCK_DIR}/pr-${pr_number}.lock"
@@ -158,6 +179,7 @@ case "${1:-help}" in
       echo "Usage: $0 check <pr_number>"
       exit 1
     fi
+    purge_expired_locks
     if check_merge_lock "$2"; then
       echo "Authorized"
       exit 0
@@ -171,9 +193,11 @@ case "${1:-help}" in
       echo "Usage: $0 status <pr_number>"
       exit 1
     fi
+    purge_expired_locks
     show_status "$2"
     ;;
   list)
+    purge_expired_locks
     list_locks
     ;;
   *)

--- a/tests/test_merge_lock_purge_expired.bats
+++ b/tests/test_merge_lock_purge_expired.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# Tests for on-use purge of expired merge-lock authorizations (issue #295).
+# Run: bats tests/test_merge_lock_purge_expired.bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/merge-lock.sh"
+
+# Read the TTL directly from the script rather than duplicating the literal,
+# so this test stays correct if LOCK_TTL_SECONDS is ever changed in-script.
+LOCK_TTL_SECONDS=$(grep -m1 "^LOCK_TTL_SECONDS=" "${BATS_TEST_DIRNAME}/../hooks/merge-lock.sh" | cut -d= -f2 | grep -o '^[0-9]*')
+
+setup() {
+  TMP_HOME="$(mktemp -d)"
+  readonly TMP_HOME
+  export HOME="${TMP_HOME}"
+}
+
+teardown() {
+  # TMP_HOME is readonly so a test can't reassign it out from under teardown,
+  # even if it reassigns HOME mid-test (see #116).
+  rm -rf "${TMP_HOME}"
+}
+
+lock_file() {
+  echo "${TMP_HOME}/.claude/merge-locks/pr-$1.lock"
+}
+
+write_backdated_lock() {
+  local pr_number="$1"
+  local age_seconds="$2"
+  local lock_dir="${TMP_HOME}/.claude/merge-locks"
+  mkdir -p "${lock_dir}"
+  local ts
+  ts=$(($(date +%s) - age_seconds))
+  {
+    echo "PR_NUMBER=${pr_number}"
+    echo "AUTHORIZED_BY=tester"
+    echo "TIMESTAMP=${ts}"
+    echo "REASON=test"
+  } >"${lock_dir}/pr-${pr_number}.lock"
+}
+
+@test "list purges an expired lock file" {
+  write_backdated_lock 100 $((LOCK_TTL_SECONDS + 60))
+  [ -f "$(lock_file 100)" ]
+
+  run bash "${SCRIPT}" list
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"Purged expired lock for PR #100"* ]]
+  [ ! -f "$(lock_file 100)" ]
+}
+
+@test "list does not purge a still-valid lock file" {
+  write_backdated_lock 200 60
+  [ -f "$(lock_file 200)" ]
+
+  run bash "${SCRIPT}" list
+  [ "${status}" -eq 0 ]
+  [ -f "$(lock_file 200)" ]
+}
+
+@test "status purges an expired lock file for a different PR" {
+  write_backdated_lock 300 $((LOCK_TTL_SECONDS + 60))
+  write_backdated_lock 301 60
+  [ -f "$(lock_file 300)" ]
+
+  run bash "${SCRIPT}" status 301
+  [ "${status}" -eq 0 ]
+  [ ! -f "$(lock_file 300)" ]
+  [ -f "$(lock_file 301)" ]
+}
+
+@test "check purges expired locks for other PRs" {
+  write_backdated_lock 400 $((LOCK_TTL_SECONDS + 60))
+  write_backdated_lock 401 60
+
+  run bash "${SCRIPT}" check 401
+  [ "${status}" -eq 0 ]
+  [ ! -f "$(lock_file 400)" ]
+  [ -f "$(lock_file 401)" ]
+}
+
+@test "list with only expired locks reports none active" {
+  write_backdated_lock 500 $((LOCK_TTL_SECONDS + 60))
+
+  run bash "${SCRIPT}" list
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"(none)"* ]]
+  [ ! -f "$(lock_file 500)" ]
+}
+
+@test "list on an empty lock dir does not error" {
+  run bash "${SCRIPT}" list
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"(none)"* ]]
+}


### PR DESCRIPTION
## Summary
- Adds `purge_expired_locks()` to `hooks/merge-lock.sh`, which sweeps `${LOCK_DIR}/*.lock` and removes any lock file older than `LOCK_TTL_SECONDS`, logging each removal.
- Wires the sweep into the `list`, `status`, and `check` command paths so stale locks (e.g. from abandoned PRs, or PRs where `check` was never re-run) no longer accumulate indefinitely — previously only `check_merge_lock()` self-purged, and only for the single PR it was asked about.
- `check_merge_lock()`'s own self-purge and return-code contract are unchanged.

## Test plan
- [x] `bats tests/test_merge_lock_purge_expired.bats` — new test file covering: expired lock purged on `list`, valid lock preserved on `list`, cross-PR purge on `status`, cross-PR purge on `check`, all-expired reports "(none)", empty lock dir does not error.
- [x] `bats tests/test_merge_lock_batch_auth.bats` — existing regression suite still passes unchanged.
- [x] `shellcheck -S info hooks/merge-lock.sh` — clean (errors, warnings, info).
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) and pre-push full-diff/codebase review both passed.

Closes #295