### PR TITLE
fix(hooks): include repo under review in disagreement issue title

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -338,7 +338,7 @@ file_reviewer_disagreement_issue() {
   [[ -z "${GH_ISSUE_FILING_DISABLED}" ]] || return 0
   command -v gh >/dev/null 2>&1 || return 0
 
-  local title="Reviewer disagreement: code-reviewer BLOCKING FAIL vs adversarial-reviewer PASS (arbiter: ${arbiter_verdict})"
+  local title="Reviewer disagreement in ${REPO_OWNER:-unknown}/${REPO_NAME:-unknown}: code-reviewer BLOCKING FAIL vs adversarial-reviewer PASS (arbiter: ${arbiter_verdict})"
   local body
   body=$(cat <<EOF
 ## Reviewer disagreement (auto-logged by run-review.sh)


### PR DESCRIPTION
## Summary
- `run-review.sh`'s auto-filed reviewer-disagreement issues intentionally always land in `smartwatermelon/claude-config` (central tracking, per dev-env#35) — that part is by design, not a bug.
- But the issue **title** gave no hint which repo the disagreement was actually about; the repo only appeared buried in the body. That made cross-repo disagreements (e.g. `beacon-biosignals/infra`) easy to overlook when auditing issues.
- Adds `${REPO_OWNER}/${REPO_NAME}` to the title, using the same fallback pattern (`:-unknown`) already used in the body.

Closes #314

## Test plan
- [x] `bash hooks/tests/run-review-test.sh` — 49/49 assertions pass
- [x] `shellcheck -S info hooks/run-review.sh` — no new findings
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Pre-push full-diff + codebase review: PASS

https://claude.ai/code/session_019Mo6i1qh3BpiykNX2GXFJa
