### PR TITLE
fix(scripts): collapse GraphQL/jq heredocs to single line in post-push-status.sh

### DIFF
--- a/scripts/post-push-status.sh
+++ b/scripts/post-push-status.sh
@@ -165,6 +165,9 @@ GQLEOF
   # above) so it survives `gh` wrapper argv round-trips that split on
   # embedded newlines. jq treats newlines as insignificant whitespace here
   # (no line comments in this filter), so behavior is unchanged.
+  # NOTE: do not add `#`-style jq line comments inside this heredoc --
+  # `tr '\n' ' '` would merge them into the following line instead of
+  # terminating them, silently corrupting the filter.
   local jq_filter
   jq_filter=$(
     cat <<'JQEOF' | tr '\n' ' '

--- a/scripts/post-push-status.sh
+++ b/scripts/post-push-status.sh
@@ -44,8 +44,16 @@ fi
 
 COMMIT_TIMESTAMP="${POSTPUSH_COMMIT_TIMESTAMP:-$(TZ=UTC git show -s --format=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' "${CURRENT_COMMIT}" 2>/dev/null || echo "")}"
 
+# Collapsed to a single line (newlines stripped) before being passed to `gh
+# api graphql -f query=...`. GraphQL treats newlines as insignificant
+# whitespace, so this is semantically identical to the multi-line form.
+# Required because some `gh` wrappers (e.g. an off-org draft-PR enforcement
+# shim) round-trip argv through `printf '%s\n' "$@" | mapfile -t`, which
+# splits any argument containing an embedded newline into multiple bogus
+# arguments -- producing errors like "accepts 1 arg(s), received 15" from
+# the underlying `gh` binary. A single-line query survives that round-trip.
 GQL_QUERY=$(
-  cat <<'GQLEOF'
+  cat <<'GQLEOF' | tr '\n' ' '
   query($owner:String!, $repo:String!, $number:Int!) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$number) {
@@ -126,9 +134,11 @@ _fetch_issue_comments_gql() {
   local owner="$1" repo="$2" number="$3"
   # Heredoc keeps $owner/$name/$number literal — they're GraphQL variables, not
   # bash expansions. `gh api -f owner=... -f name=... -F number=...` substitutes them.
+  # Collapsed to a single line (newlines stripped, see GQL_QUERY comment above)
+  # so it survives `gh` wrapper argv round-trips that split on embedded newlines.
   local query
   query=$(
-    cat <<'GQLEOF'
+    cat <<'GQLEOF' | tr '\n' ' '
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -151,9 +161,13 @@ GQLEOF
   # Reshape GraphQL nodes into REST-compatible objects so the python parser is
   # unchanged. Bot authors come back from GraphQL with `[bot]` stripped from
   # login; re-append it so BOT_PATTERN matches `claude[bot]`, `sentry[bot]`, etc.
+  # Collapsed to a single line (newlines stripped, see GQL_QUERY comment
+  # above) so it survives `gh` wrapper argv round-trips that split on
+  # embedded newlines. jq treats newlines as insignificant whitespace here
+  # (no line comments in this filter), so behavior is unchanged.
   local jq_filter
   jq_filter=$(
-    cat <<'JQEOF'
+    cat <<'JQEOF' | tr '\n' ' '
 .data.repository.pullRequest.comments.nodes
   | map(select(.isMinimized == false))
   | map({


### PR DESCRIPTION
## Summary

- Fixes `gh api graphql` failing with `accepts 1 arg(s), received 15` in `scripts/post-push-status.sh`.
- Root cause: this repo's `gh` wrapper (`~/.config/bash/gh-wrapper.sh` in the dotfiles repo) round-trips argv through `printf '%s\n' "$@" | mapfile -t` when applying off-org draft-PR enforcement. That round-trip splits any single argument containing an embedded newline into multiple bogus arguments. `post-push-status.sh` builds its GraphQL query and jq filter via multi-line heredocs and passes each as a single `-f query=...` / `--jq ...` argument — the embedded newlines get shredded by the wrapper, turning a 3-arg `gh api graphql` call into ~15 args.
- Fix: pipe each heredoc through `tr '\n' ' '` before use, collapsing it to a single line. GraphQL and jq both treat newlines as insignificant whitespace here (no `#` line comments in the jq filter), so this is a pure no-op semantically, but the resulting single-line string has no embedded newline left for the wrapper to mis-split.
- Added a defensive NOTE against ever adding `#`-style jq line comments to the now-collapsed heredoc, since `tr '\n' ' '` would silently merge such a comment into the following line.

This is a workaround in the caller, not a fix to the `gh` wrapper itself — the wrapper lives in a different repo (`smartwatermelon/dotfiles`) and is out of scope here. Fixes smartwatermelon/dotfiles#180.

## Test plan

- [x] `shellcheck -S info scripts/post-push-status.sh` — clean, no findings
- [x] `bash scripts/tests/test-post-push-status.sh` — 17/17 existing tests pass
- [x] Live verification against real merged PR #316 in this repo: `POSTPUSH_OWNER=smartwatermelon POSTPUSH_REPO=claude-config bash scripts/post-push-status.sh 316` — previously failed with `accepts 1 arg(s), received 15` / `CI_STATE=UNKNOWN`; now correctly returns `CI_STATE=SUCCESS` and parses bot findings
- [x] Minimal standalone repro confirming `printf '%s\n' "$@" | mapfile -t` splits any arg containing an embedded newline, and that a single-line arg survives the same round-trip intact
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS, both commits
- [x] Local pre-push review (Semgrep, full-diff review, codebase review): PASS

https://claude.ai/code/session_01N1j4BYRDeSmbsvxDdaaL69
