### PR TITLE
docs(claude): add "resolve the thing; don't match its label" to Verification Discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,16 @@ Before declaring work done, output the full Completion Verification template fro
 - Batch size ~3 changes, then verify against reality
 - More than 5 actions without verification = accumulating unjustified beliefs
 - **Chesterton's Fence**: Before removing anything, articulate why it exists
+- **Resolve the thing; don't match its label.** A name, tag, comment, or
+  count is a claim about state, not state. Follow it to what it actually
+  resolves to — and validate the check against a known-bad case first, or a
+  clean result proves nothing. Four wrong conclusions in one session came
+  from skipping this: a pinned SHA whose trailing `# v3` comment was four
+  months stale; an exact version tag that read as conformant while serving
+  pre-patch content; a green CI check whose job had skipped without
+  running; 62 transcript "mentions" of a tool never once invoked. Applies
+  to your own prior claims as much as to any agent's "I did X"
+  (see Protocol 4).
 
 ---
 


### PR DESCRIPTION
Adds a fifth principle to **Verification Discipline** in `CLAUDE.md`, drawn from a session where one failure mode produced four separate wrong conclusions.

## The pattern

Each case *looked* verified and wasn't, because the check matched a label instead of resolving what the label named:

| What was checked | Why it lied |
|---|---|
| A pinned commit SHA annotated `# v3` | The comment was four months stale, so a grep for tag refs classified it as current |
| An exact tag `@v3.1.0` | Immutable — read as conformant in every consumer file while serving pre-patch content |
| A green CI check | The job took a skip path and never invoked the reviewer; the checkmark attested to nothing |
| 62 transcript "mentions" of a tool | Zero actual dispatches — the mentions were its own listing text in the system prompt |

The second one was the expensive miss. It produced a fleet-wide "security advisory closed" report that was **wrong by 19 repos**, because the sweep grepped consumer files for a vulnerable SHA (finding none) without ever following each pinned tag to what it actually served.

## Why the second sentence matters as much as the first

> validate the check against a known-bad case first, or a clean result proves nothing

An audit that *cannot detect the problem* reports success indistinguishable from real success. After rewriting the sweep to resolve refs, it returned `vulnerable=0` — which was only meaningful because the same check still flagged a known-bad ref (`@v3.1.0`) as a control.

## Placement

Root `CLAUDE.md` rather than a child doc: it governs whether to trust a check at all, which is needed *before* you'd know which reference to open. It also generalizes an existing rule — Protocol 4 already says to verify agent claims of "I did X" against live state; this extends the same skepticism to tool output, comments, and counts, including one's own prior claims.

Ten lines, all non-derivable. File goes 14,454 → 15,126 chars, well under the ~40k memory-file warning threshold.

Verified the symlink at `~/.claude/CLAUDE.md` serves the new content.

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF