### PR TITLE
feat(review-issues): skip findings already tracked by an open issue

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -420,6 +420,171 @@ _repo_has_issues_enabled() {
   [[ "${_HAS_ISSUES_CACHE}" == "true" ]]
 }
 
+# ---------------------------------------------------------------
+# Deduplication against existing OPEN issues (#328)
+# ---------------------------------------------------------------
+#
+# The reviewer files a fresh issue for every finding it emits, with no
+# memory of what it already filed. In the field that produced 24 auto-filed
+# issues in one day, the largest single cluster being 8+ issues all
+# re-litigating one settled pinning-policy decision, plus repeat filings of
+# the same finding across successive PRs touching the same line.
+#
+# WHAT COUNTS AS "SIMILAR ENOUGH"
+#
+# Two signals, both required:
+#
+#   1. Same FILE PATH. The LOCATION field ("path/to/file.yml:23") is the
+#      most stable identity a finding has. Observed duplicates in
+#      smartwatermelon/dotfiles (#193 ":23", #195 ":31", #197 ":23") are the
+#      same objection at drifting line numbers, so the line suffix is
+#      stripped and only the path is compared. Findings with no usable path
+#      (LOCATION "general", or empty) are never deduped — there is no
+#      identity to match on, so they always file.
+#
+#   2. Overlapping TITLE keywords. Path alone is too blunt: two genuinely
+#      distinct findings in one large file would collide. Titles are model
+#      authored and get rephrased freely between runs (#193 "Reusable
+#      workflow reference moved from immutable SHA pin to mutable tag" vs
+#      #195 "claude.yml switched from immutable commit-SHA pin to mutable
+#      named tag"), so exact-title match catches none of the real
+#      duplicates. Instead both titles are reduced to lowercased
+#      alphanumeric tokens of 4+ characters, stopwords dropped, and a match
+#      requires at least _DEDUP_MIN_TOKEN_OVERLAP tokens in common. The pair
+#      above shares exactly two significant tokens ("immutable", "mutable"),
+#      which is why the threshold is 2 and not higher; an unrelated finding
+#      in the same file shares none.
+#
+# Deliberately NOT done here: commenting on the matched issue. That trades
+# one noise problem for another, and is out of scope for this change.
+#
+# FAILS OPEN. Only a successful listing that yields a confident match
+# suppresses a filing. A search error, timeout, empty/garbled response, or
+# missing jq output all fall through to filing the issue exactly as before —
+# same reasoning as _repo_has_issues_enabled(): a transient lookup failure
+# must never silently swallow a finding.
+
+# Minimum number of shared significant title tokens for a match.
+_DEDUP_MIN_TOKEN_OVERLAP=2
+
+# Common English words that carry no identifying signal about a finding.
+_DEDUP_STOPWORDS='this|that|with|from|when|then|than|were|will|would|should|could|have|been|does|into|only|also|same|such|they|them|there|where|which|while|about|after|before|being|other|using|used|make|made|more|most|some'
+
+# Reduce a title to a sorted, unique list of significant lowercase tokens
+# (alphanumeric, 4+ chars, stopwords removed), one per line.
+_dedup_title_tokens() {
+  printf '%s' "$1" |
+    { tr '[:upper:]' '[:lower:]' || true; } |
+    { tr -cs '[:alnum:]' '\n' || true; } |
+    { grep -E '^[[:alnum:]]{4,}$' || true; } |
+    { grep -vxE "${_DEDUP_STOPWORDS}" || true; } |
+    { sort -u || true; }
+}
+
+# Extract the bare file path from a LOCATION field, dropping any line-number
+# or line-range suffix. Prints nothing when LOCATION carries no real path.
+_dedup_location_path() {
+  local location="$1"
+  # Strip a trailing ":<digits>" or ":<digits>-<digits>" suffix.
+  local path_only="${location}"
+  path_only="$(printf '%s' "${path_only}" | sed -E 's/:[0-9]+(-[0-9]+)?[[:space:]]*$//')"
+  path_only="${path_only#"${path_only%%[![:space:]]*}"}"
+  path_only="${path_only%"${path_only##*[![:space:]]}"}"
+
+  # A usable path needs a path separator or an extension; bare words like
+  # "general" or "multiple files" carry no identity worth matching on.
+  case "${path_only}" in
+    "" | general | "multiple files" | various | n/a | N/A) return 0 ;;
+    *) ;;
+  esac
+  if [[ "${path_only}" == */* || "${path_only}" == *.* ]]; then
+    printf '%s' "${path_only}"
+  fi
+}
+
+# Cache of open issues for REPO_OWNER/REPO_NAME, as TSV: number, url, title,
+# location-path. Populated at most once per process (a single review can emit
+# many findings; one listing serves them all — same rationale and house style
+# as _HAS_ISSUES_CACHE).
+#
+# _OPEN_ISSUES_STATE is "" (not yet fetched), "ok" (usable listing, possibly
+# empty), or "error" (lookup failed — dedup disabled, everything files).
+_OPEN_ISSUES_CACHE=""
+_OPEN_ISSUES_STATE=""
+_load_open_issues() {
+  [[ -n "${_OPEN_ISSUES_STATE}" ]] && return 0
+
+  local raw jq_prog
+  # Literal jq program (single-quoted on purpose: $-free, and the escapes are
+  # jq's, not the shell's). Extracts the "**Location:** `path`" line that
+  # build_issue_body() writes into every auto-filed issue body.
+  # The backtick delimiters are written as \u0060 escapes rather than literal
+  # backticks so the single-quoted program contains no character the shell
+  # could read as a command substitution.
+  jq_prog='.[] | [(.number|tostring), .url, (.title|gsub("[\t\n\r]";" ")), ((.body // "" | capture("\\*\\*Location:\\*\\* \u0060(?<l>[^\u0060]*)\u0060").l) // "")] | @tsv'
+  # NOTE: no --search. The reviewer rephrases titles freely, so a keyword
+  # search would miss the very duplicates this targets; the whole open list
+  # is small (tens of issues) and is filtered locally instead. Untrusted
+  # model-authored text is therefore never interpolated into a query at all.
+  if ! raw=$(command gh issue list \
+    --repo "${REPO_OWNER}/${REPO_NAME}" \
+    --state open \
+    --limit 200 \
+    --json number,url,title,body \
+    --jq "${jq_prog}" 2>/dev/null); then
+    _OPEN_ISSUES_STATE="error"
+    return 0
+  fi
+
+  _OPEN_ISSUES_CACHE="${raw}"
+  _OPEN_ISSUES_STATE="ok"
+}
+
+# Find an existing OPEN issue that duplicates this finding.
+# Args: title location
+# Prints "<number>\t<url>" on a confident match; prints nothing otherwise.
+_find_duplicate_open_issue() {
+  local title="$1"
+  local location="$2"
+
+  local new_path
+  new_path=$(_dedup_location_path "${location}")
+  # No usable path identity -> never dedup, always file.
+  [[ -n "${new_path}" ]] || return 0
+
+  # NOTE: deliberately does NOT call _load_open_issues here. This function is
+  # invoked via command substitution, so any cache assignment it made would
+  # happen in a subshell and be discarded — the same trap documented above for
+  # _cached_gh_login, which is why that one re-runs `gh api user` every call.
+  # _process_issue_block primes the cache in the parent shell before calling
+  # this, so the listing really is fetched once per run.
+  # Fail open: a failed lookup disables dedup entirely for this run.
+  [[ "${_OPEN_ISSUES_STATE}" == "ok" ]] || return 0
+  [[ -n "${_OPEN_ISSUES_CACHE}" ]] || return 0
+
+  local new_tokens
+  new_tokens=$(_dedup_title_tokens "${title}")
+  [[ -n "${new_tokens}" ]] || return 0
+
+  local num url existing_title existing_loc existing_path overlap
+  while IFS=$'\t' read -r num url existing_title existing_loc; do
+    [[ -n "${num}" ]] || continue
+    existing_path=$(_dedup_location_path "${existing_loc}")
+    [[ -n "${existing_path}" ]] || continue
+    [[ "${existing_path}" == "${new_path}" ]] || continue
+
+    local existing_tokens shared
+    existing_tokens=$(_dedup_title_tokens "${existing_title}")
+    [[ -n "${existing_tokens}" ]] || continue
+    shared=$(comm -12 <(printf '%s\n' "${new_tokens}") <(printf '%s\n' "${existing_tokens}"))
+    overlap=$(printf '%s' "${shared}" | { grep -c . || true; })
+    if [[ "${overlap}" -ge "${_DEDUP_MIN_TOKEN_OVERLAP}" ]]; then
+      printf '%s\t%s' "${num}" "${url}"
+      return 0
+    fi
+  done <<<"${_OPEN_ISSUES_CACHE}"
+}
+
 # Parse a single issue block and create the GH issue (or fallback file).
 _process_issue_block() {
   local block="$1"
@@ -431,6 +596,24 @@ _process_issue_block() {
   _parse_issue_fields "${block}" title source location details
 
   [[ -n "${title}" ]] || return 0
+
+  # Dedup gate (#328): skip filing when an OPEN issue already tracks this
+  # same finding. Fails open — see _find_duplicate_open_issue.
+  local dup="" dup_num dup_url
+  if declare -F _find_duplicate_open_issue >/dev/null 2>&1 &&
+    declare -F _load_open_issues >/dev/null 2>&1; then
+    # Prime the open-issue cache in THIS shell (not inside the command
+    # substitution below, where the assignment would be lost to a subshell).
+    _load_open_issues
+    dup=$(_find_duplicate_open_issue "${title}" "${location}")
+  fi
+  if [[ -n "${dup}" ]]; then
+    dup_num="${dup%%$'\t'*}"
+    dup_url="${dup#*$'\t'}"
+    log_success "Skipped duplicate finding: ${title}"
+    log_success "  -> already tracked by #${dup_num} (${dup_url})"
+    return 0
+  fi
 
   # Determine labels
   local labels="tech-debt"

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -858,3 +858,247 @@ EOF
 
   _repo_has_issues_enabled
 }
+
+# --- dedup against existing open issues (#328) ---
+# The reviewer files one issue per finding with no memory of what it already
+# filed; in the field that produced 24 auto-filed issues in a day, the biggest
+# cluster being repeat filings of one settled objection. _process_issue_block
+# now skips a finding when an OPEN issue already tracks the same file path with
+# an overlapping title. Fails open: any lookup failure files as before.
+
+# Common loader for the dedup tests.
+_load_dedup_fns() {
+  _load_fn is_security_critical
+  _load_fn needs_security_label
+  _load_fn is_corporate_repo
+  _load_fn _cached_gh_login
+  _load_fn is_self_authored
+  _load_fn parse_nonblocking_issues
+  _load_fn build_issue_body
+  _load_fn _parse_issue_fields
+  _load_fn _write_pending_issue_file
+  _load_fn _repo_has_issues_enabled
+  _load_fn _dedup_title_tokens
+  _load_fn _dedup_location_path
+  _load_fn _load_open_issues
+  _load_fn _find_duplicate_open_issue
+  _load_fn create_nonblocking_issues
+  _load_fn _process_issue_block
+  # Constants the extracted functions reference (not picked up by _load_fn,
+  # which only extracts function definitions).
+  _DEDUP_MIN_TOKEN_OVERLAP=2
+  _DEDUP_STOPWORDS='this|that|with|from|when|then|than|were|will|would|should|could|have|been|does|into|only|also|same|such|they|them|there|where|which|while|about|after|before|being|other|using|used|make|made|more|most|some'
+  _OPEN_ISSUES_CACHE=""
+  _OPEN_ISSUES_STATE=""
+  _HAS_ISSUES_CACHE=""
+}
+
+# Mock gh whose `issue list` returns the given TSV rows and whose
+# `issue create` is recorded. $1 = TSV payload (may be empty).
+_mock_gh_with_open_issues() {
+  export DEDUP_LIST_PAYLOAD="$1"
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"api repos/"*) echo "true"; exit 0 ;;
+  *"issue list"*) printf '%s' "${DEDUP_LIST_PAYLOAD}"; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+}
+
+@test "dedup: finding matching an existing open issue is NOT filed" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # Existing open issue: the same objection, at a different line number.
+  _mock_gh_with_open_issues \
+"193	https://github.com/org/repo/issues/193	Reusable workflow reference moved from immutable SHA pin to mutable tag	.github/workflows/claude.yml:23"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: claude.yml switched from immutable commit-SHA pin to mutable named tag
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:31
+DETAILS: Same pinning objection, rephrased.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local created=0
+  grep -q "issue create" "${GH_CALLS_FILE}" && created=1
+  [[ "${created}" -eq 0 ]]
+}
+
+@test "dedup: a genuinely new finding is still filed" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # Open issue is in a different file entirely.
+  _mock_gh_with_open_issues \
+"193	https://github.com/org/repo/issues/193	Reusable workflow reference moved from immutable SHA pin to mutable tag	.github/workflows/claude.yml:23"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Handler does not validate the limit parameter
+SOURCE: Seer
+LOCATION: src/api/handler.ts:10
+DETAILS: Unvalidated input.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "dedup: two distinct findings in the SAME file are both filed" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # Same path as the new finding, but no meaningful title overlap — path
+  # alone must not be enough to suppress.
+  _mock_gh_with_open_issues \
+"193	https://github.com/org/repo/issues/193	Reusable workflow reference moved from immutable SHA pin to mutable tag	.github/workflows/claude.yml:23"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Concurrency group missing, queued runs cancel each other
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:80
+DETAILS: Unrelated concern in the same file.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "dedup: search failure files the issue anyway (fails open)" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # `gh issue list` fails outright (network/auth/rate limit). The finding is
+  # a textual duplicate of a real open issue, but a failed lookup must never
+  # silently suppress it.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"api repos/"*) echo "true"; exit 0 ;;
+  *"issue list"*) echo "error: could not connect" >&2; exit 1 ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Reusable workflow reference moved from immutable SHA pin to mutable tag
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:23
+DETAILS: Would have been deduped had the lookup succeeded.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "dedup: closed issues do not suppress a new filing" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # The listing is scoped to --state open, so a matching CLOSED issue simply
+  # never appears in the payload; the finding must file.
+  _mock_gh_with_open_issues ""
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Reusable workflow reference moved from immutable SHA pin to mutable tag
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:23
+DETAILS: Prior issue on this was closed.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local created=0
+  grep -q "issue create" "${GH_CALLS_FILE}" && created=1
+  local queried_open=0
+  grep -q -- "--state open" "${GH_CALLS_FILE}" && queried_open=1
+  [[ "${created}" -eq 1 && "${queried_open}" -eq 1 ]]
+}
+
+@test "dedup: title with shell metacharacters does not execute anything" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PWNED_FILE="${MOCK_DIR}/pwned"
+  export PWNED_FILE
+
+  _mock_gh_with_open_issues ""
+
+  # Title and location both carry command-substitution attempts, backticks
+  # and quotes. None may be evaluated by the dedup path.
+  local analysis='VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: broken $(touch "${PWNED_FILE}") and `touch "${PWNED_FILE}"` quoted'"'"'s
+SOURCE: code-reviewer
+LOCATION: src/$(touch "${PWNED_FILE}").ts:1
+DETAILS: Injection attempt.
+END_ISSUE'
+
+  create_nonblocking_issues "${analysis}"
+
+  [[ ! -e "${PWNED_FILE}" ]]
+}
+
+@test "dedup: open-issue listing is fetched once across many findings" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  _mock_gh_with_open_issues ""
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: First finding here
+SOURCE: Seer
+LOCATION: src/one.ts:1
+DETAILS: First.
+END_ISSUE
+
+NON_BLOCKING_ISSUE:
+TITLE: Second finding here
+SOURCE: Seer
+LOCATION: src/two.ts:2
+DETAILS: Second.
+END_ISSUE
+
+NON_BLOCKING_ISSUE:
+TITLE: Third finding here
+SOURCE: Seer
+LOCATION: src/three.ts:3
+DETAILS: Third.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local list_calls
+  list_calls=$(grep -c "issue list" "${GH_CALLS_FILE}" || true)
+  [[ "${list_calls}" -eq 1 ]]
+}


### PR DESCRIPTION
Closes #328

Implements **gate 1 only** of the five proposed in #328: deduplication against
existing open issues. Gates 2-5 (verify-against-HEAD, require-verifiable-claim,
severity threshold, per-PR cap) are separate judgment calls and are not
attempted here.

## What changed

`_process_issue_block()` now checks the target repo's open issues before
calling `gh issue create`. On a match it skips creation and logs the matched
issue number and URL. It does **not** comment on the existing issue — that
trades one noise problem for another.

## How "similar enough" is defined

Two signals, both required:

1. **Same file path** — from `LOCATION`, with any `:23` / `:14-19` suffix
   stripped. Grounded in the real duplicate cluster: `dotfiles#193` (`:23`),
   `#195` (`:31`) and `#197` (`:23`) are the same objection at drifting line
   numbers, so line numbers can't be part of the key. Findings with no usable
   path (`general`, empty) are never deduped — no identity to match on.
2. **>= 2 shared significant title tokens** — titles lowercased, split to
   alphanumeric tokens of 4+ chars, stopwords dropped.

Exact-title match was rejected because it catches none of the real duplicates
(#193 "Reusable workflow reference moved from immutable SHA pin to mutable tag"
vs #195 "claude.yml switched from immutable commit-SHA pin to mutable named
tag"). Path-only was rejected as too aggressive — two distinct findings in one
large file would collide. The #193/#195 pair shares exactly two tokens
(`immutable`, `mutable`), which is why the threshold is 2 and not higher.

Cross-checked against live data: all five open `tech-debt` issues in
`github-workflows` have distinct paths, so this gate would have suppressed
none of them.

## Fail-open

Any failed, empty, or ambiguous listing disables dedup for the run and the
finding files exactly as before — same documented reasoning as
`_repo_has_issues_enabled()`. A transient lookup failure must never silently
swallow a finding.

## Untrusted input

No model-authored text is ever interpolated into a query. Deliberately **no**
`--search`: the reviewer rephrases titles freely so keyword search would miss
these duplicates anyway, and filtering the (small) open list locally means
titles/locations are only ever compared as literal strings. A title containing
`$(...)` or backticks is inert.

## Caching

The listing is fetched once per process and primed **in the parent shell**.
`_find_duplicate_open_issue` runs inside a command substitution, so caching
there would be discarded with the subshell — the same trap already documented
in this file for `_cached_gh_login`. Caught by an explicit test.

## Tests

7 new cases in `tests/test_pre_merge_nonblocking.bats`:

- duplicate of an open issue -> not filed
- genuinely new finding -> filed
- distinct finding in the *same* file -> filed (path alone isn't enough)
- lookup failure -> filed (fail-open)
- closed issues -> do not suppress (listing is `--state open`)
- title with shell metacharacters -> inert, nothing executed
- listing fetched once across three findings

Nonblocking suite: **31 -> 38, all passing.** The 6 pre-existing tests in that
suite that load `_process_issue_block` without the new helpers are kept green
by a `declare -F` guard on the gate, which fails open when the helpers aren't
loaded.

Full suite: 149 -> 156 tests. The 8 pre-existing failures
(`gh_binary_wrapper`, `gh_wrapper`, `pre_merge_changes_requested`) are
unchanged by this branch and unrelated to it.

`shellcheck -S info hooks/lib-review-issues.sh` is clean, with no
suppression directives added.

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF
