### PR TITLE
feat(review-issues): flag findings that assert unchecked facts (#328 gate 3)

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -160,8 +160,16 @@ needs_security_label() {
   is_security_critical "${path_only}"
 }
 
-# Extract TITLE/SOURCE/LOCATION/DETAILS fields from a single issue block.
-# Writes results into the four nameref args (caller-declared local vars).
+# Extract TITLE/SOURCE/LOCATION/DETAILS/VERIFIED fields from a single issue
+# block. Writes results into the nameref args (caller-declared local vars).
+# The fifth nameref (VERIFIED, #328 gate 3) is OPTIONAL: callers that predate
+# it pass only four names, and the field is simply not extracted for them.
+#
+# VERIFIED is a multi-line field like DETAILS, but unlike DETAILS it is not
+# open-ended — it terminates at the next known field header so a VERIFIED:
+# block placed before DETAILS: doesn't swallow it. DETAILS keeps its original
+# swallow-everything behavior, but now stops at a VERIFIED: header for the
+# same reason.
 _parse_issue_fields() {
   local block="$1"
   local -n _pif_title="$2"
@@ -172,8 +180,15 @@ _parse_issue_fields() {
   _pif_title=$(echo "${block}" | { grep "^TITLE:" || true; } | { head -1 || true; } | sed 's/^TITLE: //')
   _pif_source=$(echo "${block}" | { grep "^SOURCE:" || true; } | { head -1 || true; } | sed 's/^SOURCE: //')
   _pif_location=$(echo "${block}" | { grep "^LOCATION:" || true; } | { head -1 || true; } | sed 's/^LOCATION: //')
-  # DETAILS may span multiple lines -- grab everything after the DETAILS: line
-  _pif_details=$(echo "${block}" | { awk '/^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+  # DETAILS may span multiple lines -- grab everything after the DETAILS: line,
+  # stopping at a VERIFIED: header if one follows.
+  _pif_details=$(echo "${block}" | { awk '/^VERIFIED:/{found=0} /^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+
+  # VERIFIED is optional and so is this nameref.
+  if [[ -n "${6:-}" ]]; then
+    local -n _pif_verified="$6"
+    _pif_verified=$(echo "${block}" | { awk '/^(TITLE|SOURCE|LOCATION|DETAILS):/{found=0} /^VERIFIED:/{found=1; sub(/^VERIFIED:[[:space:]]*/,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+  fi
 }
 
 # Write an issue body to the local pending-issues fallback dir.
@@ -368,6 +383,7 @@ create_nonblocking_issues() {
     # Ensure labels exist (idempotent) — only needed for the gh-issue path.
     command gh label create "tech-debt" --color "#e4e669" --description "Technical debt to address" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
     command gh label create "security" --color "#d93f0b" --description "Security-related concern" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
+    command gh label create "unverified" --color "#fbca04" --description "Finding asserts a fact that was never checked" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
   fi
 
   # Process each block (separated by ---ISSUE--- sentinel).
@@ -585,6 +601,105 @@ _find_duplicate_open_issue() {
   done <<<"${_OPEN_ISSUES_CACHE}"
 }
 
+# ---------------------------------------------------------------
+# Verifiable-claims gate (#328, gate 3)
+# ---------------------------------------------------------------
+#
+# On 2026-08-17 the reviewer filed several findings that asserted something
+# about external state and were simply WRONG, each costing a human a manual
+# disproof:
+#
+#   github-workflows#131 — asserted a specific actions/checkout SHA
+#     "belongs to the v4.x release line, not v7.0.1 (which does not exist
+#     for this action)". One `gh api` call resolves that. It was never run.
+#     The annotation under attack was correct.
+#   github-workflows#148 — asserted that quoting a variable in
+#     CLAUDE_ARGS="--model \"$MODEL\"" makes the string "now contain
+#     literal \" around the model name". One `echo` disproves that; bash
+#     resolves the escaping at assignment. The finding even said it "has
+#     not been tested in a live run" — and was filed anyway.
+#
+# The shared defect is NOT "the finding was wrong". It is: an assertion
+# about verifiable external state, made without checking it. That is what
+# this gate targets.
+#
+# WHAT IT DOES: annotate and label. It does NOT suppress. A finding whose
+# claim carries no supporting command still files — it just files carrying a
+# visible "unverified claim" caveat and an `unverified` label, so a human
+# reading the issue knows the assertion has not been checked before spending
+# time on it. Suppression is gate 1's job (dedup, above); a lost finding is
+# strictly worse than a labelled noisy one.
+#
+# FAILS OPEN in the strongest sense: there is no path through this code that
+# can prevent a filing. The worst case is that the caveat or the label is
+# missing.
+
+# Literal, deliberately small set of assertion markers. Matched
+# case-insensitively as fixed strings against TITLE + DETAILS. Kept dumb on
+# purpose: every entry here is a phrase that states external state is
+# factually wrong, as opposed to the hedged/suggestive phrasing ("consider",
+# "may want to", "it is unclear whether") that carries no factual claim and
+# so needs no verification. Do not grow this into a cleverness contest.
+_VERIFY_ASSERTION_MARKERS=(
+  "is incorrect"
+  "are incorrect"
+  "is wrong"
+  "is factually"
+  "does not exist"
+  "doesn't exist"
+  "will fail"
+  "is broken"
+  "never runs"
+)
+
+# Does this finding assert that something is factually incorrect/broken?
+# Args: title details
+# Returns 0 (true) on a match, 1 otherwise.
+_asserts_incorrectness() {
+  local haystack
+  haystack=$(printf '%s\n%s' "${1:-}" "${2:-}" | { tr '[:upper:]' '[:lower:]' || true; })
+
+  local marker
+  for marker in "${_VERIFY_ASSERTION_MARKERS[@]}"; do
+    # -F: the markers are fixed strings, and the haystack is model-authored
+    # text that must never be read as a pattern (or as anything else — it is
+    # passed on stdin, never interpolated into a command).
+    if printf '%s' "${haystack}" | grep -qF -- "${marker}"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Prepend the "unverified claim" caveat to an issue body.
+_unverified_caveat_body() {
+  local body="$1"
+  printf '%s\n' "> [!WARNING]"
+  printf '%s\n' "> **Unverified claim.** This finding asserts that something is"
+  printf '%s\n' "> incorrect, broken, or nonexistent, but carries no \`VERIFIED:\`"
+  printf '%s\n' "> field recording a command that was actually run to check it."
+  printf '%s\n' "> Confirm the assertion against reality before acting on it — several"
+  printf '%s\n' "> such findings have turned out to be false."
+  printf '%s\n' ""
+  printf '%s\n' "${body}"
+}
+
+# Append the "## Verification" section to an issue body.
+_verification_section_body() {
+  local body="$1"
+  local verified="$2"
+  printf '%s\n' "${body}"
+  printf '%s\n' ""
+  printf '%s\n' "## Verification"
+  printf '%s\n' ""
+  printf '%s\n' "The reviewer recorded the following command and output as support"
+  printf '%s\n' "for this finding:"
+  printf '%s\n' ""
+  printf '%s\n' '```'
+  printf '%s\n' "${verified}"
+  printf '%s\n' '```'
+}
+
 # Parse a single issue block and create the GH issue (or fallback file).
 _process_issue_block() {
   local block="$1"
@@ -592,8 +707,8 @@ _process_issue_block() {
 
   [[ -n "${block}" ]] || return 0
 
-  local title source location details
-  _parse_issue_fields "${block}" title source location details
+  local title source location details verified=""
+  _parse_issue_fields "${block}" title source location details verified
 
   [[ -n "${title}" ]] || return 0
 
@@ -624,6 +739,31 @@ _process_issue_block() {
   # Build issue body
   local body
   body=$(build_issue_body "${title}" "${source}" "${location}" "${details}")
+
+  # Verifiable-claims gate (#328 gate 3). Annotates only — never suppresses,
+  # and every branch here is wrapped so a failure still leaves ${body} and
+  # ${labels} usable and the filing proceeds untouched.
+  local unverified_label=false
+  if [[ -n "${verified}" ]]; then
+    if declare -F _verification_section_body >/dev/null 2>&1; then
+      local _body_with_verification
+      if _body_with_verification=$(_verification_section_body "${body}" "${verified}" 2>/dev/null); then
+        body="${_body_with_verification}"
+      fi
+    fi
+  elif declare -F _asserts_incorrectness >/dev/null 2>&1 &&
+    _asserts_incorrectness "${title}" "${details}" 2>/dev/null; then
+    if declare -F _unverified_caveat_body >/dev/null 2>&1; then
+      local _body_with_caveat
+      if _body_with_caveat=$(_unverified_caveat_body "${body}" 2>/dev/null); then
+        body="${_body_with_caveat}"
+        unverified_label=true
+      fi
+    fi
+  fi
+  if [[ "${unverified_label}" == true ]]; then
+    labels="${labels},unverified"
+  fi
 
   # Attempt to create GitHub issue — but only if the repo actually has
   # Issues enabled (#180). Repos with Issues disabled make `gh issue create`

--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -767,6 +767,7 @@ TITLE: [concise one-line title suitable for a GitHub issue — do not use quotes
 SOURCE: [reviewer or bot name, e.g. Seer, code-reviewer, or inline comment by alice]
 LOCATION: [file:line if applicable, or general]
 DETAILS: [2-4 sentences: what was flagged, why it matters, suggested action]
+VERIFIED: [optional — the command you actually ran and its observed output; see rules below]
 END_ISSUE
 
 IMPORTANT RULES for NON_BLOCKING_ISSUE:
@@ -775,6 +776,19 @@ IMPORTANT RULES for NON_BLOCKING_ISSUE:
 - Each block must start with NON_BLOCKING_ISSUE: on its own line and end with END_ISSUE on its own line.
 - DETAILS may span multiple lines.
 - Do not use quotes in TITLE values.
+- VERIFIABLE CLAIMS: if the finding asserts that something is incorrect, wrong,
+  broken, nonexistent, or will fail, and that assertion is about EXTERNAL STATE
+  you can check (what a commit SHA resolves to, what a file contains, whether a
+  version tag exists, how a tool or shell construct actually behaves), you must
+  either (a) run the command that checks it and record the command plus its
+  observed output in a VERIFIED: field, or (b) soften the claim into a question
+  instead of an assertion. Never assert a checkable fact you did not check.
+- VERIFIED: may span multiple lines and must come last in the block, after
+  DETAILS. Omit it entirely when the finding makes no factual claim about
+  external state (style, structure, maintainability concerns need no command).
+- Findings that assert incorrectness with no VERIFIED: field are still filed,
+  but carry an "unverified" label and a warning banner — past unverified
+  assertions of exactly this shape were false and cost a human time to disprove.
 
 Be conservative but pragmatic. If CI passes and concerns look addressed, allow merge.
 PROMPT_EOF

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -1104,7 +1104,28 @@ TITLE: <one-line title>
 SOURCE: pre-push whole-codebase review
 LOCATION: <file:line>
 DETAILS: <explanation of the pre-existing issue>
-END_ISSUE"
+VERIFIED: <optional; see VERIFIABLE CLAIMS below>
+END_ISSUE
+
+VERIFIABLE CLAIMS (mandatory):
+If a finding asserts that something is incorrect, wrong, broken, nonexistent,
+or will fail — and that assertion is about EXTERNAL STATE you can actually
+check (what a commit SHA resolves to, what a file contains, what a version
+tag points at, how a tool or shell construct actually behaves) — you must do
+ONE of these two things:
+  1. Run the command that checks it, and record the command and its observed
+     output in a VERIFIED: field on the block. Example:
+       VERIFIED: gh api repos/actions/checkout/git/ref/tags/v7.0.1 -q .object.sha
+       -> 3d3c42e5aac5ba805825da76410c181273ba90b1 (tag exists, SHA matches)
+  2. If you cannot run the check, SOFTEN the claim into a question rather
+     than an assertion — write \"is this SHA on the v4 line?\" instead of
+     \"this SHA belongs to the v4 line, not v7.0.1\".
+Never assert a checkable fact you did not check. Findings that assert
+incorrectness with no VERIFIED: field are filed with an \"unverified\" label
+and a warning banner, because past unverified assertions of exactly this
+shape turned out to be false and cost a human real time to disprove.
+VERIFIED: is optional and should be omitted entirely when the finding makes
+no factual claim about external state (style, structure, maintainability)."
 
   log_info "Running codebase reviewer with tool access..."
   codebase_start=$(date +%s)

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1102,3 +1102,191 @@ END_ISSUE"
   list_calls=$(grep -c "issue list" "${GH_CALLS_FILE}" || true)
   [[ "${list_calls}" -eq 1 ]]
 }
+
+# --- verifiable-claims gate (#328 gate 3) ---
+
+_load_gate3_fns() {
+  _load_dedup_fns
+  _load_fn _asserts_incorrectness
+  _load_fn _unverified_caveat_body
+  _load_fn _verification_section_body
+  # Marker array (not a function, so _load_fn does not pick it up). Kept in
+  # sync with the array in lib-review-issues.sh by sourcing it out of the
+  # script text rather than retyping it, so drift fails the test rather than
+  # silently testing a stale list.
+  eval "$(sed -n '/^_VERIFY_ASSERTION_MARKERS=(/,/^)$/p' "${SCRIPT}")"
+}
+
+# gh mock that records the full argv of each call, one call per line, so
+# tests can assert on --label and --body values.
+_mock_gh_recording() {
+  export DEDUP_LIST_PAYLOAD=""
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${*//$'\n'/ }" >> "${GH_CALLS_FILE}"
+case "$*" in
+  *"api repos/"*) echo "true"; exit 0 ;;
+  *"issue list"*) printf '%s' "${DEDUP_LIST_PAYLOAD}"; exit 0 ;;
+  *"issue create"*) echo "https://github.com/org/repo/issues/999"; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+}
+
+@test "gate3: assertion without VERIFIED is still filed AND labeled unverified" {
+  _load_gate3_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  _mock_gh_recording
+
+  # This is the shape of github-workflows#131: a flat assertion about what a
+  # SHA resolves to, with no command recorded.
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Pinned SHA does not match the annotated version
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:23
+DETAILS: The SHA belongs to the v4.x release line, and v7.0.1 does not exist for this action.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local create_line
+  create_line=$(grep "issue create" "${GH_CALLS_FILE}")
+  # Filed (fail open — the gate annotates, never suppresses) ...
+  [[ -n "${create_line}" ]]
+  # ... with the unverified label added alongside the existing ones ...
+  echo "${create_line}" | grep -q "tech-debt,unverified"
+  # ... and the caveat banner in the body.
+  echo "${create_line}" | grep -q "Unverified claim"
+}
+
+@test "gate3: assertion WITH VERIFIED is filed clean, with a Verification section" {
+  _load_gate3_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  _mock_gh_recording
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Pinned SHA does not match the annotated version
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:23
+DETAILS: The comment claims v7.0.1 but the SHA does not exist under that tag.
+VERIFIED: gh api repos/actions/checkout/git/ref/tags/v7.0.1 -> HTTP 404 Not Found
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local create_line
+  create_line=$(grep "issue create" "${GH_CALLS_FILE}")
+  [[ -n "${create_line}" ]]
+  # Verification section present ...
+  echo "${create_line}" | grep -q "## Verification"
+  echo "${create_line}" | grep -q "HTTP 404 Not Found"
+  # ... and NO unverified label or caveat, since the claim carries support.
+  ! echo "${create_line}" | grep -q "unverified"
+  ! echo "${create_line}" | grep -q "Unverified claim"
+  # The VERIFIED: line must not leak into DETAILS / "What was flagged".
+  ! echo "${create_line}" | grep -q "VERIFIED: gh api"
+}
+
+@test "gate3: a non-assertion finding is untouched" {
+  _load_gate3_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  _mock_gh_recording
+
+  # Hedged, suggestive phrasing — makes no factual claim about external
+  # state, so it needs no VERIFIED: field and must not be labelled.
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Consider extracting the retry loop into a helper
+SOURCE: code-reviewer
+LOCATION: src/api/handler.ts:42
+DETAILS: The retry logic is duplicated in three places. Extracting it would reduce drift.
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local create_line
+  create_line=$(grep "issue create" "${GH_CALLS_FILE}")
+  [[ -n "${create_line}" ]]
+  ! echo "${create_line}" | grep -q "unverified"
+  ! echo "${create_line}" | grep -q "Unverified claim"
+  ! echo "${create_line}" | grep -q "## Verification"
+}
+
+@test "gate3: title/details/VERIFIED with shell metacharacters execute nothing" {
+  _load_gate3_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PWNED_FILE="${MOCK_DIR}/pwned_gate3"
+  export PWNED_FILE
+  _mock_gh_recording
+
+  # All three model-authored fields carry command substitution, backticks and
+  # quotes, AND the block trips the assertion markers so the whole gate-3
+  # code path runs over the hostile text.
+  local analysis='VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: config $(touch "${PWNED_FILE}") is incorrect and `touch "${PWNED_FILE}"` is broken
+SOURCE: code-reviewer
+LOCATION: src/$(touch "${PWNED_FILE}").ts:1
+DETAILS: The value $(touch "${PWNED_FILE}") does not exist; `touch "${PWNED_FILE}"` will fail.
+VERIFIED: $(touch "${PWNED_FILE}") && `touch "${PWNED_FILE}"`
+END_ISSUE'
+
+  create_nonblocking_issues "${analysis}"
+
+  [[ ! -e "${PWNED_FILE}" ]]
+}
+
+@test "gate3: failure inside the gate does not block filing (fails open)" {
+  _load_gate3_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  _mock_gh_recording
+
+  # Simulate the gate's helpers being broken/absent at runtime. The filing
+  # must proceed exactly as it did before gate 3 existed — a lost finding is
+  # worse than an unannotated one.
+  _asserts_incorrectness() { return 1; }
+  _unverified_caveat_body() { return 1; }
+  _verification_section_body() { return 1; }
+
+  local analysis="VERDICT: SAFE_TO_MERGE
+
+NON_BLOCKING_ISSUE:
+TITLE: Pinned SHA does not match and the tag does not exist
+SOURCE: code-reviewer
+LOCATION: .github/workflows/claude.yml:23
+DETAILS: This assertion is broken and will fail.
+VERIFIED: some command output
+END_ISSUE"
+
+  create_nonblocking_issues "${analysis}"
+
+  local create_line
+  create_line=$(grep "issue create" "${GH_CALLS_FILE}")
+  # Filed, with the original body and the original labels intact.
+  [[ -n "${create_line}" ]]
+  echo "${create_line}" | grep -q "Non-Blocking Review Concern"
+  ! echo "${create_line}" | grep -q "unverified"
+}
+
+@test "gate3: _asserts_incorrectness matches markers case-insensitively and only on real assertions" {
+  _load_gate3_fns
+
+  _asserts_incorrectness "The SHA is incorrect" ""
+  _asserts_incorrectness "" "This IS WRONG in the general case"
+  _asserts_incorrectness "Tag v7.0.1 does not exist" ""
+  _asserts_incorrectness "The job never runs" ""
+  ! _asserts_incorrectness "Consider extracting the retry loop" "Would reduce drift."
+  ! _asserts_incorrectness "It is unclear whether this path is reachable" "May want to check."
+}


### PR DESCRIPTION
Implements gate 3 (verifiable claims) for the local review-issue filing path. Closes part of #328. Gate 1 (dedup) shipped in #331; this follows its conventions.

## The failure mode

The reviewer files a GitHub issue for every `NON_BLOCKING_ISSUE` block. On 2026-08-17 several of those were factually wrong, and each cost a human real time to disprove. Both examples are now closed:

- **github-workflows#131** claimed SHA `3d3c42e5aac5ba805825da76410c181273ba90b1` for `actions/checkout` "belongs to the v4.x release line, not v7.0.1 (which does not exist for this action)". That is an assertion about a specific external object, resolvable with one `gh api` call. The reviewer never ran it. The annotation it attacked was correct.
- **github-workflows#148** claimed that changing `CLAUDE_ARGS="--model $MODEL"` to `CLAUDE_ARGS="--model \"$MODEL\""` means the string "now contains literal `\"` around the model name". One `echo` disproves it — bash resolves the escaping at assignment. The finding even admitted it "has not been tested in a live run", and was filed anyway.

The shared defect is **not** "the finding was wrong". It is: *an assertion about verifiable external state, made without checking it.* That is the thing gated here.

## Design

**Part A — prompt.** The `NON_BLOCKING_ISSUE` format gains an optional `VERIFIED:` field where the reviewer records the command it actually ran and the output it observed. Both prompt sites (`hooks/run-review.sh`, `hooks/pre-merge-review.sh`, including the latter's IMPORTANT RULES list) now instruct: if a finding asserts something about external state — what a SHA resolves to, what a file contains, whether a version exists, how a tool or shell construct behaves — either run the check and record it, or soften the claim into a question instead of an assertion.

**Part B — shell gate** (`hooks/lib-review-issues.sh`):

- `_parse_issue_fields` extracts `VERIFIED` via an **optional sixth nameref**, so existing four-arg callers (`_process_issue_block_apple_note`, `_format_issue_bullet`) are untouched.
- `_process_issue_block` matches a small, literal, case-insensitive set of assertion markers (`is incorrect`, `does not exist`, `will fail`, `is broken`, `never runs`, …) against title+details — placed **after** the dedup gate and **before** `gh issue create`.
- Assertion **without** `VERIFIED:` → issue is still filed, plus a `> [!WARNING]` "Unverified claim" banner prepended to the body and an `unverified` label alongside the existing ones.
- `VERIFIED:` present → rendered as a `## Verification` section in the body.

## Why it annotates rather than suppresses

Suppression is gate 1's job. A lost finding is strictly worse than a labelled noisy one — the whole point of the filing path is that concerns don't evaporate. This gate changes only what a human sees when they open the issue: a visible signal that the assertion has not been checked, so they know to confirm it before spending time on it.

## Fail-open property

There is no path through the new code that can prevent a filing. Every branch is guarded (`declare -F` presence checks, command-substitution failures caught, stderr suppressed) such that any error leaves `${body}` and `${labels}` in their pre-gate state and the filing proceeds exactly as it did before this change. The worst case is a missing caveat or a missing label — never a missing issue. A dedicated test asserts this by breaking all three helpers at runtime.

## Injection safety

`TITLE`, `DETAILS` and `VERIFIED` are model-authored and are never `eval`'d or interpolated into a shell command. Marker matching pipes the text to `grep -qF` on **stdin** (fixed-string, so the haystack is never read as a pattern). This follows gate 1's approach, which deliberately avoids `gh --search` for the same reason. A test drives command substitution, backticks and quotes through all three fields simultaneously while tripping the assertion markers, and asserts nothing executes.

## Verification

- **Tests:** 6 new cases in `tests/test_pre_merge_nonblocking.bats`, 38 → 44 in that file, all passing. Coverage: assertion-without-VERIFIED files and is labelled; assertion-with-VERIFIED files clean with a Verification section and no label leak; non-assertions untouched; shell metacharacters in all three fields execute nothing; a broken gate still files; marker matching is case-insensitive and does not fire on hedged phrasing.
- **Full suite:** `bats tests/` → **154 passing**. The same **8 failures** are present on the unmodified baseline (gh-wrapper merge routing, `CHANGES_REQUESTED` output) — both unrelated to this path, verified by stashing.
- **shellcheck -S info:** `hooks/lib-review-issues.sh` — the only file receiving logic — is **completely clean**. The other two files received prompt-string edits only and report exactly their baseline findings (SC2249 at `run-review.sh:88`, SC1091 source-resolution notices), verified identical against the stashed baseline. No `# shellcheck disable` directives added.
- Local `code-reviewer` and `adversarial-reviewer` both returned PASS at commit time. No `--no-verify`, no `SKIP=`.

## Scope

Gate 3 only — gates 2, 4 and 5 are not implemented here. Scoped to claude-config's local filing path; the CI reviewer in `github-workflows` is untouched.

https://claude.ai/code/session_0165j8uC57NWoexNQ6wwbLC8
