### PR TITLE
fix(review-issues): flag self-admitted-unverified findings (#337); reject #334's broad markers

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -640,7 +640,31 @@ _find_duplicate_open_issue() {
 # factually wrong, as opposed to the hedged/suggestive phrasing ("consider",
 # "may want to", "it is unclear whether") that carries no factual claim and
 # so needs no verification. Do not grow this into a cleverness contest.
+#
+# Two groups, both narrow:
+#
+#   1. Direct assertions — "X is incorrect".
+#   2. Self-admitted-unverified assertions (#337) — the finding makes a
+#      factual claim and states in the same breath that it never checked it.
+#      github-workflows#148 is the motivating case: it asserted a bash
+#      escaping behaviour, then wrote "has not been tested in a live run",
+#      and was filed anyway. It turned out to be wrong. This is NOT the
+#      harmless hedging described above: a claim the author flags as
+#      unchecked is precisely what this gate exists to label.
+#
+# Calibrated against a 137-finding corpus of every reviewer-filed issue
+# across the fleet (see PR for the measurement). The phrases proposed in
+# claude-config#334 were measured and deliberately REJECTED:
+#   - "is not present" / "cannot be found" / "contains no" -> 0 real matches
+#   - "is not" (9 matches) and "has no" (9) are far too broad. In the corpus
+#     they overwhelmingly catch the reviewer being CAREFUL — "this is not a
+#     correctness issue", "is not currently vulnerable", "this is not a
+#     confirmed regression". Flagging those as unverified assertions would
+#     invert the gate's meaning and punish exactly the phrasing we want.
+# The additions below flag exactly one more finding in 137 (#148) and zero
+# false positives. Re-run the measurement before adding anything.
 _VERIFY_ASSERTION_MARKERS=(
+  # Group 1: direct assertions of incorrectness.
   "is incorrect"
   "are incorrect"
   "is wrong"
@@ -650,6 +674,12 @@ _VERIFY_ASSERTION_MARKERS=(
   "will fail"
   "is broken"
   "never runs"
+  # Group 2: the finding admits, in its own text, that it never checked.
+  "has not been tested"
+  "has not been verified"
+  "has not been confirmed"
+  "was not verified"
+  "not been validated"
 )
 
 # Does this finding assert that something is factually incorrect/broken?

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1290,3 +1290,36 @@ END_ISSUE"
   ! _asserts_incorrectness "Consider extracting the retry loop" "Would reduce drift."
   ! _asserts_incorrectness "It is unclear whether this path is reachable" "May want to check."
 }
+
+@test "gate3: self-admitted-unverified phrasing is flagged (#337, github-workflows#148)" {
+  _load_gate3_fns
+
+  # The motivating case: a factual claim about bash escaping, with the
+  # finding itself stating it was never checked. Filed anyway; turned out
+  # to be wrong.
+  _asserts_incorrectness \
+    '`--model` argument now double-quoted in assembled claude_args string' \
+    'The behavior change is real. But it differs from the pre-existing unquoted form and has not been tested in a live run.'
+
+  _asserts_incorrectness "" "This has not been verified against the live API."
+  _asserts_incorrectness "" "The mapping has not been confirmed on a real run."
+  _asserts_incorrectness "" "The regex was not verified against the actual input."
+  _asserts_incorrectness "" "This path has not been validated end to end."
+}
+
+@test "gate3: broad negative phrasing stays UNflagged (rejected #334 candidates)" {
+  _load_gate3_fns
+
+  # Measured against a 137-finding corpus: "is not" and "has no"
+  # overwhelmingly catch the reviewer being CAREFUL, not asserting.
+  # Flagging these would invert the gate's meaning.
+  ! _asserts_incorrectness "" "This is not a correctness issue — capped PRs simply wait."
+  ! _asserts_incorrectness "" "It is not currently vulnerable, but a future refactor could change that."
+  ! _asserts_incorrectness "" "This is not a confirmed regression — it may be correct as written."
+  ! _asserts_incorrectness "" "The --verbose flag has no observable effect."
+  ! _asserts_incorrectness "" "This has no practical impact, but the directive is dead."
+
+  # Phrases #334 proposed that never occur in the real corpus.
+  ! _asserts_incorrectness "" "The entry is not present in the allowlist."
+  ! _asserts_incorrectness "" "The helper cannot be found on PATH."
+}


### PR DESCRIPTION
Closes #337. Proposes closing #334 as **measured and rejected** — see below.

Gate 3 shipped in #336 catching direct assertions ("X is incorrect"), but missed the *second* finding that motivated it.

## The gap

`github-workflows#148` asserted a bash escaping behaviour, then wrote **"has not been tested in a live run"** in the same paragraph, and was filed anyway. It was wrong.

The marker comment treats hedged phrasing as harmless — "consider", "may want to" — because it carries no factual claim. #148 is a third category the original design missed: **a factual claim whose own author flags it as unchecked.** That is precisely what this gate exists to label.

## Method: measure, don't guess

I built a corpus of **all 137 reviewer-filed issues** across `github-workflows`, `claude-config`, `dotfiles`, `dev-env`, and `homebrew-tap`, stripped the gate-3 banner so the original text was measured, and ran candidate markers against it.

Current markers flag 16/137 (12%).

## What #334 proposed, and why it's rejected

#334 asked for "is not present", "cannot be found", "is missing", "has no", "contains no". Measured:

| candidate | new matches in 137 |
|---|---|
| `is not present` | **0** |
| `cannot be found` | **0** |
| `contains no` | **0** |
| `is missing` | 2 |
| `is not` | 9 |
| `has no` | 9 |

The specific phrases #334 names **never occur**. The two that do match are far too broad — and looking at *what* they catch is the argument against them:

> "this **is not** a correctness issue — capped PRs simply wait"
> "it **is not** currently vulnerable. however, if a future..."
> "this **is not** a confirmed regression — it may be correct"
> "`--verbose` **has no** observable effect"
> "markdown **has no** comment syntax"

Those are the reviewer being **careful**. Flagging them as unverified assertions would invert the gate's meaning and penalise exactly the phrasing we want reviewers to use.

## What this PR adds instead

Five narrow Group-2 markers for self-admitted-unverified claims: `has not been tested`, `has not been verified`, `has not been confirmed`, `was not verified`, `not been validated`.

Measured effect: **flags exactly one more finding in 137 (#148), zero false positives.**

## Tests

44 → 46. One test pins the motivating #148 text; the other pins the **rejected** candidates as must-not-flag, so any future widening has to argue with a failing test rather than a comment.

Full suite: 156 passing. The 8 failures are pre-existing — I diffed the failure set against the stashed baseline and it is byte-identical (gh-wrapper merge routing, `CHANGES_REQUESTED` output), not merely the same count.

`shellcheck -S info`: clean. No disable directives.

https://claude.ai/code/session_0165j8uC57NWoexNQ6wwbLC8