### PR TITLE
fix(run-review): record reviewer disagreements in a local log, file issues only on arbiter FAIL

### DIFF
--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -324,40 +324,102 @@ invoke_agent() {
   fi
 }
 
-# Files a GitHub issue in smartwatermelon/claude-config (the reviewer
-# infrastructure's OWN repo — hardcoded, never REPO_OWNER/REPO_NAME, which
-# is the repo under review) logging a code-reviewer/adversarial-reviewer
-# disagreement and how the arbiter resolved it. Best-effort: never blocks
-# the commit regardless of gh auth state or API errors. dev-env#35's own
-# investigation asked for this so recurring disagreement patterns are
-# visible for future prompt/model tuning instead of silently resolved
-# and forgotten each time.
+# Records a code-reviewer/adversarial-reviewer disagreement and how the
+# arbiter resolved it. claude-config#332 reworked this: it used to file a
+# GitHub issue on EVERY disagreement, which had three defects.
+#
+#   1. Wrong destination. The destination repo is hardcoded to
+#      smartwatermelon/claude-config, but four of the six issues ever filed
+#      were about beacon-biosignals/infra — a different org entirely.
+#   2. Leaked reviewed source. The body pasted all three reviewers' verbatim
+#      output, which quotes code from the repo under review. Another org's
+#      Terraform (module wiring, cluster names, bucket refs) ended up in a
+#      personal repo purely as a side effect.
+#   3. Fired on the healthy case. The arbiter ruled PASS in 5 of 6. A strict
+#      reviewer disagreeing with a skeptical one is the system working, not
+#      a defect worth a tracked issue.
+#
+# New behavior:
+#   * The LOCAL LOG is the default record. Every disagreement appends a full
+#     verbatim record (all three reviewers) to ${DISAGREEMENT_LOG}, a sibling
+#     of REVIEW_LOG inside this repo's .git/. Verbatim is fine there: it never
+#     leaves the machine and it stays with the repo it describes.
+#   * A GitHub issue is filed ONLY when the arbiter verdict is FAIL. That is
+#     the case where the disagreement says something about the TOOLING (a
+#     reviewer produced a finding the arbiter upheld against a PASS), which is
+#     why the destination stays hardcoded to this infrastructure's own repo.
+#   * When an issue IS filed, it carries only metadata and the arbiter's own
+#     reasoning — our tooling's summary, not reviewed source. Reviewer output
+#     stays in the local log, which the issue points at by path.
+#   * Deduped on (repo, branch) using the local log as the source of truth, so
+#     a long-running branch files at most once no matter how many pushes it
+#     takes. Issues #323/#324/#325 were one branch re-filing on every push.
+#
+# Best-effort throughout: this must never block or fail a commit, whatever
+# the gh auth state, API result, or writability of the log path.
+#
+# Reviewer output is MODEL-AUTHORED and untrusted. It is only ever written to
+# a file via printf with a literal format string — never eval'd, never
+# interpolated into a command, never passed to a search query.
 file_reviewer_disagreement_issue() {
   local cr_output="$1" ar_output="$2" arbiter_output="$3" arbiter_verdict="$4"
 
+  local repo_slug="${REPO_OWNER:-unknown}/${REPO_NAME:-unknown}"
+  local branch="${_review_branch:-unknown}"
+  local commit="${_review_commit:-unknown}"
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+
+  # Dedup key: one line per (repo, branch) that has already produced an issue.
+  # Read back from the local log before deciding to file again.
+  local dedup_marker="filed-issue-for: ${repo_slug} ${branch}"
+  local already_filed="no"
+  if [[ -n "${DISAGREEMENT_LOG}" && -r "${DISAGREEMENT_LOG}" ]]; then
+    if grep -qxF -- "${dedup_marker}" "${DISAGREEMENT_LOG}" 2>/dev/null; then
+      already_filed="yes"
+    fi
+  fi
+
+  # --- 1. Local log: the default record, written on every disagreement ---
+  # This runs even when GH_ISSUE_FILING_DISABLED is set: that is a filing
+  # guard, not a logging guard.
+  if [[ -n "${DISAGREEMENT_LOG}" ]]; then
+    {
+      printf -- '=== REVIEWER DISAGREEMENT %s ===\n' "${ts}"
+      printf -- 'repo: %s\n' "${repo_slug}"
+      printf -- 'branch: %s\n' "${branch}"
+      printf -- 'commit: %s\n' "${commit}"
+      printf -- 'arbiter_model: %s\n' "${ARBITER_MODEL:-unknown}"
+      printf -- 'arbiter_verdict: %s\n' "${arbiter_verdict}"
+      printf -- '--- code-reviewer output ---\n%s\n' "${cr_output}"
+      printf -- '--- adversarial-reviewer output ---\n%s\n' "${ar_output}"
+      printf -- '--- arbiter reasoning ---\n%s\n' "${arbiter_output}"
+      printf -- '=== END DISAGREEMENT ===\n'
+    } >>"${DISAGREEMENT_LOG}" 2>/dev/null || true
+  fi
+
+  # --- 2. GitHub issue: only for arbiter FAIL, and only once per (repo, branch) ---
+  [[ "${arbiter_verdict}" == "FAIL" ]] || return 0
+  [[ "${already_filed}" == "no" ]] || return 0
   [[ -z "${GH_ISSUE_FILING_DISABLED}" ]] || return 0
   command -v gh >/dev/null 2>&1 || return 0
 
-  local title="Reviewer disagreement in ${REPO_OWNER:-unknown}/${REPO_NAME:-unknown}: code-reviewer BLOCKING FAIL vs adversarial-reviewer PASS (arbiter: ${arbiter_verdict})"
+  local title="Reviewer disagreement upheld by arbiter in ${repo_slug} (branch ${branch})"
   local body
   body=$(cat <<EOF
-## Reviewer disagreement (auto-logged by run-review.sh)
+## Reviewer disagreement, arbiter verdict FAIL (auto-logged by run-review.sh)
 
-**Repo under review:** ${REPO_OWNER:-unknown}/${REPO_NAME:-unknown}
-**Branch:** ${_review_branch:-unknown}
-**Commit:** ${_review_commit:-unknown}
-**Arbiter model:** ${ARBITER_MODEL}
+code-reviewer returned a BLOCKING FAIL, adversarial-reviewer returned PASS,
+and the arbiter upheld code-reviewer. Filed here — in the reviewer
+infrastructure's own repo — because an arbiter FAIL is a fact about the
+TOOLING, not about the code that happened to be under review.
+
+**Repo under review:** ${repo_slug}
+**Branch under review:** ${branch}
+**Commit:** ${commit}
+**Arbiter model:** ${ARBITER_MODEL:-unknown}
 **Arbiter verdict:** ${arbiter_verdict}
-
-### code-reviewer output
-\`\`\`
-${cr_output}
-\`\`\`
-
-### adversarial-reviewer output
-\`\`\`
-${ar_output}
-\`\`\`
+**Local log (full verbatim reviewer output):** \`${DISAGREEMENT_LOG}\`
 
 ### Arbiter reasoning
 \`\`\`
@@ -365,16 +427,26 @@ ${arbiter_output}
 \`\`\`
 
 ---
-Filed automatically to track disagreement frequency and patterns for
-future code-reviewer prompt/model tuning. See smartwatermelon/dev-env#35.
+code-reviewer and adversarial-reviewer output is deliberately NOT reproduced
+here: it quotes source from the repo under review, which may belong to a
+different org (claude-config#332). Read it from the local log path above on
+the machine that ran the review.
+
+Deduped on (repo under review, branch) — one branch files at most one issue.
+See smartwatermelon/dev-env#35 and claude-config#332.
 EOF
 )
 
-  gh issue create --repo "smartwatermelon/claude-config" \
+  if gh issue create --repo "smartwatermelon/claude-config" \
     --title "${title}" \
     --body "${body}" \
     --label "tech-debt" \
-    >/dev/null 2>&1 || true
+    >/dev/null 2>&1; then
+    # Record the dedup marker only on a confirmed successful file, so a
+    # transient gh failure doesn't permanently suppress the issue.
+    [[ -n "${DISAGREEMENT_LOG}" ]] && printf -- '%s\n' "${dedup_marker}" >>"${DISAGREEMENT_LOG}" 2>/dev/null
+  fi
+  return 0
 }
 
 # --- Helper Functions for Progressive Review ---
@@ -761,6 +833,12 @@ DIFF=$(cat)
 # the repo and commit they just made.
 GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || echo ".git")"
 REVIEW_LOG="${REVIEW_LOG:-${GIT_DIR_PATH}/last-review-result.log}"
+# Sibling of REVIEW_LOG: the append-only record of code-reviewer /
+# adversarial-reviewer disagreements and how the arbiter resolved each one.
+# Unlike REVIEW_LOG (truncated each run), this accumulates across runs — it
+# doubles as the dedup source of truth for issue filing (claude-config#332).
+# Overridable by env var so tests can point it at a temp path.
+DISAGREEMENT_LOG="${DISAGREEMENT_LOG:-${GIT_DIR_PATH}/reviewer-disagreements.log}"
 _review_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ || true)
 _review_repo=$(cdup=$(git rev-parse --show-cdup 2>/dev/null) && cd "./${cdup:-.}" >/dev/null 2>&1 && pwd -L || echo "unknown")
 _review_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -1879,12 +1879,14 @@ No blocking issues found." \
 
 adversarial-reviewer is correct; the finding does not apply."
 
+MOCK33_GH="${TMPDIR_TEST}/gh33"
+make_mock_gh "${MOCK33_GH}"
 TEST33_LOG="${TMPDIR_TEST}/test33-review.log"
 rm -f "${TEST33_LOG}"
 
 exit_t33=0
 cd "${REPO_DIR}"
-PATH="${MOCK30_GH}:${PATH}" REVIEW_LOG="${TEST33_LOG}" \
+PATH="${MOCK33_GH}:${PATH}" REVIEW_LOG="${TEST33_LOG}" \
   DISAGREEMENT_LOG="/nonexistent-dir-claude-config-332/disagreements.log" \
   CLAUDE_CLI="${MOCK33_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || exit_t33=$?
 cd - >/dev/null

--- a/hooks/tests/run-review-test.sh
+++ b/hooks/tests/run-review-test.sh
@@ -27,6 +27,9 @@
 #   22. CODE_REVIEWER_AGENT default resolves to the installed agent ID (issue #209)
 #   23. review.adversarialModel overrides adversarial-reviewer's model independently
 #       of review.model / REVIEW_MODE (issue #235)
+#   30-33. Reviewer disagreements: PASS logs locally and files no issue; FAIL files
+#       one issue with no verbatim reviewer output; (repo, branch) dedup; an
+#       unwritable log path never fails the run (claude-config#332)
 
 set -euo pipefail
 
@@ -1637,12 +1640,266 @@ assert_eq \
   "true" \
   "${adversarial_not_cached}"
 
+# Mock `gh` that records every `gh issue create` invocation instead of
+# hitting the API. Placed first on PATH so run-review.sh's
+# `command -v gh` / `gh issue create` resolve to it.
+make_mock_gh() {
+  local mock_dir="$1"
+  mkdir -p "${mock_dir}"
+  : >"${mock_dir}/gh_calls.txt"
+  cat >"${mock_dir}/gh" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "issue" && "\$2" == "create" ]]; then
+  printf 'issue-create\n' >>"${mock_dir}/gh_calls.txt"
+  # Persist the body so the test can assert on what would be published.
+  _prev=""
+  for _a in "\$@"; do
+    [[ "\${_prev}" == "--body" ]] && printf '%s\n' "\${_a}" >>"${mock_dir}/gh_bodies.txt"
+    _prev="\${_a}"
+  done
+  echo "https://github.com/smartwatermelon/claude-config/issues/9999"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${mock_dir}/gh"
+}
+
+# =========================================================
+# TEST 30: arbiter PASS writes the local disagreement log and files NO issue
+# (claude-config#332 — a strict reviewer disagreeing with a skeptical one is
+# the system working; 5 of 6 historical filings were this healthy case)
+# =========================================================
+echo ""
+echo "=== Test 30: arbiter PASS logs locally, files no GitHub issue (claude-config#332) ==="
+
+setup_repo
+stage_small_change
+
+MOCK30_DIR="${TMPDIR_TEST}/mock30"
+make_mock_claude_three_way "${MOCK30_DIR}" \
+  "VERDICT: FAIL
+
+ISSUE: Missing Linux platform guard
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: SENTINEL_CR_VERBATIM add a runtime OS check." \
+  "VERDICT: PASS
+
+No blocking issues found. SENTINEL_AR_VERBATIM macOS-only scope." \
+  "VERDICT: PASS
+
+adversarial-reviewer is correct: the header already documents macOS-only scope."
+
+MOCK30_GH="${TMPDIR_TEST}/gh30"
+make_mock_gh "${MOCK30_GH}"
+TEST30_LOG="${TMPDIR_TEST}/test30-review.log"
+TEST30_DIS="${TMPDIR_TEST}/test30-disagreements.log"
+rm -f "${TEST30_LOG}" "${TEST30_DIS}"
+
+cd "${REPO_DIR}"
+PATH="${MOCK30_GH}:${PATH}" REVIEW_LOG="${TEST30_LOG}" DISAGREEMENT_LOG="${TEST30_DIS}" \
+  CLAUDE_CLI="${MOCK30_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || true
+cd - >/dev/null
+
+test30_dis="$(cat "${TEST30_DIS}" 2>/dev/null || echo "")"
+
+assert_contains \
+  "PASS disagreement is recorded in the local disagreement log" \
+  "=== REVIEWER DISAGREEMENT" \
+  "${test30_dis}"
+
+assert_contains \
+  "local log records the arbiter verdict" \
+  "arbiter_verdict: PASS" \
+  "${test30_dis}"
+
+assert_contains \
+  "local log keeps code-reviewer output verbatim (local-only, never published)" \
+  "SENTINEL_CR_VERBATIM" \
+  "${test30_dis}"
+
+assert_contains \
+  "local log keeps adversarial-reviewer output verbatim" \
+  "SENTINEL_AR_VERBATIM" \
+  "${test30_dis}"
+
+test30_gh_calls="$(cat "${MOCK30_GH}/gh_calls.txt" 2>/dev/null || echo "")"
+assert_eq \
+  "arbiter PASS files NO GitHub issue (claude-config#332 defect 3)" \
+  "" \
+  "${test30_gh_calls}"
+
+# =========================================================
+# TEST 31: arbiter FAIL DOES file a GitHub issue, and that issue does NOT
+# contain verbatim reviewer output (claude-config#332 defect 2 — cross-org
+# source leak)
+# =========================================================
+echo ""
+echo "=== Test 31: arbiter FAIL files one issue, with no verbatim reviewer output ==="
+
+setup_repo
+stage_small_change
+
+MOCK31_DIR="${TMPDIR_TEST}/mock31"
+make_mock_claude_three_way "${MOCK31_DIR}" \
+  "VERDICT: FAIL
+
+ISSUE: Hardcoded credential
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: SENTINEL_CR_VERBATIM remove the hardcoded credential." \
+  "VERDICT: PASS
+
+No blocking issues found. SENTINEL_AR_VERBATIM out of scope." \
+  "VERDICT: FAIL
+
+ISSUE: Hardcoded credential
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: SENTINEL_ARBITER_REASONING code-reviewer is correct."
+
+MOCK31_GH="${TMPDIR_TEST}/gh31"
+make_mock_gh "${MOCK31_GH}"
+TEST31_LOG="${TMPDIR_TEST}/test31-review.log"
+TEST31_DIS="${TMPDIR_TEST}/test31-disagreements.log"
+rm -f "${TEST31_LOG}" "${TEST31_DIS}"
+
+cd "${REPO_DIR}"
+PATH="${MOCK31_GH}:${PATH}" REVIEW_LOG="${TEST31_LOG}" DISAGREEMENT_LOG="${TEST31_DIS}" \
+  CLAUDE_CLI="${MOCK31_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || true
+cd - >/dev/null
+
+test31_calls="$(grep -c 'issue-create' "${MOCK31_GH}/gh_calls.txt" 2>/dev/null || echo "0")"
+assert_eq \
+  "arbiter FAIL files exactly one GitHub issue" \
+  "1" \
+  "${test31_calls}"
+
+test31_body="$(cat "${MOCK31_GH}/gh_bodies.txt" 2>/dev/null || echo "")"
+
+assert_contains \
+  "filed issue names the repo/branch actually under review" \
+  "**Branch under review:**" \
+  "${test31_body}"
+
+assert_contains \
+  "filed issue points at the local log path instead of pasting reviewer output" \
+  "${TEST31_DIS}" \
+  "${test31_body}"
+
+assert_contains \
+  "filed issue still carries the arbiter's own reasoning (our tooling's summary)" \
+  "SENTINEL_ARBITER_REASONING" \
+  "${test31_body}"
+
+test31_leaked="no"
+echo "${test31_body}" | grep -qF "SENTINEL_CR_VERBATIM" && test31_leaked="yes"
+echo "${test31_body}" | grep -qF "SENTINEL_AR_VERBATIM" && test31_leaked="yes"
+assert_eq \
+  "filed issue does NOT embed verbatim reviewer output (cross-org source leak, claude-config#332)" \
+  "no" \
+  "${test31_leaked}"
+
+# =========================================================
+# TEST 32: the same (repo, branch) files at most one issue no matter how many
+# times the disagreement recurs (claude-config#332 — #323/#324/#325 were one
+# branch re-filing on every push)
+# =========================================================
+echo ""
+echo "=== Test 32: dedup on (repo, branch) — a long-running branch files once ==="
+
+MOCK32_GH="${TMPDIR_TEST}/gh32"
+make_mock_gh "${MOCK32_GH}"
+TEST32_LOG="${TMPDIR_TEST}/test32-review.log"
+TEST32_DIS="${TMPDIR_TEST}/test32-disagreements.log"
+rm -f "${TEST32_LOG}" "${TEST32_DIS}"
+
+# Two runs on the same branch, each producing the same arbiter FAIL.
+for _t32_round in 1 2; do
+  setup_repo
+  stage_small_change
+  MOCK32_DIR="${TMPDIR_TEST}/mock32-${_t32_round}"
+  make_mock_claude_three_way "${MOCK32_DIR}" \
+    "VERDICT: FAIL
+
+ISSUE: Hardcoded credential
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: Remove the hardcoded credential." \
+    "VERDICT: PASS
+
+No blocking issues found." \
+    "VERDICT: FAIL
+
+ISSUE: Hardcoded credential
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: code-reviewer is correct."
+  cd "${REPO_DIR}"
+  PATH="${MOCK32_GH}:${PATH}" REVIEW_LOG="${TEST32_LOG}" DISAGREEMENT_LOG="${TEST32_DIS}" \
+    CLAUDE_CLI="${MOCK32_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || true
+  cd - >/dev/null
+done
+
+test32_calls="$(grep -c 'issue-create' "${MOCK32_GH}/gh_calls.txt" 2>/dev/null || echo "0")"
+assert_eq \
+  "same (repo, branch) files at most one issue across two runs (claude-config#332)" \
+  "1" \
+  "${test32_calls}"
+
+test32_records="$(grep -c '=== REVIEWER DISAGREEMENT' "${TEST32_DIS}" 2>/dev/null || echo "0")"
+assert_eq \
+  "both runs still appended a local disagreement record (dedup gates filing, not logging)" \
+  "2" \
+  "${test32_records}"
+
+# =========================================================
+# TEST 33: an unwritable disagreement-log path must not fail the run
+# (best-effort requirement, claude-config#332)
+# =========================================================
+echo ""
+echo "=== Test 33: unwritable disagreement log does not fail the run ==="
+
+setup_repo
+stage_small_change
+
+MOCK33_DIR="${TMPDIR_TEST}/mock33"
+make_mock_claude_three_way "${MOCK33_DIR}" \
+  "VERDICT: FAIL
+
+ISSUE: Missing Linux platform guard
+SEVERITY: BLOCKING
+LOCATION: foo.sh:2
+DETAILS: Add a runtime OS check." \
+  "VERDICT: PASS
+
+No blocking issues found." \
+  "VERDICT: PASS
+
+adversarial-reviewer is correct; the finding does not apply."
+
+TEST33_LOG="${TMPDIR_TEST}/test33-review.log"
+rm -f "${TEST33_LOG}"
+
+exit_t33=0
+cd "${REPO_DIR}"
+PATH="${MOCK30_GH}:${PATH}" REVIEW_LOG="${TEST33_LOG}" \
+  DISAGREEMENT_LOG="/nonexistent-dir-claude-config-332/disagreements.log" \
+  CLAUDE_CLI="${MOCK33_DIR}/claude" bash "${SUBJECT}" < <(git diff --cached || true) 2>/dev/null || exit_t33=$?
+cd - >/dev/null
+
+assert_eq \
+  "unwritable disagreement log does not block an otherwise-passing commit (exit 0)" \
+  "0" \
+  "${exit_t33}"
+
 # =========================================================
 # Summary
 # =========================================================
 echo ""
 echo "======================================="
-echo "Results: ${PASS} passed, ${FAIL} failed (of 49 assertions)"
+echo "Results: ${PASS} passed, ${FAIL} failed (of 62 assertions)"
 echo "======================================="
 
 if [[ "${FAIL}" -gt 0 ]]; then


### PR DESCRIPTION
Closes #332.

## The problem

`file_reviewer_disagreement_issue()` filed a GitHub issue every time code-reviewer returned a BLOCKING FAIL and adversarial-reviewer returned PASS. Three defects, per the corrected analysis in #332:

**1. Wrong destination.** The destination repo was hardcoded to `smartwatermelon/claude-config` regardless of what was actually reviewed. Four of the six issues ever filed were about `beacon-biosignals/infra` — a different org.

**2. Leaked reviewed source.** The body pasted all three reviewers' verbatim output, which quotes code from the repo under review. Another org's Terraform — module wiring, cluster names, bucket references — ended up in a personal repo purely as a side effect of defect 1. This is the strongest reason to act.

**3. Fired on the healthy case.** The arbiter ruled PASS in 5 of 6. A strict reviewer disagreeing with a skeptical one is the system working, not tracked work. On top of that, #323/#324/#325 were the *same branch* re-filing on every push — one active branch produced three issues by itself.

## The design

**The local log is the default record, not a GitHub issue.** Disagreements are tuning telemetry, not tracked work. Every disagreement now appends a record to `.git/reviewer-disagreements.log` — a sibling of the existing `last-review-result.log`, following the same convention — containing a UTC timestamp, the repo under review, branch, commit, arbiter model, arbiter verdict, and the full verbatim output of all three reviewers.

Verbatim is fine *there*: the log never leaves the machine, and it stays with the repo it describes. That single move fixes both the wrong-repo problem and the cross-org source leak, because nothing gets published. The path is overridable via `DISAGREEMENT_LOG` so tests can point it at a temp file.

**An issue is filed only when the arbiter verdict is FAIL.** That is the case where the disagreement says something about the *tooling* — a reviewer produced a finding the arbiter upheld against a PASS — which is also why the destination deliberately stays hardcoded to this infrastructure's own repo. Historically this is 1 of 6, a filing rate that matches the signal.

**A filed issue no longer carries reviewed source.** It includes the repo and branch under review, the commit, the arbiter verdict, a pointer to the local log path, and the arbiter's reasoning only — that last one is our own tooling's summary, not code from the repo under review. code-reviewer and adversarial-reviewer output stays in the local log, which the issue points at by path. Naming the repo under review also means the hardcoded destination is no longer misleading to a reader.

**Filing is deduped on (repo, branch),** using the local log as the source of truth, so a long-running branch files at most once no matter how many pushes it takes. The dedup marker is written only after a confirmed successful `gh` call, so a transient API failure doesn't permanently suppress a legitimate issue.

### Why not post to the PR

Ruled out on mechanics, per the correction in #332: `run-review.sh` runs at pre-commit/pre-push and never sets `PR_NUMBER`. At the moment a disagreement is detected there is frequently no PR to comment on — and for cross-org work, possibly never one this tooling can post to. A PR-comment implementation would silently no-op in exactly the common case.

## Safety properties

- **Best-effort end to end.** Every new write is guarded; an unwritable log path, or `gh` being absent or unauthenticated, cannot fail a commit. There is a test for the unwritable case specifically.
- **`GH_ISSUE_FILING_DISABLED` still gates issue filing only.** The local log is written regardless — it is a filing guard, not a logging guard. This did not break any existing test.
- **Reviewer output is model-authored and untrusted.** It is only ever written to a file via `printf` with a literal format string. Never eval'd, never interpolated into a command, never passed to a `gh --search` query.

## Testing

Four new cases in `hooks/tests/run-review-test.sh` (13 assertions), matching the framework that already covers this path:

- arbiter PASS writes the local log and files **no** issue
- arbiter FAIL files exactly one issue, and sentinel strings planted in the reviewer output are asserted **absent** from the issue body while the arbiter's reasoning is present
- the same (repo, branch) files at most one issue across two runs, while still logging both
- an unwritable log path does not fail the run

**Results:**

- `hooks/tests/run-review-test.sh`: **62 passed, 0 failed** (baseline 49/49)
- `bats tests/`: **156 passed, 8 failed** — all 8 pre-existing. Verified by stashing the changes, re-running, and diffing the failure *sets*: identical, not merely the same count. They are gh-wrapper and pre-merge tests unrelated to this code path.
- `shellcheck -S info -x`: output is byte-identical to baseline on `run-review.sh`, and clean on the test file. No `# shellcheck disable` directives added.

The second commit resolves #339, a test-isolation finding the pre-push reviewer raised on the first push.

https://claude.ai/code/session_0165j8uC57NWoexNQ6wwbLC8
