### PR TITLE
feat(hooks): allow path-scoped worktree creation and cleanup

### DIFF
--- a/scripts/hook-block-enter-worktree.sh
+++ b/scripts/hook-block-enter-worktree.sh
@@ -1,24 +1,68 @@
 #!/usr/bin/env bash
-# Hook: Block the EnterWorktree built-in tool
+# Hook: Gate the EnterWorktree built-in tool
 #
 # Purpose:
 #   EnterWorktree is a Claude Code built-in tool that creates an isolated git
-#   worktree. CC add-on skills (e.g. superpowers:using-git-worktrees) invoke
-#   this tool for task isolation, which conflicts with the project workflow.
+#   worktree. It is the tool-level counterpart to the Bash-level `git worktree`
+#   creation gated by hook-block-git-worktree.sh.
 #
-#   This hook fires via PreToolUse matcher "EnterWorktree" and unconditionally
-#   blocks the tool. The Bash-level `git worktree` command is blocked separately
-#   by hook-block-git-worktree.sh in the hook-block-all.sh chain.
+#   Policy (see smartwatermelon/dotfiles#200, superseding the blanket ban):
+#   worktree creation is ALLOWED, because subagent-driven execution is the
+#   documented default in CLAUDE.md and a shared checkout is not isolation --
+#   `git checkout -b` swaps the branch out from under a concurrent agent
+#   mid-edit. Blocking this tool while permitting scoped Bash-level creation
+#   would be incoherent: they are the same mechanism through different doors.
+#
+#   PATH SCOPING DOES NOT APPLY HERE, and that is not an oversight. The Bash
+#   hook restricts creation to `.claude/worktrees/` because a raw git command
+#   can target anywhere. EnterWorktree's tool_input carries only a `name`
+#   (observed payload: {"tool_input":{"name":"my-worktree"}}) -- the caller
+#   cannot choose a location, so there is no path to validate and no way for
+#   this tool to escape the harness-chosen directory. What IS validated is the
+#   name itself, which becomes a path component: it must be a plain slug, so it
+#   cannot traverse out of that directory or inject shell/path metacharacters.
+#
+# Called by: settings.json PreToolUse matcher "EnterWorktree"
 
 set -euo pipefail
 
 input=$(cat)
-printf '%s BLOCKED ENTER_WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${input}" \
-  >>"${HOME}/.claude/blocked-commands.log"
-printf '🛑 BLOCKED: The EnterWorktree tool is forbidden.\n' >&2
-printf '\n' >&2
-printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
-printf '\n' >&2
-printf 'For task isolation, work directly on a feature branch instead:\n' >&2
-printf '  git checkout -b claude/<description>\n' >&2
-exit 2
+# NOTE: the `$( )` command substitution strips trailing newlines, so a name of
+# `good\n` reaches the regex as `good` and is accepted (harmlessly -- what gets
+# used is the sanitized value). An embedded newline mid-string, e.g.
+# `good\nEVIL`, survives and is correctly denied by the anchored regex below.
+# A future refactor to `jq -j` or a `read -r`-based read would remove that
+# stripping and change this behavior -- re-test the newline cases if you touch it.
+name=$(printf '%s\n' "${input}" | jq -r '.tool_input.name // empty')
+
+deny() {
+  local reason="${1}"
+  printf '%s BLOCKED ENTER_WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${input}" \
+    >>"${HOME}/.claude/blocked-commands.log"
+  printf '🛑 BLOCKED: %s\n' "${reason}" >&2
+  printf '\n' >&2
+  printf 'Worktree creation is permitted (dotfiles#200), but the worktree name\n' >&2
+  printf 'becomes a directory component, so it must be a plain slug:\n' >&2
+  printf '  letters, digits, dot, underscore, hyphen; 1-100 characters\n' >&2
+  printf '  no slashes, no "..", no leading dot or hyphen\n' >&2
+  printf '\n' >&2
+  printf 'Example: fix-gh-wrapper-issue-parsing\n' >&2
+  exit 2
+}
+
+# A missing/empty name would let the harness fall back to a default we cannot
+# inspect. Require it explicitly.
+[[ -n "${name}" ]] || deny "EnterWorktree requires an explicit worktree name"
+
+# Reject the traversal component outright, ahead of the charset check, so the
+# failure message is specific rather than a generic charset complaint.
+[[ "${name}" == ".." ]] && deny "EnterWorktree name '..' is forbidden (path traversal)"
+
+# Allowlist the charset. Slashes are excluded, so the name cannot introduce a
+# nested path; a leading dot or hyphen is excluded so the name cannot create a
+# hidden directory or be mistaken for a flag by downstream tooling.
+if [[ ! "${name}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,99}$ ]]; then
+  deny "EnterWorktree name is not a valid slug (got: ${name})"
+fi
+
+exit 0

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -39,7 +39,11 @@
 #
 #   Both the Bash-level command and the EnterWorktree built-in tool are gated.
 #   This script handles the Bash layer only; EnterWorktree is handled separately
-#   by hook-block-enter-worktree.sh, which applies the same path-scoping rule.
+#   by hook-block-enter-worktree.sh. Note that path scoping does NOT apply
+#   there: EnterWorktree's tool_input carries only a `name` and no path, so the
+#   caller cannot choose a location and there is nothing to scope. That hook
+#   validates the name as a strict slug instead, since it becomes a directory
+#   component. See its header for the reasoning.
 #
 # Called by: hook-block-all.sh (PreToolUse Bash hook chain)
 

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -1,25 +1,45 @@
 #!/usr/bin/env bash
-# Hook: Block mutating git worktree subcommands
+# Hook: Gate git worktree subcommands
 #
 # Purpose:
 #   git worktree creates and manages multiple working trees from a single repo.
-#   CC add-on skills occasionally attempt to use worktrees for task isolation,
-#   but this conflicts with the project workflow and causes problems.
 #
-#   Only MUTATING subcommands are blocked (add, remove, prune, move, lock,
-#   unlock, repair) plus bare `git worktree` with no subcommand (ambiguous,
-#   blocked conservatively) and any unrecognized/future subcommand (fail
-#   closed). Read-only/inspection subcommands (list, --help, -h) are allowed
-#   through, since they don't create or mutate worktree state and are needed
-#   for observability: e.g. auditing stale `.claude/worktrees/agent-*`
-#   directories left behind by Agent-tool `isolation: "worktree"` subagents
-#   after their branch merges. Previously this hook blocked the entire
-#   `git worktree` family unconditionally, which made `git worktree list`
-#   itself blocked and prevented that audit.
+#   Policy INTENT (see smartwatermelon/dotfiles#200, superseding the blanket
+#   ban). This table describes what the hook aims to enforce; see the KNOWN
+#   LIMITATION note above `worktree_re` below for the crafted command forms
+#   that evade detection entirely:
 #
-#   Both the Bash-level `git worktree` command and the EnterWorktree built-in
-#   tool are blocked. This script handles the Bash layer only; EnterWorktree
-#   is blocked separately by hook-block-enter-worktree.sh.
+#     ALLOWED  list, --help, -h   read-only inspection (shipped in #154)
+#     ALLOWED  remove, prune      cleanup; these only ever REDUCE worktree
+#                                 count, so they cannot reintroduce the
+#                                 collisions the original ban existed to
+#                                 prevent. Blocking them meant any worktree
+#                                 predating the ban was permanently
+#                                 un-cleanable by tooling, and held its
+#                                 branch checked out so `git branch -D`
+#                                 refused.
+#     ALLOWED  add <path>         ONLY when <path> is under `.claude/worktrees/`.
+#                                 This matches the Agent tool's
+#                                 `isolation: "worktree"` convention
+#                                 (`.claude/worktrees/agent-<id>`), keeps every
+#                                 worktree in one auditable location, and
+#                                 leaves `git worktree list` able to find them.
+#     BLOCKED  add <other path>   unscoped creation, which is what caused the
+#                                 "which directory is *the* checkout" confusion.
+#     BLOCKED  move, lock, unlock, repair
+#                                 rewrite worktree administrative state.
+#     BLOCKED  bare `git worktree`, unknown/future subcommands (fail closed).
+#
+#   Why the ban was relaxed at all: "work directly on a feature branch instead"
+#   assumed one worker per checkout. Subagent-driven execution is now the
+#   documented default in CLAUDE.md, and a branch is not isolation when two
+#   processes share a working tree -- `git checkout -b` swaps the branch out
+#   from under a concurrent agent mid-edit. See dotfiles#200 for the collision
+#   that motivated this.
+#
+#   Both the Bash-level command and the EnterWorktree built-in tool are gated.
+#   This script handles the Bash layer only; EnterWorktree is handled separately
+#   by hook-block-enter-worktree.sh, which applies the same path-scoping rule.
 #
 # Called by: hook-block-all.sh (PreToolUse Bash hook chain)
 
@@ -28,61 +48,210 @@ set -euo pipefail
 input=$(cat)
 cmd=$(printf '%s\n' "${input}" | jq -r '.tool_input.command // empty')
 
-# Match: git [optional-flags] worktree [subcommand-token]
+# Shared with hook-block-enter-worktree.sh: the only directory under which
+# worktree creation is permitted.
+readonly WORKTREE_SCOPE='.claude/worktrees'
+
+# Decide whether an `add` target path is inside the sanctioned scope.
+#
+# SECURITY NOTE: a PreToolUse hook sees the RAW, UNEXPANDED command string.
+# `$HOME/x`, `~/x`, and `$(cmd)` are just text here -- this hook cannot know
+# what they resolve to, and must not guess. Anything whose literal form is not
+# provably inside the scope is rejected. That includes `..` at any position,
+# which would otherwise let `.claude/worktrees/../../elsewhere` read as scoped.
+path_in_scope() {
+  local path="${1}"
+
+  # Empty path: creation with no target. Not provably in scope.
+  [[ -n "${path}" ]] || return 1
+
+  # Strip one layer of surrounding quotes, which shells would remove.
+  # Anything quoted more exotically than this falls through and is rejected
+  # below by the metacharacter check.
+  if [[ "${path}" =~ ^\"(.*)\"$ ]] || [[ "${path}" =~ ^\'(.*)\'$ ]]; then
+    path="${BASH_REMATCH[1]}"
+  fi
+
+  # Reject unexpanded shell constructs. We cannot resolve these statically,
+  # so they can never be proven in-scope. Covers $VAR, ${VAR}, $(cmd),
+  # backticks, ~ expansion, and glob characters.
+  case "${path}" in
+    *'$'* | *'`'* | *'~'* | *'*'* | *'?'* | *'['*) return 1 ;;
+    # No unexpanded shell construct found; continue validating below.
+    *) ;;
+  esac
+
+  # Reject path traversal anywhere in the string. Checking for the `..`
+  # component specifically (rather than the substring) avoids false-rejecting
+  # a legitimate name like `.claude/worktrees/agent..1`, while still catching
+  # every real traversal.
+  local -a parts
+  IFS='/' read -r -a parts <<<"${path}"
+  local part
+  for part in "${parts[@]}"; do
+    [[ "${part}" == ".." ]] && return 1
+  done
+
+  # Require the scope to appear as a real path prefix, and require a non-empty
+  # leaf after it (so bare `.claude/worktrees` itself is not a valid target).
+  # Accepts both the relative form (`.claude/worktrees/x`, `./.claude/...`)
+  # and an absolute form (`/abs/repo/.claude/worktrees/x`).
+  #
+  # SCOPE OF THE GUARANTEE: this proves the path is SPELLED in-scope, not that
+  # it lands in THIS repo's `.claude/worktrees/`. A hook cannot resolve the
+  # command's working directory, so `git -C /elsewhere worktree add
+  # .claude/worktrees/x` passes, as does an absolute path carrying the scope
+  # literal under any parent (`/tmp/anything/.claude/worktrees/x`). Both create
+  # a worktree in a real `.claude/worktrees/` directory -- just possibly not
+  # this one. The value delivered is a strong convention that keeps worktrees
+  # discoverable and blocks the arbitrary-location creation that caused the
+  # "which directory is *the* checkout" confusion; it is not an airtight
+  # containment boundary.
+  [[ "${path}" == "${WORKTREE_SCOPE}/"?* ]] && return 0
+  [[ "${path}" == "./${WORKTREE_SCOPE}/"?* ]] && return 0
+  [[ "${path}" == /*"/${WORKTREE_SCOPE}/"?* ]] && return 0
+
+  return 1
+}
+
+# Pull the target path out of a creation invocation's argument list.
+#
+# Creation accepts flags before the path (`-b <branch>`, `-B <branch>`,
+# `--detach`, `--force`, ...), so the path is NOT reliably the first argument.
+# Walk the tokens, consuming flags (and the value of those flags that take one),
+# and return the first bare operand -- that is the path. A trailing <commit-ish>
+# may follow it, which we ignore.
+extract_add_path() {
+  local -a tokens=("$@")
+  local i=0 tok
+  while ((i < ${#tokens[@]})); do
+    tok="${tokens[i]}"
+    case "${tok}" in
+      # Flags that take a separate value argument: skip both tokens.
+      -b | -B)
+        ((i += 2))
+        ;;
+      # `--flag=value` and valueless flags: skip one token.
+      --*=* | --* | -*)
+        ((i += 1))
+        ;;
+      # First non-flag operand is the path.
+      *)
+        printf '%s' "${tok}"
+        return 0
+        ;;
+    esac
+  done
+  # No operand found.
+  return 0
+}
+
+block() {
+  local reason="${1}"
+  printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
+    >>"${HOME}/.claude/blocked-commands.log"
+  printf '🛑 BLOCKED: %s\n' "${reason}" >&2
+  printf '\n' >&2
+  printf 'Worktree policy (dotfiles#200):\n' >&2
+  printf '  allowed: list, --help, remove, prune\n' >&2
+  printf '  allowed: creation -- only under %s/\n' "${WORKTREE_SCOPE}" >&2
+  printf '  blocked: move, lock, unlock, repair\n' >&2
+  printf '\n' >&2
+  printf 'To create an isolated worktree, scope it to the sanctioned directory:\n' >&2
+  printf '  %s/<name>\n' "${WORKTREE_SCOPE}" >&2
+  printf '\n' >&2
+  printf 'Keeping every worktree under one path keeps them discoverable via\n' >&2
+  printf '"git worktree list". Paths containing variables, ~, globs, or ".."\n' >&2
+  printf 'are rejected because a hook cannot resolve them before the shell runs.\n' >&2
+  exit 2
+}
+
+# Match: git [optional-flags] worktree [rest-of-invocation]
 # Requires `git` to appear as a command (at start of string or after shell operators &&, ||, ;, |).
-# Handles interposed flags: git -C /path worktree add, git --no-pager worktree list, etc.
+# Handles interposed flags: `git -C /path`, `git --no-pager`, etc.
 # The group (-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)* matches zero or more
 # flag groups before `worktree`. Each group is a token starting with `-`, optionally followed by
 # a non-flag value token. This prevents matching subcommands like `grep` (which don't start with
 # `-`), so `git grep worktree` is NOT matched here.
 #
-# Capture group 2 grabs the token immediately following `worktree` (the subcommand), if any, so
-# we can classify it below. Bare `git worktree` with nothing after it yields an empty capture.
+# Everything after `worktree` up to the next shell operator is captured so the
+# subcommand AND its arguments (needed for path-scoping creation) can be inspected.
 #
-# IMPORTANT: a compound command can contain MULTIPLE `git worktree` invocations
-# (e.g. `git worktree list && git worktree add /tmp/wt`). Matching only the
-# first occurrence and branching on it would let a read-only invocation at the
-# start mask a mutating one later in the same command string. So every
-# occurrence in the string is enumerated with `grep -oE`, and the whole
-# command is blocked if ANY occurrence is not read-only.
-worktree_re='(^|&&|\|\||;|\|)[[:space:]]*git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+([^[:space:]|;&]+))?'
+# IMPORTANT: a compound command can contain MULTIPLE `git worktree` invocations.
+# Matching only the first occurrence and branching on it would let a read-only
+# invocation at the start mask a mutating one later in the same command string.
+# So every occurrence in the string is enumerated with `grep -oE`, and the whole
+# command is blocked if ANY occurrence is not permitted.
+#
+# KNOWN LIMITATION -- READ BEFORE RELYING ON THIS AS A SECURITY BOUNDARY.
+# This is a regex approximation of shell syntax, not a shell parser, and it is
+# BYPASSABLE. The separator alternation below recognizes `&&`, `||`, `;`, `|`,
+# `&`, `(`, and `{`, plus the `then`/`do` keywords. It does NOT recognize:
+#
+#   * backticks:             echo `git ... `                   -- NOT blocked
+#   * aliases and shell functions that resolve to git
+#   * obfuscation via variables, e.g. G=git; $G ...
+#
+# Handled: `$(...)` command substitution (the `(` alternative catches it),
+# `env`/`command`/`sudo`-prefixed git, and absolute/relative-path invocation
+# such as `/usr/bin/git`.
+#
+# These gaps predate the dotfiles#200 carve-out (the pre-change hook fails open
+# on them identically), but they matter MORE now. Previously this regex gated a
+# decision already fixed at "block", so a bypass merely produced an unscoped
+# worktree. Now it is the sole gate deciding whether path-scoping runs at all:
+# a bypassed occurrence skips path_in_scope() entirely. Treat the policy table
+# at the top of this file as describing INTENT, not a guarantee that no crafted
+# string can evade it. Properly closing this requires real shell tokenization
+# rather than a regex, which is deliberately out of scope here.
+# `(env|command|sudo[[:space:]]+)*` consumes wrapper commands; `([^[:space:]]*/)?`
+# consumes a leading path on the git binary itself (/usr/bin/git, ./git).
+worktree_re='(^|&&|\|\||;|\||&|\(|\{|[[:space:]]then|[[:space:]]do)[[:space:]]*((env|command|sudo)[[:space:]]+)*([^[:space:]|;&(){]*/)?git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+[^|;&){]*)?'
 
 mapfile -t matches < <(printf '%s\n' "${cmd}" | grep -oE "${worktree_re}" || true)
 
 for match in "${matches[@]}"; do
-  # Re-extract the subcommand token from this specific match (last
-  # whitespace-delimited field; empty if the match was bare `git worktree`).
-  subcmd=""
-  if [[ "${match}" =~ worktree[[:space:]]+([^[:space:]]+)$ ]]; then
-    subcmd="${BASH_REMATCH[1]}"
-  fi
+  # Isolate the argument list that follows the `worktree` keyword in this
+  # specific occurrence, then split it into tokens.
+  args="${match#*worktree}"
+  tokens=()
+  read -r -a tokens <<<"${args}" || true
+
+  subcmd="${tokens[0]-}"
 
   case "${subcmd}" in
     # Read-only / inspection: this occurrence is fine, keep checking others.
     list | --help | -h)
       continue
       ;;
-    # Mutating subcommands, bare `git worktree`, or any unrecognized/future
-    # subcommand: block the whole command. `repair` can rewrite worktree
+    # Cleanup: only ever reduces worktree count, so it cannot recreate the
+    # collision conditions the ban was written for.
+    remove | prune)
+      continue
+      ;;
+    # Creation: permitted only when the target path is provably inside the
+    # sanctioned scope.
+    add)
+      target="$(extract_add_path "${tokens[@]:1}")"
+      if path_in_scope "${target}"; then
+        continue
+      fi
+      if [[ -n "${target}" ]]; then
+        block "worktree creation outside ${WORKTREE_SCOPE}/ is forbidden (got: ${target})"
+      else
+        block "worktree creation without an explicit path is forbidden"
+      fi
+      ;;
+    # Mutating administrative subcommands, bare `git worktree`, or any
+    # unrecognized/future subcommand. `repair` can rewrite worktree
     # administrative files, so it's treated as mutating despite sounding
     # read-only. Bare `git worktree` (no subcommand) is ambiguous and blocked
     # conservatively. Unknown subcommands fail closed.
+    "")
+      block "git worktree (no subcommand) is forbidden"
+      ;;
     *)
-      printf '%s BLOCKED GIT WORKTREE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" \
-        >>"${HOME}/.claude/blocked-commands.log"
-      if [[ -n "${subcmd}" ]]; then
-        printf '🛑 BLOCKED: git worktree %s is forbidden.\n' "${subcmd}" >&2
-      else
-        printf '🛑 BLOCKED: git worktree (no subcommand) is forbidden.\n' >&2
-      fi
-      printf '\n' >&2
-      printf 'Worktrees conflict with the project workflow. There is no valid use case for them here.\n' >&2
-      printf '\n' >&2
-      printf '(Read-only inspection via "git worktree list" / "--help" is allowed.)\n' >&2
-      printf '\n' >&2
-      printf 'For task isolation, work directly on a feature branch instead:\n' >&2
-      printf '  git checkout -b claude/<description>\n' >&2
-      exit 2
+      block "git worktree ${subcmd} is forbidden"
       ;;
   esac
 done

--- a/scripts/tests/test-hook-block-enter-worktree.sh
+++ b/scripts/tests/test-hook-block-enter-worktree.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for hook-block-enter-worktree.sh
+#
+# Policy under test (smartwatermelon/dotfiles#200): EnterWorktree is permitted,
+# because worktree creation is permitted. The tool's tool_input carries only a
+# `name` and no path, so there is nothing to path-scope; what is validated is
+# that the name is a plain slug, since it becomes a directory component.
+
+set -euo pipefail
+unset CDPATH
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-enter-worktree.sh"
+pass=0
+fail=0
+
+check() {
+  local desc="${1}" expected="${2}" input="${3}" actual
+  actual=0
+  printf '%s\n' "${input}" | "${HOOK}" >/dev/null 2>&1 || actual=$?
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (expected exit ${expected}, got ${actual})"
+    ((fail += 1))
+  fi
+}
+
+make_input() {
+  jq -n --arg name "$1" '{"tool_input":{"name":$name}}'
+}
+
+echo "=== hook-block-enter-worktree tests ==="
+
+# Should PASS (exit 0) — valid slugs
+inp="$(make_input 'my-worktree')"
+check "simple hyphenated slug" 0 "${inp}"
+inp="$(make_input 'fix-gh-wrapper-issue-parsing')"
+check "realistic branch-style slug" 0 "${inp}"
+inp="$(make_input 'agent-a091b53da3a954c2e')"
+check "agent-id style slug" 0 "${inp}"
+inp="$(make_input 'wt_1.2')"
+check "underscore and dot" 0 "${inp}"
+inp="$(make_input 'a')"
+check "single character" 0 "${inp}"
+
+# Should BLOCK (exit 2) — names that would escape or confuse the worktree dir
+inp="$(make_input '..')"
+check "traversal: bare .." 2 "${inp}"
+inp="$(make_input '../escape')"
+check "traversal: ../escape" 2 "${inp}"
+inp="$(make_input 'foo/../../etc')"
+check "traversal: embedded .." 2 "${inp}"
+inp="$(make_input 'nested/path')"
+check "slash: nested path component" 2 "${inp}"
+inp="$(make_input '/absolute')"
+check "slash: absolute path" 2 "${inp}"
+inp="$(make_input '.hidden')"
+check "leading dot (hidden dir)" 2 "${inp}"
+inp="$(make_input '-flaglike')"
+check "leading hyphen (flag-like)" 2 "${inp}"
+inp="$(make_input 'name with spaces')"
+check "spaces" 2 "${inp}"
+
+# The literal dollar/backtick are assembled rather than written inline so the
+# hook receives genuinely unexpanded shell constructs.
+dollar='$'
+backtick='`'
+inp="$(make_input "${dollar}(whoami)")"
+check "command substitution" 2 "${inp}"
+inp="$(make_input "${dollar}HOME")"
+check "variable reference" 2 "${inp}"
+inp="$(make_input "${backtick}id${backtick}")"
+check "backtick substitution" 2 "${inp}"
+inp="$(make_input 'semi;colon')"
+check "shell operator" 2 "${inp}"
+inp="$(make_input 'glob*')"
+check "glob character" 2 "${inp}"
+
+# Missing name: the harness would pick a default we cannot inspect.
+inp='{"tool_input":{}}'
+check "missing name" 2 "${inp}"
+inp="$(make_input '')"
+check "empty name" 2 "${inp}"
+
+# Length bound (1-100 chars).
+long_name="$(printf 'a%.0s' {1..100})"
+inp="$(make_input "${long_name}")"
+check "name at 100-char limit" 0 "${inp}"
+too_long="$(printf 'a%.0s' {1..101})"
+inp="$(make_input "${too_long}")"
+check "name over 100-char limit" 2 "${inp}"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -27,13 +27,10 @@ make_input() {
 
 echo "=== hook-block-git-worktree tests ==="
 
-# Should BLOCK (exit 2) — mutating subcommands, bare worktree, unknown subcommands
+# Should BLOCK (exit 2) — unscoped creation, administrative subcommands,
+# bare worktree, unknown subcommands
 inp="$(make_input 'git worktree add /tmp/wt feature')"
-check "git worktree add" 2 "${inp}"
-inp="$(make_input 'git worktree remove /tmp/wt')"
-check "git worktree remove" 2 "${inp}"
-inp="$(make_input 'git worktree prune')"
-check "git worktree prune" 2 "${inp}"
+check "creation outside scope (/tmp)" 2 "${inp}"
 inp="$(make_input 'git worktree move /tmp/wt /tmp/wt2')"
 check "git worktree move" 2 "${inp}"
 inp="$(make_input 'git worktree lock /tmp/wt')"
@@ -47,11 +44,80 @@ check "bare git worktree (no subcommand)" 2 "${inp}"
 inp="$(make_input 'git worktree unknownfuturesubcommand')"
 check "git worktree unknown subcommand (fail closed)" 2 "${inp}"
 inp="$(make_input 'git -C /some/path worktree add /tmp/wt')"
-check "git -C /path worktree add" 2 "${inp}"
+check "git -C /path, unscoped creation" 2 "${inp}"
 inp="$(make_input 'git --no-pager worktree add /tmp/wt')"
-check "git --no-pager worktree add" 2 "${inp}"
+check "git --no-pager, unscoped creation" 2 "${inp}"
 inp="$(make_input 'cd /repo && git worktree add /tmp/wt')"
-check "chained: cd && git worktree add" 2 "${inp}"
+check "chained: cd && unscoped creation" 2 "${inp}"
+
+# --- dotfiles#200: cleanup subcommands are now ALLOWED ---
+# These only ever reduce worktree count, so they cannot reintroduce the
+# collisions the original ban existed to prevent.
+inp="$(make_input 'git worktree remove .claude/worktrees/agent-abc')"
+check "cleanup: remove (now allowed)" 0 "${inp}"
+inp="$(make_input 'git worktree prune')"
+check "cleanup: prune (now allowed)" 0 "${inp}"
+inp="$(make_input 'git worktree remove /tmp/some-stale-wt')"
+check "cleanup: remove of an out-of-scope stale worktree (allowed)" 0 "${inp}"
+inp="$(make_input 'git -C /some/repo worktree prune')"
+check "cleanup: prune with interposed -C flag" 0 "${inp}"
+# `remove` refuses when the worktree has untracked files, so real cleanup of an
+# agent worktree (whose post-checkout setup generates files) needs --force.
+# Verified against a live create/remove cycle; blocking this would leave the
+# un-cleanable-worktree problem from dotfiles#200 only half fixed.
+inp="$(make_input 'git worktree remove --force .claude/worktrees/agent-abc')"
+check "cleanup: remove --force (required for dirty worktrees)" 0 "${inp}"
+inp="$(make_input 'git worktree prune --dry-run')"
+check "cleanup: prune --dry-run" 0 "${inp}"
+
+# --- dotfiles#200: creation ALLOWED only under .claude/worktrees/ ---
+inp="$(make_input 'git worktree add .claude/worktrees/agent-abc123')"
+check "creation: scoped relative path" 0 "${inp}"
+inp="$(make_input 'git worktree add ./.claude/worktrees/agent-abc123')"
+check "creation: scoped ./ relative path" 0 "${inp}"
+inp="$(make_input 'git worktree add /Users/me/Developer/repo/.claude/worktrees/wt1')"
+check "creation: scoped absolute path" 0 "${inp}"
+inp="$(make_input 'git worktree add -b claude/my-feature .claude/worktrees/wt1')"
+check "creation: scoped with -b branch before path" 0 "${inp}"
+inp="$(make_input 'git worktree add --detach .claude/worktrees/wt1')"
+check "creation: scoped with valueless flag" 0 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees/wt1 HEAD~2')"
+check "creation: scoped with trailing commit-ish" 0 "${inp}"
+inp="$(make_input 'git -C /some/repo worktree add .claude/worktrees/wt1')"
+check "creation: scoped with interposed -C flag" 0 "${inp}"
+
+# Creation rejections: the path must be PROVABLY in scope.
+inp="$(make_input 'git worktree add ../elsewhere/.claude/worktrees/wt1')"
+check "creation: rejects leading .. traversal" 2 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees/../../escape')"
+check "creation: rejects embedded .. traversal" 2 "${inp}"
+# The literal dollar sign is assembled rather than written inline: the hook must
+# see an UNEXPANDED variable reference, which is precisely what this asserts.
+dollar='$'
+inp="$(make_input "git worktree add ${dollar}HOME/.claude/worktrees/wt1")"
+check "creation: rejects unexpanded variable reference" 2 "${inp}"
+inp="$(make_input 'git worktree add ~/.claude/worktrees/wt1')"
+check "creation: rejects unexpanded ~" 2 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees/*')"
+check "creation: rejects glob" 2 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees')"
+check "creation: rejects bare scope dir with no leaf" 2 "${inp}"
+inp="$(make_input 'git worktree add')"
+check "creation: rejects missing path" 2 "${inp}"
+inp="$(make_input 'git worktree add -b claude/feature')"
+check "creation: rejects -b consuming the only operand" 2 "${inp}"
+inp="$(make_input 'git worktree add /tmp/.claude/worktreesevil/wt1')"
+check "creation: rejects scope-lookalike prefix" 2 "${inp}"
+inp="$(make_input 'git worktree add notclaude/worktrees/wt1')"
+check "creation: rejects non-scope path" 2 "${inp}"
+
+# A scoped creation must not launder a mutating sibling in a compound command.
+inp="$(make_input 'git worktree add .claude/worktrees/ok && git worktree move /a /b')"
+check "compound: scoped add && move (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees/ok && git worktree add /tmp/bad')"
+check "compound: scoped add && unscoped add (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree add .claude/worktrees/a && git worktree remove .claude/worktrees/b')"
+check "compound: scoped add && remove (both allowed)" 0 "${inp}"
 
 # Should PASS (exit 0) — read-only/inspection subcommands
 inp="$(make_input 'git worktree list')"
@@ -85,7 +151,9 @@ check "chained: | git worktree list" 0 "${inp}"
 inp="$(make_input 'ls; git worktree add /tmp/wt')"
 check "chained: ; git worktree add" 2 "${inp}"
 inp="$(make_input 'true || git worktree prune')"
-check "chained: || git worktree prune" 2 "${inp}"
+check "chained: || git worktree prune (cleanup, now allowed)" 0 "${inp}"
+inp="$(make_input 'true || git worktree move /a /b')"
+check "chained: || git worktree move (still blocked)" 2 "${inp}"
 inp="$(make_input 'echo x | git worktree add')"
 check "chained: | git worktree add" 2 "${inp}"
 
@@ -102,10 +170,61 @@ inp="$(make_input 'git worktree list | git worktree add /tmp/wt')"
 check "compound: list | add (must still block)" 2 "${inp}"
 inp="$(make_input 'git worktree add /tmp/wt && git worktree list')"
 check "compound: add && list, mutating first (must still block)" 2 "${inp}"
+inp="$(make_input 'git worktree list ; git worktree lock /tmp/wt')"
+check "compound: list ; lock (must still block)" 2 "${inp}"
 inp="$(make_input 'git worktree list ; git worktree remove /tmp/wt')"
-check "compound: list ; remove (must still block)" 2 "${inp}"
+check "compound: list ; remove (cleanup, now allowed)" 0 "${inp}"
 inp="$(make_input 'git worktree list && git worktree --help')"
 check "compound: list && --help, both read-only (must pass)" 0 "${inp}"
+
+# --- Separator coverage (closed by the dotfiles#200 review) ---
+# These forms previously evaded the matcher entirely, which mattered more once
+# `add` became a conditional allow: an unmatched occurrence skips path scoping.
+inp="$(make_input 'git worktree list & git worktree add /tmp/evil')"
+check "separator: & backgrounding" 2 "${inp}"
+inp="$(make_input '(git worktree add /tmp/evil)')"
+check "separator: subshell parens" 2 "${inp}"
+inp="$(make_input 'git status && (git worktree add /tmp/evil)')"
+check "separator: subshell after &&" 2 "${inp}"
+inp="$(make_input '{ git worktree add /tmp/evil; }')"
+check "separator: brace group" 2 "${inp}"
+inp="$(make_input 'if true; then git worktree add /tmp/evil; fi')"
+check "separator: then keyword" 2 "${inp}"
+inp="$(make_input 'for i in 1; do git worktree add /tmp/evil; done')"
+check "separator: do keyword" 2 "${inp}"
+# Scoped creation must still be allowed through the newly-recognized separators.
+inp="$(make_input '(git worktree add .claude/worktrees/ok)')"
+check "separator: subshell with scoped path (allowed)" 0 "${inp}"
+
+# --- Wrapped / path-prefixed invocation (also closed by the review) ---
+inp="$(make_input "echo ${dollar}(git worktree add /tmp/evil)")"
+check "wrapper: command substitution" 2 "${inp}"
+inp="$(make_input '/usr/bin/git worktree add /tmp/evil')"
+check "wrapper: absolute-path git" 2 "${inp}"
+inp="$(make_input 'env git worktree add /tmp/evil')"
+check "wrapper: env-prefixed git" 2 "${inp}"
+inp="$(make_input 'command git worktree add /tmp/evil')"
+check "wrapper: command-prefixed git" 2 "${inp}"
+inp="$(make_input 'sudo git worktree add /tmp/evil')"
+check "wrapper: sudo-prefixed git" 2 "${inp}"
+inp="$(make_input '/usr/bin/git worktree add .claude/worktrees/ok')"
+check "wrapper: absolute-path git, scoped path (allowed)" 0 "${inp}"
+
+# False-positive guards for the wrapper/path-prefix alternatives above: a bare
+# word merely ENDING in `git` must not match (the prefix requires a `/`).
+inp="$(make_input 'mygit worktree add /tmp/x')"
+check "false positive: mygit is not git" 0 "${inp}"
+inp="$(make_input 'echo not-git worktree stuff')"
+check "false positive: hyphenated word containing git" 0 "${inp}"
+
+# --- KNOWN-OPEN gap, asserted as CURRENT behavior, not as desired behavior ---
+# Documented in the KNOWN LIMITATION block in the hook header. Asserted so the
+# gap stays visible, and so a future fix trips this test (expected-0 -> 2)
+# rather than changing behavior unnoticed. Closing it properly needs real shell
+# tokenization, not a regex.
+backtick='`'
+inp="$(make_input "echo ${backtick}git worktree add /tmp/evil${backtick}")"
+check "KNOWN GAP: backtick substitution is not detected" 0 "${inp}"
 
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"


### PR DESCRIPTION
Relaxes the blanket `git worktree` ban to a path-scoped carve-out, per smartwatermelon/dotfiles#200.

## Why

The ban's rationale — "work directly on a feature branch instead" — assumed one worker per checkout. That premise no longer holds. Subagent-driven execution is the documented default in CLAUDE.md, and a branch is not isolation when two processes share a working tree: `git checkout -b` swaps the branch out from under a concurrent agent mid-edit. dotfiles#200 documents a real collision where recovery took several steps and could plausibly have lost work.

The ban also blocked *cleanup*, so worktrees predating it were permanently un-cleanable by tooling and held their branches checked out, making `git branch -D` refuse.

## Policy

| Subcommand | Before | After |
|---|---|---|
| `list`, `--help`, `-h` | allowed | allowed |
| `remove`, `prune` | blocked | **allowed** |
| `add` under `.claude/worktrees/` | blocked | **allowed** |
| `add` elsewhere | blocked | blocked |
| `move`, `lock`, `unlock`, `repair` | blocked | blocked |
| bare / unknown | blocked | blocked (fails closed) |

`remove`/`prune` only ever *reduce* worktree count, so they cannot reintroduce the collisions the ban existed to prevent. Scoping `add` to `.claude/worktrees/` matches the Agent tool's `isolation: "worktree"` convention and keeps worktrees discoverable via the already-allowed `list`.

## Implementation notes

Path validation treats the command string as raw and unexpanded, because that is what a PreToolUse hook receives. Paths containing `$VAR`, `~`, globs, or a `..` component are rejected rather than guessed at. The `add` operand is located by walking flags (`-b`/`-B` consume a value) rather than by position, since the path is not reliably first.

**EnterWorktree is allowed to match, with one deliberate difference.** Its `tool_input` carries only a `name` and no path — verified against real payloads in `blocked-commands.log` — so the caller cannot choose a location and there is nothing to path-scope. The name is validated as a strict slug instead, since it becomes a directory component.

## Matcher hardening (from adversarial review)

The separator alternation previously recognized only `&&`, `||`, `;`, `|`. These all evaded it entirely:

- `(git worktree add /tmp/evil)` — subshell
- `git worktree list & git worktree add /tmp/evil` — backgrounding
- `{ ...; }`, `if ...; then ...`, `for ...; do ...`
- `env git`, `command git`, `sudo git`, `/usr/bin/git`
- `echo $(git worktree add /tmp/evil)`

These gaps **predate this change** (the pre-change hook fails open on them identically), but they became load-bearing once `add` turned into a conditional allow: an unmatched occurrence skips path scoping altogether. All are now closed, with false-positive guards confirming `mygit` and `not-git` still pass.

## Known limitations (documented, not fixed)

- **Backtick substitution** is still undetected. Pinned by a test asserting current behavior, so a future fix trips the test rather than passing silently. Also #349 (heredocs / ANSI-C quoting) — same class.
- **Scoping proves a path is *spelled* in-scope**, not that it lands in this repo. A hook cannot resolve `-C` or the working directory. The header previously overclaimed a "complete audit"; corrected.
- **`remove` accepts out-of-scope paths** (#347) — deliberate, so pre-existing worktrees anywhere remain cleanable.

A regex is the wrong long-term shape for this; closing the residue properly needs real shell tokenization.

## Verification

- **97 tests passing**: 75 (`git worktree`) + 22 (EnterWorktree, new file). The #268 compound-command regression intent is preserved, re-pointed at `lock` since `remove` is no longer forbidden.
- 80 sibling hook tests green — no regressions.
- All four files shellcheck-clean at `-S info`, no `disable` directives.
- **Live end-to-end lifecycle**: create → `list` → `remove --force` → branch delete, workspace clean. This is how `--force` surfaced as necessary — agent worktrees always contain untracked setup files, so plain `remove` refuses. Unit tests alone would have shipped a half-fix.

## Follow-up

Per the issue author: revisit in a few weeks. If the scoped rules prove out, the restriction may be liftable entirely — the original hard block responded to a real incident, and current models handle worktrees more reliably.

Closes smartwatermelon/dotfiles#200
Closes #346

https://claude.ai/code/session_01Jek7cuYDFwiqEqFLXoyetC
