### PR TITLE
fix: clear six tracked tech-debt issues in review and install tooling

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -170,6 +170,14 @@ needs_security_label() {
 # block placed before DETAILS: doesn't swallow it. DETAILS keeps its original
 # swallow-everything behavior, but now stops at a VERIFIED: header for the
 # same reason.
+#
+# Both multi-line fields also stop at a bare END_ISSUE line (#333). In the
+# normal flow that line is already gone — parse_nonblocking_issues() consumes
+# END_ISSUE as the block terminator and never emits it — so this is defensive
+# hardening, not a live bug fix: it removes a silent dependency on that
+# call-site behavior, so a caller that hands _parse_issue_fields a raw block
+# with its terminator still attached can't get END_ISSUE swallowed into the
+# tail of DETAILS or VERIFIED.
 _parse_issue_fields() {
   local block="$1"
   local -n _pif_title="$2"
@@ -181,13 +189,13 @@ _parse_issue_fields() {
   _pif_source=$(echo "${block}" | { grep "^SOURCE:" || true; } | { head -1 || true; } | sed 's/^SOURCE: //')
   _pif_location=$(echo "${block}" | { grep "^LOCATION:" || true; } | { head -1 || true; } | sed 's/^LOCATION: //')
   # DETAILS may span multiple lines -- grab everything after the DETAILS: line,
-  # stopping at a VERIFIED: header if one follows.
-  _pif_details=$(echo "${block}" | { awk '/^VERIFIED:/{found=0} /^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+  # stopping at a VERIFIED: header or an END_ISSUE terminator if one follows.
+  _pif_details=$(echo "${block}" | { awk '/^VERIFIED:/{found=0} /^END_ISSUE$/{found=0} /^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
 
   # VERIFIED is optional and so is this nameref.
   if [[ -n "${6:-}" ]]; then
     local -n _pif_verified="$6"
-    _pif_verified=$(echo "${block}" | { awk '/^(TITLE|SOURCE|LOCATION|DETAILS):/{found=0} /^VERIFIED:/{found=1; sub(/^VERIFIED:[[:space:]]*/,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
+    _pif_verified=$(echo "${block}" | { awk '/^(TITLE|SOURCE|LOCATION|DETAILS):/{found=0} /^END_ISSUE$/{found=0} /^VERIFIED:/{found=1; sub(/^VERIFIED:[[:space:]]*/,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
   fi
 }
 
@@ -525,6 +533,12 @@ _dedup_location_path() {
 #
 # _OPEN_ISSUES_STATE is "" (not yet fetched), "ok" (usable listing, possibly
 # empty), or "error" (lookup failed — dedup disabled, everything files).
+#
+# _OPEN_ISSUES_LIMIT is gh's documented maximum for `issue list --limit`.
+# Asking for the maximum is free — gh paginates internally and returns only
+# what exists — so there is no cost to raising it, and a repo that really has
+# grown past the old 200 no longer loses its tail silently.
+_OPEN_ISSUES_LIMIT=1000
 _OPEN_ISSUES_CACHE=""
 _OPEN_ISSUES_STATE=""
 _load_open_issues() {
@@ -539,17 +553,33 @@ _load_open_issues() {
   # could read as a command substitution.
   jq_prog='.[] | [(.number|tostring), .url, (.title|gsub("[\t\n\r]";" ")), ((.body // "" | capture("\\*\\*Location:\\*\\* \u0060(?<l>[^\u0060]*)\u0060").l) // "")] | @tsv'
   # NOTE: no --search. The reviewer rephrases titles freely, so a keyword
-  # search would miss the very duplicates this targets; the whole open list
-  # is small (tens of issues) and is filtered locally instead. Untrusted
-  # model-authored text is therefore never interpolated into a query at all.
+  # search would miss the very duplicates this targets, so the whole open list
+  # is fetched and filtered locally instead. Untrusted model-authored text is
+  # therefore never interpolated into a query at all. On the repos this runs
+  # against the list is normally small (tens of issues), but that is an
+  # observation, not a guarantee — hence the explicit _OPEN_ISSUES_LIMIT and
+  # the truncation check below.
   if ! raw=$(command gh issue list \
     --repo "${REPO_OWNER}/${REPO_NAME}" \
     --state open \
-    --limit 200 \
+    --limit "${_OPEN_ISSUES_LIMIT}" \
     --json number,url,title,body \
     --jq "${jq_prog}" 2>/dev/null); then
     _OPEN_ISSUES_STATE="error"
     return 0
+  fi
+
+  # Probable-truncation check (#330). gh gives no "there was more" signal, so
+  # the only tell is a row count that lands exactly on the requested limit.
+  # That is suggestive, not proof (a repo with precisely _OPEN_ISSUES_LIMIT
+  # open issues is a false positive), which is why this warns rather than
+  # setting "error": the listing we did get is still usable for dedup, it just
+  # may be incomplete, and the operator should know that a duplicate slipping
+  # through has a known explanation.
+  local row_count
+  row_count=$(printf '%s' "${raw}" | { grep -c . || true; })
+  if [[ "${row_count}" -ge "${_OPEN_ISSUES_LIMIT}" ]]; then
+    log_warn "Open-issue listing for ${REPO_OWNER}/${REPO_NAME} hit the ${_OPEN_ISSUES_LIMIT}-issue limit; dedup may be incomplete and duplicates may be filed."
   fi
 
   _OPEN_ISSUES_CACHE="${raw}"

--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -34,10 +34,40 @@ unset CDPATH
 
 # --- Configuration ---
 CLAUDE_CLI="${CLAUDE_CLI:-${HOME}/.local/bin/claude}"
-# Default 180s handles typical PRs; large PRs with 30k+ token smart-diffs
-# routinely exceeded the prior 120s default and timed out unnecessarily.
-# Override via `git config review.preMergeTimeout N` when needed.
-TIMEOUT_SECONDS=$(git config --get --type=int review.preMergeTimeout 2>/dev/null || echo "180")
+
+# Analysis timeout policy.
+#
+# The time the model needs to render a verdict tracks the size of the prompt it
+# is handed, and prompt size varies enormously between PRs — independently of
+# anything knowable at startup. A flat constant is therefore the wrong shape:
+# it is either too small for big diffs (an infrastructure timeout that presents
+# as a merge-blocking review objection) or wastefully large for small ones.
+#
+# Note the failure is NOT confined to the >1000-line "smart diff" path, which
+# an earlier version of this comment claimed. The observed timeout came from a
+# 460-line PR taking the ordinary full-diff path: its prompt was 33,835 bytes,
+# it timed out twice at 180s, and it completed comfortably at 420s.
+#
+# So the effective timeout is computed AFTER the prompt is assembled, from its
+# actual byte size — see compute_effective_timeout() and its call site below.
+# These constants calibrate that scaling:
+#   - FLOOR is the previous flat default, retained for small prompts.
+#   - PER_KB is set so the 33,835-byte data point yields 510s: comfortably
+#     above the 420s that was observed to work, without being open-ended.
+#   - CEILING bounds a pathological prompt so a wedged call cannot hang the
+#     merge for the better part of an hour.
+TIMEOUT_FLOOR_SECONDS=180
+TIMEOUT_PER_KB_SECONDS=10
+TIMEOUT_CEILING_SECONDS=900
+
+# Explicit operator override. When `git config review.preMergeTimeout N` is set
+# (repo-local or --global), that value is honored verbatim and scaling is
+# skipped entirely — an operator who has named a number means that number.
+# Unset (the normal case) means "scale with the prompt".
+TIMEOUT_OVERRIDE=$(git config --get --type=int review.preMergeTimeout 2>/dev/null || echo "")
+
+# Placeholder until the prompt exists; see compute_effective_timeout() below.
+TIMEOUT_SECONDS="${TIMEOUT_FLOOR_SECONDS}"
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -51,6 +81,41 @@ log_info() { echo -e "${BLUE}[pre-merge]${NC} $*" >&2; }
 log_success() { echo -e "${GREEN}[pre-merge]${NC} $*" >&2; }
 log_warn() { echo -e "${YELLOW}[pre-merge]${NC} $*" >&2; }
 log_error() { echo -e "${RED}[pre-merge]${NC} $*" >&2; }
+
+# --- Timeout Scaling ---
+
+# Resolve the analysis timeout for a prompt of a given byte size.
+#
+# Sets TIMEOUT_SECONDS and logs which path was taken, so an operator reading
+# the transcript can see why the analysis was given the budget it got.
+#
+# Args:
+#   $1 - prompt size in bytes
+compute_effective_timeout() {
+  local prompt_size="$1"
+  local prompt_kb scaled
+
+  # Explicit override wins outright — no scaling, no clamping to the ceiling.
+  if [[ -n "${TIMEOUT_OVERRIDE}" ]]; then
+    TIMEOUT_SECONDS="${TIMEOUT_OVERRIDE}"
+    log_info "Analysis timeout: ${TIMEOUT_SECONDS}s (explicit override from git config review.preMergeTimeout)"
+    return 0
+  fi
+
+  # Integer division: sub-1KB prompts contribute nothing and land on the floor.
+  prompt_kb=$((prompt_size / 1024))
+  scaled=$((TIMEOUT_FLOOR_SECONDS + (prompt_kb * TIMEOUT_PER_KB_SECONDS)))
+
+  if ((scaled > TIMEOUT_CEILING_SECONDS)); then
+    scaled=${TIMEOUT_CEILING_SECONDS}
+    TIMEOUT_SECONDS="${scaled}"
+    log_info "Analysis timeout: ${TIMEOUT_SECONDS}s (scaled for ${prompt_kb}KB prompt, clamped to ${TIMEOUT_CEILING_SECONDS}s ceiling)"
+    return 0
+  fi
+
+  TIMEOUT_SECONDS="${scaled}"
+  log_info "Analysis timeout: ${TIMEOUT_SECONDS}s (scaled: ${TIMEOUT_FLOOR_SECONDS}s floor + ${prompt_kb}KB x ${TIMEOUT_PER_KB_SECONDS}s/KB)"
+}
 
 # --- File Classification Functions ---
 
@@ -835,6 +900,10 @@ fi
 PROMPT_SIZE=${#FULL_PROMPT}
 PROMPT_LINES=$(echo "${FULL_PROMPT}" | wc -l)
 log_info "Prompt size: ${PROMPT_SIZE} bytes, ${PROMPT_LINES} lines"
+
+# Now that the prompt exists, size the timeout to it (or honor an override).
+compute_effective_timeout "${PROMPT_SIZE}"
+
 log_info "Analyzing review comments..."
 
 # Unset CLAUDECODE so this can be invoked from within a Claude Code session.
@@ -843,7 +912,20 @@ log_info "Analyzing review comments..."
 ANALYSIS_TEXT=$(echo "${FULL_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAUDECODE "${CLAUDE_CLI}" -p "${MERGE_MODEL_ARGS[@]}" --tools "" --no-session-persistence 2>&1) || {
   EXIT_CODE=$?
   if [[ ${EXIT_CODE} -eq 124 ]]; then
-    log_error "Analysis timed out after ${TIMEOUT_SECONDS}s"
+    # An infrastructure failure, NOT a review finding. Say so unambiguously:
+    # a bare "timed out" line above an `exit 1` reads like the reviewer
+    # objected to the PR, when in fact it never got far enough to have an
+    # opinion about it at all.
+    log_error "Analysis TIMED OUT after ${TIMEOUT_SECONDS}s (prompt: ${PROMPT_SIZE} bytes)."
+    log_error "This is an infrastructure failure, not a review finding: the"
+    log_error "analysis never completed and rendered NO opinion on this PR."
+    log_error "Nothing was found wrong with the code - nothing was assessed."
+    log_error ""
+    log_error "What to do:"
+    log_error "  1. Re-run the merge - the analysis often completes on a retry."
+    log_error "  2. If it times out repeatedly, raise the ceiling explicitly:"
+    log_error "       git config --global review.preMergeTimeout $((TIMEOUT_SECONDS * 2))"
+    log_error "     That value is honored verbatim and disables size-based scaling."
   else
     log_error "Claude CLI failed (exit code: ${EXIT_CODE})"
     log_error "${ANALYSIS_TEXT}"

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -405,8 +405,19 @@ file_reviewer_disagreement_issue() {
   command -v gh >/dev/null 2>&1 || return 0
 
   local title="Reviewer disagreement upheld by arbiter in ${repo_slug} (branch ${branch})"
-  local body
-  body=$(cat <<EOF
+
+  # The issue body is built in a tempfile and handed to `gh --body-file`,
+  # NOT captured from a heredoc into a variable. ${arbiter_output} is
+  # MODEL-AUTHORED: if the arbiter ever emitted a line consisting of exactly
+  # the heredoc delimiter, a `body=$(cat <<EOF ...)` capture would terminate
+  # early and file a silently truncated issue (claude-config#342). Writing
+  # to a file keeps model text off the delimiter-collision path entirely
+  # while preserving the ${var} expansion the body needs.
+  #
+  # Not `local`: the EXIT trap references this by name as the backstop for
+  # SIGINT / errexit. The explicit rm below is the normal-path cleanup.
+  _issue_body=$(mktemp "${TMPDIR:-/tmp}/run-review-issue-body.XXXXXX") || return 0
+  cat >"${_issue_body}" <<EOF
 ## Reviewer disagreement, arbiter verdict FAIL (auto-logged by run-review.sh)
 
 code-reviewer returned a BLOCKING FAIL, adversarial-reviewer returned PASS,
@@ -435,17 +446,18 @@ the machine that ran the review.
 Deduped on (repo under review, branch) — one branch files at most one issue.
 See smartwatermelon/dev-env#35 and claude-config#332.
 EOF
-)
 
   if gh issue create --repo "smartwatermelon/claude-config" \
     --title "${title}" \
-    --body "${body}" \
+    --body-file "${_issue_body}" \
     --label "tech-debt" \
     >/dev/null 2>&1; then
     # Record the dedup marker only on a confirmed successful file, so a
     # transient gh failure doesn't permanently suppress the issue.
     [[ -n "${DISAGREEMENT_LOG}" ]] && printf -- '%s\n' "${dedup_marker}" >>"${DISAGREEMENT_LOG}" 2>/dev/null
   fi
+  { rm -f "${_issue_body}" || true; }
+  _issue_body=""
   return 0
 }
 
@@ -863,7 +875,7 @@ _global_log="${HOME}/.claude/last-review-result.log"
 } >"${_global_log}" || true
 
 _ec=0 # captured by EXIT trap; declared here so shellcheck sees the assignment
-trap '_ec=$?; rm -rf "${_chunk_results:-}" 2>/dev/null; rm -f "${_cr_out:-}" "${_ar_out:-}" "${DIFF_TMPFILE:-}" "${_codebase_err:-}" 2>/dev/null; [[ -n "${REVIEW_LOG:-}" ]] && printf "exit_code: %d\n" "$_ec" >> "${REVIEW_LOG}" || true' EXIT
+trap '_ec=$?; rm -rf "${_chunk_results:-}" 2>/dev/null; rm -f "${_cr_out:-}" "${_ar_out:-}" "${DIFF_TMPFILE:-}" "${_codebase_err:-}" "${_issue_body:-}" 2>/dev/null; [[ -n "${REVIEW_LOG:-}" ]] && printf "exit_code: %d\n" "$_ec" >> "${REVIEW_LOG}" || true' EXIT
 
 if [[ -z "${DIFF}" ]]; then
   log_warn "No staged changes to review"

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,11 @@ _dry() { printf '\033[1;35m[DRY]\033[0m   %s\n' "$*"; }
 installed=()
 skipped=()
 failures=()
+# Dry-run counterpart to installed[]: the DRY_RUN early-return paths never
+# reach the installed+=() at the end of _ensure_symlink, so without this the
+# --sync --dry-run summary reported zero pending work and printed "deployed
+# tree already matches repo" even with items queued up (claude-config#344).
+would_install=()
 
 # ── Constants ────────────────────────────────────────────
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -185,6 +190,7 @@ _ensure_symlink() {
     _warn "Symlink ${link} points to ${current}, replacing"
     if [[ "${DRY_RUN}" == true ]]; then
       _dry "Would replace symlink: ${link} -> ${target}"
+      would_install+=("symlink:${link}")
       return
     fi
     rm "${link}"
@@ -196,6 +202,7 @@ _ensure_symlink() {
     else
       _dry "Would symlink: ${link} -> ${target}"
     fi
+    would_install+=("symlink:${link}")
     return
   fi
 
@@ -235,6 +242,9 @@ repair_symlinks() {
     if [[ -f "${link}" && ! -L "${link}" ]]; then
       if [[ "${DRY_RUN}" == true ]]; then
         _dry "Would repair: ${link} -> ${target}"
+        # Repairs are pending work too — the non-dry path rewrites the link,
+        # so the dry-run summary must count them or it under-reports.
+        would_install+=("repair:${link}")
         ((repair_count += 1))
         continue
       fi
@@ -392,9 +402,27 @@ fi
 # surfaces a broken deploy instead of silently continuing to `updates`.
 if ${SYNC_ONLY}; then
   echo ""
-  if [[ ${#installed[@]} -gt 0 ]]; then
-    _info "Sync created:"
-    for item in "${installed[@]}"; do
+  # Under --dry-run nothing was actually created, so the summary must report
+  # from would_install[] instead of installed[] (which is always empty in that
+  # mode). Reporting from installed[] made a dry run claim the tree already
+  # matched the repo while listing [DRY] lines above it (claude-config#344).
+  # This block runs at script scope, so no `local`/nameref: copy the right
+  # array into a plain one and pick the matching wording.
+  _sync_pending=("${installed[@]}")
+  _sync_header="Sync created:"
+  _sync_empty="Sync complete — deployed tree already matches repo"
+  _sync_prefix="Sync complete — "
+  _sync_suffix=" item(s) created"
+  if [[ "${DRY_RUN}" == true ]]; then
+    _sync_pending=("${would_install[@]}")
+    _sync_header="Sync would create:"
+    _sync_empty="Dry run complete — deployed tree already matches repo"
+    _sync_prefix="Dry run complete — would create "
+    _sync_suffix=" item(s)"
+  fi
+  if [[ ${#_sync_pending[@]} -gt 0 ]]; then
+    _info "${_sync_header}"
+    for item in "${_sync_pending[@]}"; do
       echo "  + ${item}"
     done
   fi
@@ -405,10 +433,10 @@ if ${SYNC_ONLY}; then
     done
     exit 1
   fi
-  if [[ ${#installed[@]} -eq 0 ]]; then
-    _ok "Sync complete — deployed tree already matches repo"
+  if [[ ${#_sync_pending[@]} -eq 0 ]]; then
+    _ok "${_sync_empty}"
   else
-    _ok "Sync complete — ${#installed[@]} item(s) created"
+    _ok "${_sync_prefix}${#_sync_pending[@]}${_sync_suffix}"
   fi
   exit 0
 fi

--- a/tests/test_install_sync_dry_run.bats
+++ b/tests/test_install_sync_dry_run.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for the `--sync --dry-run` summary in install.sh.
+#
+# Why this exists: in dry-run mode both _ensure_symlink() and repair_symlinks()
+# return early WITHOUT appending to installed[], so the sync-mode exit block
+# saw ${#installed[@]} == 0 and printed "Sync complete — deployed tree already
+# matches repo" even when it had just printed a screenful of [DRY] lines
+# describing links it would create. A user previewing changes got an actively
+# misleading summary (claude-config#344).
+#
+# The fix maintains a parallel would_install[] array populated on the dry-run
+# paths, and the sync-mode exit block reports from it when DRY_RUN is true.
+#
+# These tests run install.sh against a THROWAWAY repo and a THROWAWAY HOME so
+# they never read or write the developer's real ~/.claude. install.sh derives
+# REPO_DIR from ${BASH_SOURCE[0]} and DEPLOY_DIR from ${HOME}, so copying the
+# script into a temp repo and overriding HOME is sufficient isolation.
+#
+# Run: bats ~/.claude/tests/test_install_sync_dry_run.bats
+
+setup() {
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+
+  FAKE_REPO="${TMPDIR_TEST}/repo"
+  FAKE_HOME="${TMPDIR_TEST}/home"
+  export FAKE_REPO FAKE_HOME
+  mkdir -p "${FAKE_REPO}" "${FAKE_HOME}"
+
+  # A minimal git repo with a couple of tracked files. install.sh enumerates
+  # tracked files via `git ls-files`, so they must actually be committed.
+  git -C "${FAKE_REPO}" init -q
+  git -C "${FAKE_REPO}" config user.email "test@test.com"
+  git -C "${FAKE_REPO}" config user.name "Test"
+
+  # install.sh refuses to run unless these canary files are present, so the
+  # fixture must supply all three (settings.json, CLAUDE.md, hooks/run-review.sh).
+  cp "${BATS_TEST_DIRNAME}/../install.sh" "${FAKE_REPO}/install.sh"
+  printf '{}\n' >"${FAKE_REPO}/settings.json"
+  printf '# test\n' >"${FAKE_REPO}/CLAUDE.md"
+  mkdir -p "${FAKE_REPO}/hooks"
+  printf '#!/usr/bin/env bash\n' >"${FAKE_REPO}/hooks/run-review.sh"
+  git -C "${FAKE_REPO}" add install.sh settings.json CLAUDE.md hooks/run-review.sh
+  GIT_CONFIG_GLOBAL=/dev/null git -C "${FAKE_REPO}" commit -q -m "initial"
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# Helper: run install.sh in --sync --dry-run against the throwaway HOME.
+run_sync_dry_run() {
+  HOME="${FAKE_HOME}" bash "${FAKE_REPO}/install.sh" --sync --dry-run 2>&1
+}
+
+@test "dry run with pending work does NOT claim the tree already matches" {
+  run run_sync_dry_run
+  # Nothing is deployed yet, so there is definitely pending work.
+  [[ "${output}" != *"already matches repo"* ]]
+}
+
+@test "dry run with pending work reports a 'would create N item(s)' count" {
+  run run_sync_dry_run
+  [[ "${output}" =~ would\ create\ [1-9][0-9]*\ item\(s\) ]]
+}
+
+@test "dry run lists the items it would create" {
+  run run_sync_dry_run
+  [[ "${output}" == *"Sync would create:"* ]]
+  [[ "${output}" == *"symlink:${FAKE_HOME}/.claude/settings.json"* ]]
+}
+
+@test "dry run makes no changes to the deploy dir" {
+  run run_sync_dry_run
+  [[ ! -e "${FAKE_HOME}/.claude/settings.json" ]]
+}
+
+@test "dry run with nothing pending still reports the tree already matches" {
+  # Pre-create correct symlinks for every tracked file so _ensure_symlink
+  # takes its "already correct" _skip path and would_install[] stays empty.
+  mkdir -p "${FAKE_HOME}/.claude"
+  local file
+  while IFS= read -r file; do
+    mkdir -p "$(dirname "${FAKE_HOME}/.claude/${file}")"
+    ln -s "${FAKE_REPO}/${file}" "${FAKE_HOME}/.claude/${file}"
+  done < <(git -C "${FAKE_REPO}" ls-files)
+
+  run run_sync_dry_run
+  [[ "${output}" == *"already matches repo"* ]]
+  [[ "${output}" != *"would create"* ]]
+}

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -859,6 +859,68 @@ EOF
   _repo_has_issues_enabled
 }
 
+# --- _parse_issue_fields: END_ISSUE stop-set (#333) ---
+# In the normal flow parse_nonblocking_issues() has already consumed the
+# END_ISSUE terminator, so these blocks never reach _parse_issue_fields with it
+# attached. The stop-set entry is defensive hardening against a caller that
+# doesn't strip it first; these tests pin that behavior so it can't regress
+# back into a silent call-site dependency.
+
+@test "_parse_issue_fields: DETAILS stops at a trailing END_ISSUE" {
+  _load_fn _parse_issue_fields
+  local block="TITLE: Something
+SOURCE: code-reviewer
+LOCATION: src/a.ts:1
+DETAILS: First detail line.
+Second detail line.
+END_ISSUE"
+
+  local t s l d
+  _parse_issue_fields "${block}" t s l d
+
+  [[ "${d}" == "First detail line.
+Second detail line." ]]
+}
+
+@test "_parse_issue_fields: VERIFIED stops at a trailing END_ISSUE" {
+  _load_fn _parse_issue_fields
+  local block="TITLE: Something
+SOURCE: code-reviewer
+LOCATION: src/a.ts:1
+DETAILS: A detail.
+VERIFIED: gh api some/path -> 404
+second line of evidence
+END_ISSUE"
+
+  local t s l d v
+  _parse_issue_fields "${block}" t s l d v
+
+  [[ "${v}" == "gh api some/path -> 404
+second line of evidence" ]]
+  # DETAILS still terminates at the VERIFIED: header, as before.
+  [[ "${d}" == "A detail." ]]
+}
+
+@test "_parse_issue_fields: END_ISSUE-stripped blocks parse exactly as before" {
+  # Regression guard: the stop-set addition must not change the normal path,
+  # where parse_nonblocking_issues() has already removed the terminator.
+  _load_fn _parse_issue_fields
+  local block="TITLE: Something
+SOURCE: code-reviewer
+LOCATION: src/a.ts:1
+DETAILS: First detail line.
+Second detail line.
+VERIFIED: a command"
+
+  local t s l d v
+  _parse_issue_fields "${block}" t s l d v
+
+  [[ "${t}" == "Something" ]]
+  [[ "${d}" == "First detail line.
+Second detail line." ]]
+  [[ "${v}" == "a command" ]]
+}
+
 # --- dedup against existing open issues (#328) ---
 # The reviewer files one issue per finding with no memory of what it already
 # filed; in the field that produced 24 auto-filed issues in a day, the biggest
@@ -891,6 +953,10 @@ _load_dedup_fns() {
   _OPEN_ISSUES_CACHE=""
   _OPEN_ISSUES_STATE=""
   _HAS_ISSUES_CACHE=""
+  # Deliberately small so the truncation tests can hit the limit with a
+  # two-row payload instead of generating a thousand of them; the production
+  # value lives in lib-review-issues.sh and is asserted separately below.
+  _OPEN_ISSUES_LIMIT=2
 }
 
 # Mock gh whose `issue list` returns the given TSV rows and whose
@@ -1103,18 +1169,109 @@ END_ISSUE"
   [[ "${list_calls}" -eq 1 ]]
 }
 
+# --- open-issue listing truncation (#330) ---
+# `gh issue list --limit N` returns at most N rows and gives no signal that it
+# clipped anything, so a repo with more open issues than the limit would let
+# duplicates through with no explanation. The listing now asks for gh's maximum
+# and warns when the row count lands on the limit.
+
+# Capture log_warn output for the duration of one test. The file-scope
+# log_warn is a silent no-op; this shadows it locally.
+_capture_warnings() {
+  WARN_FILE="${MOCK_DIR}/warnings"
+  export WARN_FILE
+  log_warn() { printf '%s\n' "$*" >>"${WARN_FILE}"; }
+}
+
+@test "truncation: production limit is gh's documented maximum" {
+  # Guards against the limit being quietly lowered back toward the old 200.
+  # Read from the real library rather than the test's local override.
+  local limit
+  limit=$(bash -c 'source "$1"; printf "%s" "${_OPEN_ISSUES_LIMIT}"' _ "${SCRIPT}")
+  [[ "${limit}" -eq 1000 ]]
+}
+
+@test "truncation: listing at the limit warns that dedup may be incomplete" {
+  _load_dedup_fns
+  _capture_warnings
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  # _OPEN_ISSUES_LIMIT is 2 in tests, so a two-row payload is "full".
+  _mock_gh_with_open_issues \
+"1	https://github.com/org/repo/issues/1	First open issue title here	src/a.ts:1
+2	https://github.com/org/repo/issues/2	Second open issue title here	src/b.ts:2"
+
+  _load_open_issues
+
+  # Warned ...
+  grep -q "dedup may be incomplete" "${WARN_FILE}"
+  # ... but the listing is still usable, not downgraded to "error".
+  [[ "${_OPEN_ISSUES_STATE}" == "ok" ]]
+  [[ -n "${_OPEN_ISSUES_CACHE}" ]]
+}
+
+@test "truncation: a listing under the limit warns about nothing" {
+  _load_dedup_fns
+  _capture_warnings
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  _mock_gh_with_open_issues \
+"1	https://github.com/org/repo/issues/1	First open issue title here	src/a.ts:1"
+
+  _load_open_issues
+
+  [[ ! -e "${WARN_FILE}" ]]
+  [[ "${_OPEN_ISSUES_STATE}" == "ok" ]]
+}
+
+@test "truncation: an empty listing warns about nothing" {
+  _load_dedup_fns
+  _capture_warnings
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  _mock_gh_with_open_issues ""
+
+  _load_open_issues
+
+  [[ ! -e "${WARN_FILE}" ]]
+  [[ "${_OPEN_ISSUES_STATE}" == "ok" ]]
+}
+
+@test "truncation: the requested limit is what gh is actually asked for" {
+  _load_dedup_fns
+  PR_NUMBER="55"; PR_TITLE="Test PR"; REPO_OWNER="org"; REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+
+  _mock_gh_with_open_issues ""
+  _load_open_issues
+
+  grep -q -- "--limit ${_OPEN_ISSUES_LIMIT}" "${GH_CALLS_FILE}"
+}
+
 # --- verifiable-claims gate (#328 gate 3) ---
 
 _load_gate3_fns() {
+  # Marker array (not a function, so _load_fn does not pick it up). Get the
+  # REAL array by sourcing the library, rather than re-extracting its text
+  # with a sed range (#335) — a pattern match on the source silently yields an
+  # empty or partial array the moment the array's formatting changes, and an
+  # empty marker list makes every gate3 assertion test pass vacuously.
+  # Sourcing is safe here: lib-review-issues.sh is function definitions plus a
+  # source guard and a few constant assignments, with no top-level code that
+  # runs commands, exits, or touches the filesystem. `_LIB_REVIEW_ISSUES_LOADED`
+  # is cleared first so a second test in the same shell isn't no-op'd by the
+  # guard.
+  unset _LIB_REVIEW_ISSUES_LOADED
+  source "${SCRIPT}"
+  # _load_fn extraction still runs afterwards, so these tests keep exercising
+  # the same individually-extracted definitions they always did.
   _load_dedup_fns
   _load_fn _asserts_incorrectness
   _load_fn _unverified_caveat_body
   _load_fn _verification_section_body
-  # Marker array (not a function, so _load_fn does not pick it up). Kept in
-  # sync with the array in lib-review-issues.sh by sourcing it out of the
-  # script text rather than retyping it, so drift fails the test rather than
-  # silently testing a stale list.
-  eval "$(sed -n '/^_VERIFY_ASSERTION_MARKERS=(/,/^)$/p' "${SCRIPT}")"
 }
 
 # gh mock that records the full argv of each call, one call per line, so

--- a/tests/test_pre_merge_timeout.bats
+++ b/tests/test_pre_merge_timeout.bats
@@ -1,0 +1,212 @@
+#!/usr/bin/env bats
+# Tests for prompt-size-scaled analysis timeout in pre-merge-review.sh
+#
+# Background: TIMEOUT_SECONDS used to be a flat 180s constant assigned at
+# startup. Prompt size varies enormously between PRs and independently of
+# anything knowable at that point, so the constant was either too small for
+# big diffs or wastefully large for small ones. The observed failure was a
+# 460-line PR whose 33,835-byte prompt timed out twice at 180s and completed
+# comfortably at 420s.
+#
+# Fix: compute_effective_timeout() sizes the timeout from the assembled
+# prompt's byte count — a 180s floor plus 10s per KB, clamped to a 900s
+# ceiling — unless `git config review.preMergeTimeout` is set, in which case
+# that value is honored verbatim and scaling is skipped entirely.
+#
+# Run: bats ~/.claude/tests/test_pre_merge_timeout.bats
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+
+# Capture log_info output so tests can assert on which path was reported.
+# Exported so the eval'd function can call them.
+log_info() { echo "$*" >>"${LOG_FILE}"; }
+export -f log_info
+log_warn() { :; }
+export -f log_warn
+log_success() { :; }
+export -f log_success
+log_error() { :; }
+export -f log_error
+
+export LOG_FILE=""
+
+setup() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  LOG_FILE="${MOCK_DIR}/log.txt"
+  : >"${LOG_FILE}"
+}
+
+teardown() {
+  rm -rf "${MOCK_DIR}"
+}
+
+# Load only the named function from the script using sed range matching.
+# Same helper pattern as test_pre_merge_nonblocking.bats: the sed range stops
+# at the first bare `}` on its own line, so extracted functions must not
+# contain an unindented nested closing brace.
+_load_fn() {
+  local fn_name="$1"
+  local func_def
+  func_def=$(sed -n "/^${fn_name}()/,/^}$/p" "${SCRIPT}")
+  eval "${func_def}"
+}
+
+# Set up the constants the function reads, mirroring the script's own values,
+# then load the function under test.
+_setup_timeout_fn() {
+  TIMEOUT_FLOOR_SECONDS=180
+  TIMEOUT_PER_KB_SECONDS=10
+  TIMEOUT_CEILING_SECONDS=900
+  TIMEOUT_SECONDS="${TIMEOUT_FLOOR_SECONDS}"
+  TIMEOUT_OVERRIDE="${1:-}"
+  _load_fn compute_effective_timeout
+}
+
+# --- Constants match the calibration documented in the script ---
+
+@test "constants: script defines floor 180, 10s/KB, ceiling 900" {
+  grep -qE '^TIMEOUT_FLOOR_SECONDS=180$' "${SCRIPT}"
+  grep -qE '^TIMEOUT_PER_KB_SECONDS=10$' "${SCRIPT}"
+  grep -qE '^TIMEOUT_CEILING_SECONDS=900$' "${SCRIPT}"
+}
+
+# --- Scaled path ---
+
+@test "scaled: zero-byte prompt yields the 180s floor" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 0
+  [[ "${TIMEOUT_SECONDS}" == "180" ]]
+}
+
+@test "scaled: sub-1KB prompt still yields the 180s floor" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 900
+  [[ "${TIMEOUT_SECONDS}" == "180" ]]
+}
+
+@test "scaled: exactly 1KB prompt yields floor plus one increment" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 1024
+  [[ "${TIMEOUT_SECONDS}" == "190" ]]
+}
+
+@test "scaled: the 33835-byte regression case clears 420s comfortably" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 33835
+  # 33835 / 1024 = 33 KB -> 180 + 330 = 510
+  [[ "${TIMEOUT_SECONDS}" == "510" ]]
+  # The whole point: strictly greater than both the old flat default and the
+  # 420s value that was observed to work.
+  ((TIMEOUT_SECONDS > 180))
+  ((TIMEOUT_SECONDS > 420))
+}
+
+@test "scaled: mid-size prompt scales linearly" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 20480
+  # 20480 / 1024 = 20 KB -> 180 + 200 = 380
+  [[ "${TIMEOUT_SECONDS}" == "380" ]]
+}
+
+@test "scaled: logs the scaling rationale" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 33835
+  grep -q "510s" "${LOG_FILE}"
+  grep -q "scaled" "${LOG_FILE}"
+}
+
+# --- Ceiling ---
+
+@test "ceiling: pathological prompt is clamped to 900s" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 10000000
+  [[ "${TIMEOUT_SECONDS}" == "900" ]]
+}
+
+@test "ceiling: prompt just past the ceiling boundary is clamped" {
+  _setup_timeout_fn ""
+  # 900s ceiling is reached at 72 KB; 73 KB would compute 910.
+  compute_effective_timeout $((73 * 1024))
+  [[ "${TIMEOUT_SECONDS}" == "900" ]]
+}
+
+@test "ceiling: prompt at exactly the ceiling boundary is not clamped early" {
+  _setup_timeout_fn ""
+  compute_effective_timeout $((72 * 1024))
+  [[ "${TIMEOUT_SECONDS}" == "900" ]]
+  # Reported as a plain scaled value, not a clamp, since 180 + 720 == 900.
+  ! grep -q "clamped" "${LOG_FILE}"
+}
+
+@test "ceiling: clamped path says so in the log" {
+  _setup_timeout_fn ""
+  compute_effective_timeout 10000000
+  grep -q "clamped" "${LOG_FILE}"
+}
+
+# --- Explicit override path ---
+
+@test "override: configured value is honored verbatim" {
+  _setup_timeout_fn "420"
+  compute_effective_timeout 33835
+  [[ "${TIMEOUT_SECONDS}" == "420" ]]
+}
+
+@test "override: a value below the floor is still honored (no clamping up)" {
+  _setup_timeout_fn "60"
+  compute_effective_timeout 33835
+  [[ "${TIMEOUT_SECONDS}" == "60" ]]
+}
+
+@test "override: a value above the ceiling is still honored (no clamping down)" {
+  _setup_timeout_fn "3600"
+  compute_effective_timeout 10000000
+  [[ "${TIMEOUT_SECONDS}" == "3600" ]]
+}
+
+@test "override: logs that the override path was taken" {
+  _setup_timeout_fn "420"
+  compute_effective_timeout 33835
+  grep -q "explicit override" "${LOG_FILE}"
+  grep -q "review.preMergeTimeout" "${LOG_FILE}"
+}
+
+# --- Wiring: the function is actually called with the real prompt size ---
+
+@test "wiring: compute_effective_timeout is called with PROMPT_SIZE" {
+  grep -qE '^compute_effective_timeout "\$\{PROMPT_SIZE\}"$' "${SCRIPT}"
+}
+
+@test "wiring: the call site follows the prompt-size log line" {
+  local prompt_line call_line
+  prompt_line=$(grep -n 'Prompt size: ' "${SCRIPT}" | head -1 | cut -d: -f1)
+  call_line=$(grep -n '^compute_effective_timeout ' "${SCRIPT}" | head -1 | cut -d: -f1)
+  ((call_line > prompt_line))
+}
+
+@test "wiring: the git config read is an override, not a default of 180" {
+  # Guards against a regression to `... || echo "180"`, which would make the
+  # override path indistinguishable from the unset case.
+  grep -qE '^TIMEOUT_OVERRIDE=.*review\.preMergeTimeout.*echo ""\)$' "${SCRIPT}"
+}
+
+# --- Timeout message distinguishes infrastructure failure from a finding ---
+
+@test "message: timeout error states no opinion was rendered" {
+  grep -q "rendered NO opinion" "${SCRIPT}"
+}
+
+@test "message: timeout error names it an infrastructure failure" {
+  grep -q "infrastructure failure, not a review finding" "${SCRIPT}"
+}
+
+@test "message: timeout error surfaces the config key to the operator" {
+  grep -q 'git config --global review.preMergeTimeout' "${SCRIPT}"
+}
+
+@test "message: timeout error tells the operator to re-run the merge" {
+  grep -qi "Re-run the merge" "${SCRIPT}"
+}


### PR DESCRIPTION
Clears six tracked tech-debt issues. Each is an independent, self-contained fix with its own commit.

| Issue | Area | Fix |
|---|---|---|
| #330 | `lib-review-issues.sh` | Raise open-issue listing limit to gh's max; warn on probable truncation |
| #333 | `lib-review-issues.sh` | Stop DETAILS/VERIFIED awk at `END_ISSUE` |
| #335 | `test_pre_merge_nonblocking.bats` | Source the lib instead of re-extracting the marker array by `sed` |
| #342 | `run-review.sh` | Build issue body in a tempfile; model output can no longer truncate it |
| #343 | `pre-merge-review.sh` | Scale analysis timeout with prompt size |
| #344 | `install.sh` | `--sync --dry-run` reports pending work instead of claiming a match |

## Notes

**#343** is the substantive one. The timeout was a flat 180s while prompt size varies independently; a 460-line PR produced a 33,835-byte prompt, timed out twice, and cleared at 420s. Now computed after the prompt is assembled: 180s floor + 10s/KB, clamped at 900s — the known-bad case yields 510s. `review.preMergeTimeout` becomes a true explicit override (fallback is now empty rather than `180`, so "operator chose 180" is distinguishable from "unset"). The timeout message now states the analysis rendered no opinion and that this is infrastructure rather than a review finding.

**#335** was fixed by sourcing the library, after confirming it is side-effect-free (function definitions, a source guard, and constants only).

**#342** keeps the unquoted heredoc delimiter deliberately — the body depends on `${var}` expansion, so quoting it to dodge the collision would defeat the purpose. The tempfile is what removes model text from the delimiter path.

## Testing

164 -> 199 tests (+35). Full suite run before and after; the set of failing tests is **identical to clean `main`** by name, not just by count. Those 8 pre-existing failures are environmental (`Claude CLI not found` under the sandboxed `HOME`) in `test_gh_wrapper*.bats` and `test_pre_merge_changes_requested.bats`, and are untouched by this branch.

`shellcheck -S info` clean on all four changed shell scripts (run from `hooks/` so relative source paths resolve). The one remaining finding, SC2249 at `run-review.sh:88`, is pre-existing in code this PR does not touch. No `# shellcheck disable` directives added.

New test files: `tests/test_pre_merge_timeout.bats` (22 tests), `tests/test_install_sync_dry_run.bats` (5 tests, isolated to a throwaway repo and HOME).

Closes #330
Closes #333
Closes #335
Closes #342
Closes #343
Closes #344

https://claude.ai/code/session_01L2LtUHANbr8gLcV9sWNBwD