### PR TITLE
fix(tests): resolve scripts under test from the checkout, not the deployed tree

### DIFF
--- a/tests/test_hook_block_api_merge.bats
+++ b/tests/test_hook_block_api_merge.bats
@@ -12,7 +12,7 @@
 #
 # Run: bats ~/.claude/tests/test_hook_block_api_merge.bats
 
-HOOK="${HOME}/.claude/scripts/hook-block-api-merge.sh"
+HOOK="${BATS_TEST_DIRNAME}/../scripts/hook-block-api-merge.sh"
 
 # Build a Claude Code PreToolUse JSON payload for a Bash tool call.
 # Uses jq to properly escape special characters (quotes, backslashes, etc.)

--- a/tests/test_pre_merge_changes_requested.bats
+++ b/tests/test_pre_merge_changes_requested.bats
@@ -11,7 +11,7 @@
 #
 # Run: bats ~/.claude/tests/test_pre_merge_changes_requested.bats
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/pre-merge-review.sh"
 
 # PR JSON with reviewDecision = CHANGES_REQUESTED
 JSON_CHANGES_REQUESTED='{"number":640,"title":"fix: something","reviewDecision":"CHANGES_REQUESTED","reviews":[{"author":{"login":"alice"},"state":"CHANGES_REQUESTED","body":"needs work","submittedAt":"2026-01-20T18:00:00Z"}],"comments":[],"state":"OPEN","statusCheckRollup":[]}'
@@ -83,7 +83,7 @@ echo \"[]\"
 exit 0
 GHEOF
       chmod +x \"${MOCK_DIR}/gh\"
-      '${SCRIPT}' pr merge 640
+      '${SCRIPT}' pr merge 640 --squash --delete-branch
     " 2>&1
 }
 

--- a/tests/test_pre_merge_early_auth.bats
+++ b/tests/test_pre_merge_early_auth.bats
@@ -12,7 +12,7 @@
 #
 # Run: bats ~/.claude/tests/test_pre_merge_early_auth.bats
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/pre-merge-review.sh"
 VALID_JSON='{"number":59,"title":"test PR","reviewDecision":"","reviews":[],"comments":[],"state":"OPEN","statusCheckRollup":[]}'
 
 setup() {

--- a/tests/test_pre_merge_fetch.bats
+++ b/tests/test_pre_merge_fetch.bats
@@ -10,7 +10,7 @@
 #
 # Run: bats ~/.claude/tests/test_pre_merge_fetch.bats
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/pre-merge-review.sh"
 VALID_JSON='{"number":53,"title":"test PR","reviewDecision":"","reviews":[],"comments":[],"state":"OPEN","statusCheckRollup":[]}'
 
 setup() {

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -5,7 +5,7 @@
 
 bats_require_minimum_version 1.5.0
 
-SCRIPT="${HOME}/.claude/hooks/lib-review-issues.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/lib-review-issues.sh"
 
 # Suppress log output in tests (exported so eval'd functions can call them)
 log_info() { :; }

--- a/tests/test_pre_merge_repo_flag.bats
+++ b/tests/test_pre_merge_repo_flag.bats
@@ -17,7 +17,7 @@
 #
 # Run: bats ~/.claude/tests/test_pre_merge_repo_flag.bats
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/pre-merge-review.sh"
 VALID_JSON='{"number":123,"title":"test PR","reviewDecision":"APPROVED","reviews":[],"comments":[],"state":"OPEN","statusCheckRollup":[{"name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}]}'
 
 setup() {

--- a/tests/test_pre_merge_timeout.bats
+++ b/tests/test_pre_merge_timeout.bats
@@ -17,7 +17,7 @@
 
 bats_require_minimum_version 1.5.0
 
-SCRIPT="${HOME}/.claude/hooks/pre-merge-review.sh"
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/pre-merge-review.sh"
 
 # Capture log_info output so tests can assert on which path was reported.
 # Exported so the eval'd function can call them.

--- a/tests/test_run_review_identity.bats
+++ b/tests/test_run_review_identity.bats
@@ -6,6 +6,12 @@
 #
 # Run: bats ~/.claude/tests/test_run_review_identity.bats
 
+# Resolve the script under test relative to THIS test file, not via
+# ${HOME}/.claude/hooks — that path is a symlink to the main working
+# directory, so in a git worktree it would silently exercise main's copy
+# instead of the branch under test.
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/run-review.sh"
+
 setup() {
   # Create a temp git repo so git commands work
   TMPDIR_TEST="$(mktemp -d)"
@@ -46,7 +52,7 @@ run_review() {
   cd "${TMPDIR_TEST}" || exit
   printf 'diff --git a/foo.js b/foo.js\nindex 0000000..1234567 100644\n--- a/foo.js\n+++ b/foo.js\n@@ -0,0 +1 @@\n+const x = 1;\n' \
     | REVIEW_LOG="${EXPECTED_LOG}" CLAUDE_CLI="${CLAUDE_CLI}" \
-      bash "${HOME}/.claude/hooks/run-review.sh"
+      bash "${SCRIPT}"
 }
 
 @test "log header contains 'repo:' field pointing to the test repo root" {
@@ -77,7 +83,7 @@ run_review() {
   cd "${TMPDIR_TEST}"
   printf 'diff --git a/foo.js b/foo.js\nindex 0000000..1234567 100644\n--- a/foo.js\n+++ b/foo.js\n@@ -0,0 +1 @@\n+const x = 1;\n' \
     | CLAUDE_CLI="${CLAUDE_CLI}" \
-      bash "${HOME}/.claude/hooks/run-review.sh" || true
+      bash "${SCRIPT}" || true
   [[ -f "${TMPDIR_TEST}/.git/last-review-result.log" ]]
 }
 

--- a/tests/test_run_review_message_file.bats
+++ b/tests/test_run_review_message_file.bats
@@ -14,6 +14,12 @@
 #
 # Run: bats ~/.claude/tests/test_run_review_message_file.bats
 
+# Resolve the script under test relative to THIS test file, not via
+# ${HOME}/.claude/hooks — that path is a symlink to the main working
+# directory, so in a git worktree it would silently exercise main's copy
+# instead of the branch under test.
+SCRIPT="${BATS_TEST_DIRNAME}/../hooks/run-review.sh"
+
 setup() {
   TMPDIR_TEST="$(mktemp -d)"
   export TMPDIR_TEST
@@ -82,7 +88,7 @@ _run_review() {
     cd "${TMPDIR_TEST}" || return 1
     printf '%s\n' "${diff}" \
       | REVIEW_LOG="${EXPECTED_LOG}" CLAUDE_CLI="${CLAUDE_CLI}" \
-        bash "${HOME}/.claude/hooks/run-review.sh" "$@"
+        bash "${SCRIPT}" "$@"
   )
 }
 

--- a/tests/test_suite_paths_worktree_safe.bats
+++ b/tests/test_suite_paths_worktree_safe.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# Guards that test suites resolve the scripts under test from the checkout
+# they live in, not from the deployed ~/.claude tree.
+#
+# Background: several suites used to set SCRIPT="${HOME}/.claude/hooks/...".
+# install.sh symlinks ~/.claude/hooks/* back to the main checkout, so an agent
+# working in a git worktree ran those grep-based assertions against the
+# unmodified main copy. That fails in both directions: new tests for a
+# worktree edit fail no matter how correct the edit is, and — worse — a suite
+# reports green against main while the worktree change is actually broken.
+# This was demonstrated by flipping TIMEOUT_CEILING_SECONDS to 901 in a
+# worktree and watching all 22 timeout tests still pass.
+#
+# Fix: address scripts as "${BATS_TEST_DIRNAME}/../<dir>/<script>". Test files
+# are never deployed — install.sh excludes tests/* and *.bats from the symlink
+# tree — so BATS_TEST_DIRNAME/.. is always the repo root of whichever checkout
+# is being exercised. No ~/.claude fallback is warranted: it could never be
+# reached, and would only mask a genuinely missing script.
+#
+# Run: bats ~/.claude/tests/test_suite_paths_worktree_safe.bats
+
+bats_require_minimum_version 1.5.0
+
+TESTS_DIR="${BATS_TEST_DIRNAME}"
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+@test "no suite resolves the script under test from the deployed ~/.claude tree" {
+  # Matches assignments and direct invocations pointing into ~/.claude/hooks
+  # or ~/.claude/scripts. Sandboxed fake deploy trees (MOCK_HOME, or a HOME
+  # reassigned inside the test) are deliberately excluded: those construct
+  # their own tree rather than reading the developer's real one.
+  # Anchored at line start so this file's own explanatory prose, which quotes
+  # the retired pattern, is not mistaken for a live assignment.
+  run grep -rnE '^(SCRIPT|HOOK)="\$\{HOME\}/\.claude/' "${TESTS_DIR}"
+  [[ "${status}" -ne 0 ]]
+
+  run grep -rnE 'bash "\$\{HOME\}/\.claude/(hooks|scripts)/' "${TESTS_DIR}"
+  [[ "${status}" -ne 0 ]]
+}
+
+@test "every BATS_TEST_DIRNAME-relative script reference resolves to a real file" {
+  # A path that does not resolve means a suite is silently asserting against
+  # nothing, which greps would report as a pass-by-absence.
+  local ref path missing=0
+  while IFS= read -r ref; do
+    [[ -z "${ref}" ]] && continue
+    path="${REPO_ROOT}/${ref}"
+    if [[ ! -f "${path}" ]]; then
+      echo "unresolvable script reference: ${ref}"
+      ((missing += 1))
+    fi
+  done < <(grep -rhoE '\$\{BATS_TEST_DIRNAME\}/\.\./[A-Za-z0-9_./-]+\.sh' "${TESTS_DIR}" \
+    | sed 's|\${BATS_TEST_DIRNAME}/\.\./||' | sort -u)
+
+  [[ "${missing}" -eq 0 ]]
+}
+
+@test "install.sh excludes tests from the deployed tree, so no ~/.claude fallback is needed" {
+  # This is the load-bearing premise of the fix above. If tests ever start
+  # being deployed, BATS_TEST_DIRNAME/.. would no longer be a repo root and
+  # this guard should fail loudly rather than let the suites drift.
+  grep -qE '^\s*tests/\*\) return 0 ;;' "${REPO_ROOT}/install.sh"
+  grep -qE '^\s*\*\.bats\) return 0 ;;' "${REPO_ROOT}/install.sh"
+}


### PR DESCRIPTION
## What this fixes

Ten bats suites addressed the script under test via `${HOME}/.claude/...`. `install.sh` symlinks that path back into the main working directory, so tests run from a git worktree exercised **main's copy, not the branch under test**. A green run proved nothing about the diff.

Demonstrated with a known-bad case: flipping `TIMEOUT_CEILING_SECONDS` from 900 to 901 in a worktree left **all 22 tests in `test_pre_merge_timeout.bats` passing**.

## Changes

**Path resolution (7 suites)** — `SCRIPT`/`HOOK` now resolve as `${BATS_TEST_DIRNAME}/../<dir>/…`, the pattern five sibling suites already used. Test files are never deployed (`install.sh:160,162` exclude `*.bats` and `tests/*`), so that is always the repo root of whichever checkout is running.

**Direct invocations (2 suites)** — `test_run_review_{identity,message_file}.bats` called `run-review.sh` through the deployed path; routed through `SCRIPT`.

**A real behavioral bug (1 suite)** — `test_pre_merge_changes_requested.bats` invoked `pr merge 640` without `--squash --delete-branch`. The hook rejects that at flag validation and exits *before* reaching the CHANGES_REQUESTED block the tests assert on, so three tests failed for a reason unrelated to their subject. Now **12/12**, up from 9/12.

**A regression guard (new)** — `test_suite_paths_worktree_safe.bats` fails if any suite reintroduces a `~/.claude` path, if a `BATS_TEST_DIRNAME`-relative reference does not resolve to a real file, or if `install.sh` stops excluding tests from the deployed tree.

The guard earned its place immediately: it caught **two violations missed on the first pass** — a `HOOK=` assignment (different variable name, so the original grep missed it) and three direct `bash "${HOME}/.claude/..."` invocations in two untouched files.

## Verification

| Check | Result |
|---|---|
| bats | 197 pass, 5 fail |
| `scripts/tests/*.sh` | 177/177 |
| shellcheck -S info | 17 informational, **identical to baseline** (stash-verified) |
| Guard assertions | 3/3, each validated against a deliberately broken case |

The 5 bats failures are the pre-existing missing-`claude`-stub fixture gap tracked in #360, unchanged by this PR. Confirmed identical before and after via `git stash`.

Both suites were run — `bats tests/` alone does not cover `scripts/tests/*.sh`, which is its own five standalone suites.

## Why this matters beyond the immediate bug

This is a plausible engine behind the repeating follow-up-issue cycle in this repo: fixes land looking verified, vacuous green hides what is still wrong, and the next review round rediscovers it as a fresh issue. Three separate instances of "a check that does not cover what it claims to" surfaced in one session (#359, #360, and a second test suite going unrun).

## Scope

Deliberately limited to the confirmed test-harness work. The worktree-hook cluster (#347/#348/#349/#352) has competing candidate fixes that need design judgment and will come separately.

Refs #359, #360

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
