### PR TITLE
fix(hooks): treat an opening quote as a separator in the worktree hook

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -219,13 +219,24 @@ block() {
 # Handled: `$(...)` command substitution (the `(` alternative catches it),
 # `` `...` `` command substitution (the backtick alternative, which also
 # terminates the captured argument list so the closing backtick is not
-# swallowed into the path token), `env`/`command`/`sudo`-prefixed git, and
-# absolute/relative-path invocation such as `/usr/bin/git`.
+# swallowed into the path token), `env`/`command`/`sudo`-prefixed git,
+# absolute/relative-path invocation such as `/usr/bin/git`, and git preceded by
+# an opening quote of any kind -- `'`, `\"`, or ANSI-C `$'...'`.
+#
+# The quote alternatives close a class that was silently open: `bash -c 'git
+# worktree add /tmp/evil'`, the `\"` form, and `eval $'...'` all placed git
+# after a quote rather than after a separator, so none matched and every one
+# skipped path_in_scope() entirely. Heredocs were never part of this class --
+# `grep -oE` matches per line, so a heredoc body's `git` sits at line start and
+# the `^` alternative already caught it. Enumerating heredocs as a bypass would
+# have been wrong.
 #
 # NOT handled, and NOT closeable at this layer:
 #
 #   * aliases and shell functions that resolve to git
 #   * obfuscation via variables, e.g. G=git; $G worktree add /tmp/evil
+#   * any construction that spells `git` without the literal four characters,
+#     e.g. concatenation or parameter expansion producing the name at runtime
 #
 # Both require knowing what a name resolves to at runtime. A PreToolUse hook
 # receives the raw, unexpanded command string and never sees the shell that
@@ -250,7 +261,7 @@ block() {
 # substitution (SC2016), and disable directives are not permitted here.
 bt=$(printf '\140')
 readonly bt
-worktree_re="(^|&&|\\|\\||;|\\||&|\\(|\\{|${bt}|[[:space:]]then|[[:space:]]do)[[:space:]]*((env|command|sudo)[[:space:]]+)*([^[:space:]|;&(){${bt}]*/)?git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&${bt}[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+[^|;&){${bt}]*)?"
+worktree_re="(^|&&|\\|\\||;|\\||&|\\(|\\{|${bt}|'|\"|[[:space:]]then|[[:space:]]do)[[:space:]]*((env|command|sudo)[[:space:]]+)*([^[:space:]|;&(){${bt}]*/)?git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&${bt}[:space:]]*[[:space:]]+)?)*worktree([[:space:]]+[^|;&){${bt}]*)?"
 
 mapfile -t matches < <(printf '%s\n' "${cmd}" | grep -oE "${worktree_re}" || true)
 
@@ -262,6 +273,12 @@ for match in "${matches[@]}"; do
   read -r -a tokens <<<"${args}" || true
 
   subcmd="${tokens[0]-}"
+  # A quote-prefixed occurrence carries its closing quote into the last token,
+  # so `bash -c 'git worktree list'` arrives as `list'`. Strip one trailing
+  # quote so the subcommand compares equal. The path is untouched --
+  # path_in_scope() strips a matched pair itself.
+  subcmd="${subcmd%\'}"
+  subcmd="${subcmd%\"}"
 
   case "${subcmd}" in
     # Read-only / inspection: this occurrence is fine, keep checking others.

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -240,6 +240,39 @@ check "backtick substitution: scoped creation allowed" 0 "${inp}"
 inp="$(make_input "echo ${backtick}git worktree list${backtick}")"
 check "backtick substitution: read-only subcommand allowed" 0 "${inp}"
 
+# --- Quote-prefixed git (was a silently open gap; now closed) ---
+# `git` placed after an opening quote rather than a separator matched none of
+# the alternation, so path_in_scope() never ran. Covers single, double, and
+# ANSI-C quoting; `eval` is included because it is the common vehicle.
+sq="'"
+dq='"'
+inp="$(make_input "bash -c ${sq}git worktree add /tmp/evil${sq}")"
+check "quote prefix: single-quoted unscoped creation blocked" 2 "${inp}"
+inp="$(make_input "bash -c ${dq}git worktree add /tmp/evil${dq}")"
+check "quote prefix: double-quoted unscoped creation blocked" 2 "${inp}"
+inp="$(make_input "bash -c ${dollar}${sq}git worktree add /tmp/evil${sq}")"
+check "quote prefix: ANSI-C quoted unscoped creation blocked" 2 "${inp}"
+inp="$(make_input "eval ${sq}git worktree add /tmp/evil${sq}")"
+check "quote prefix: eval-wrapped unscoped creation blocked" 2 "${inp}"
+inp="$(make_input "bash -c ${sq}git worktree move /tmp/a /tmp/b${sq}")"
+check "quote prefix: administrative subcommand blocked" 2 "${inp}"
+# Scoped targets must still pass, and a quoted path must not be contaminated by
+# its own quotes -- otherwise legitimate quoted creation would be rejected.
+inp="$(make_input "bash -c ${sq}git worktree add .claude/worktrees/ok${sq}")"
+check "quote prefix: scoped creation allowed" 0 "${inp}"
+inp="$(make_input "git worktree add ${dq}.claude/worktrees/ok${dq}")"
+check "quote prefix: quoted scoped path still allowed" 0 "${inp}"
+inp="$(make_input "bash -c ${sq}git worktree list${sq}")"
+check "quote prefix: read-only subcommand allowed" 0 "${inp}"
+
+# --- Heredocs: already blocked, asserted so nobody "fixes" a non-gap ---
+# grep -oE matches per line, so a heredoc body's `git` sits at line start and
+# the `^` alternative catches it. Issue #349 claimed heredocs were a bypass;
+# they are not. Pinned so that claim cannot be reintroduced as a change.
+heredoc_cmd=$(printf 'cat <<EOF\ngit %s add /tmp/evil\nEOF' 'worktree')
+inp="$(make_input "${heredoc_cmd}")"
+check "heredoc body is matched at line start (not a bypass)" 2 "${inp}"
+
 # --- PERMANENTLY OPEN gaps, asserted as CURRENT behavior, not desired ---
 # Documented in the KNOWN LIMITATION block in the hook header. A PreToolUse
 # hook sees the raw, unexpanded command string with no access to the executing


### PR DESCRIPTION
Closes #349.

## The gap

`git` placed after an opening **quote** rather than after a separator matched no alternative in `worktree_re`, so the occurrence was never inspected and `path_in_scope()` never ran.

Four forms bypassed the hook entirely — all verified at **exit 0** before this change:

| Form | Example |
|---|---|
| single-quoted | ``bash -c 'git worktree add /tmp/evil'`` |
| double-quoted | ``bash -c "git worktree add /tmp/evil"`` |
| ANSI-C quoted | ``bash -c $'git worktree add /tmp/evil'`` |
| eval-wrapped | ``eval 'git worktree add /tmp/evil'`` |

## The fix

Adds `'` and `"` to the separator alternation, then strips one trailing quote from the **subcommand token** — a quote-prefixed occurrence carries its closing quote into the last token, so ``bash -c 'git worktree list'`` arrives as `list'`, matches no allowed subcommand, and would fall through to blocked.

The path is deliberately **not** quote-stripped the same way. An earlier attempt added the quote characters to the regex terminator classes, which broke ``git worktree add ".claude/worktrees/x"`` — a legitimately quoted scoped path, previously exit 0, became exit 2. `path_in_scope()` already strips a matched pair itself; only the subcommand needed help.

## #349 is half wrong, and this PR records which half

**Its primary claim — that heredoc bodies bypass the hook — is FALSE.** `grep -oE` matches per line, so a heredoc body's `git` sits at line start and the `^` alternative already catches it. Verified: a heredoc payload with a real newline exits 2.

Enumerating heredocs as a bypass, as the issue suggests, would have documented a gap that does not exist. A test now pins this so the claim cannot be reintroduced as a change.

**Its secondary claim — ANSI-C quoting — is REAL**, and generalizes further than the issue described: the gap was never about `$'` specifically, but about *any* opening quote preceding `git`.

## Validation

The five quote-prefix assertions **fail against the pre-fix hook** and pass after it:

```
FAIL: quote prefix: single-quoted unscoped creation blocked (expected exit 2, got 0)
FAIL: quote prefix: double-quoted unscoped creation blocked (expected exit 2, got 0)
FAIL: quote prefix: ANSI-C quoted unscoped creation blocked (expected exit 2, got 0)
FAIL: quote prefix: eval-wrapped unscoped creation blocked (expected exit 2, got 0)
FAIL: quote prefix: administrative subcommand blocked (expected exit 2, got 0)
```

The heredoc assertion passes in both — correctly, since it pins existing behaviour rather than new.

Regression-checked: quoted scoped paths and ``bash -c 'git worktree list'`` both still exit 0.

| Check | Result |
|---|---|
| `scripts/tests/*.sh` | 191/191 (worktree suite **89**, was 80) |
| bats | 197 pass, 5 fail (pre-existing #360 gap) |
| shellcheck -S info | clean, no disable directives |

## Still open

Documented in the header, unchanged: aliases and shell functions resolving to `git`, variable obfuscation, and any construction spelling `git` without the literal characters. Those need runtime resolution a PreToolUse hook cannot perform.

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
