### PR TITLE
fix(hooks): refuse worktree paths containing a backslash

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -103,8 +103,17 @@ path_in_scope() {
   # Reject unexpanded shell constructs. We cannot resolve these statically,
   # so they can never be proven in-scope. Covers $VAR, ${VAR}, $(cmd),
   # backticks, ~ expansion, and glob characters.
+  #
+  # A backslash is rejected for a related but distinct reason: the argument list
+  # is split with `read -r -a`, which does NOT honor backslash escaping. A path
+  # written `.claude/worktrees/my\ evil` therefore arrives as two tokens, and only
+  # the first (`.claude/worktrees/my`) reaches this function -- which approves it,
+  # while the shell goes on to create `.claude/worktrees/my evil`. The hook would
+  # be approving a path that is not the one created. Since the escape cannot be
+  # honored here, a path carrying a backslash is refused rather than
+  # approximated.
   case "${path}" in
-    *'$'* | *'`'* | *'~'* | *'*'* | *'?'* | *'['*) return 1 ;;
+    *'$'* | *'`'* | *'~'* | *'*'* | *'?'* | *'['* | *\\*) return 1 ;;
     # No unexpanded shell construct found; continue validating below.
     *) ;;
   esac

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -272,6 +272,19 @@ check "quote prefix: read-only subcommand allowed" 0 "${inp}"
 heredoc_cmd=$(printf 'cat <<EOF\ngit %s add /tmp/evil\nEOF' 'worktree')
 inp="$(make_input "${heredoc_cmd}")"
 check "heredoc body is matched at line start (not a bypass)" 2 "${inp}"
+# --- Backslash in a path (read -r -a does not honor the escape) ---
+# `read -r -a` splits on IFS without honoring backslash escapes, so
+# `.claude/worktrees/my\\ evil` arrives as two tokens and only the first reaches
+# path_in_scope(). That token IS a valid in-scope prefix, so the hook would
+# approve it -- while the shell goes on to create `.claude/worktrees/my evil`,
+# a different path than the one validated. Refused rather than approximated.
+bs='\\'
+inp="$(make_input "git worktree add .claude/worktrees/my${bs} evil")"
+check "backslash: escaped space in an in-scope path is refused" 2 "${inp}"
+inp="$(make_input "git worktree add /tmp/my${bs} evil")"
+check "backslash: escaped space in an out-of-scope path is refused" 2 "${inp}"
+inp="$(make_input "git worktree add .claude/worktrees/plain")"
+check "backslash: an unescaped scoped path is still allowed" 0 "${inp}"
 
 # --- PERMANENTLY OPEN gaps, asserted as CURRENT behavior, not desired ---
 # Documented in the KNOWN LIMITATION block in the hook header. A PreToolUse


### PR DESCRIPTION
Closes #348.

## The gap

`read -r -a` splits the argument list on IFS **without honoring backslash escapes**. A path written `.claude/worktrees/my\ evil` arrives as two tokens, and only the first — `.claude/worktrees/my` — reaches `path_in_scope()`.

That token *is* a valid in-scope prefix, so the hook approved it. The shell then went on to create `.claude/worktrees/my evil` — a different path than the one validated.

Verified before the change: **exit 0**. The hook was approving a path it had not actually checked.

## The fix

Adds a backslash to the metacharacter rejection in `path_in_scope()`. The escape cannot be honored at this layer, so a path carrying one is refused rather than approximated.

The accompanying comment explains why a backslash differs from the neighbouring metacharacters: those are *expansion* hazards ($VAR, globs, `~`), this is a *tokenization* hazard. Worth stating so the next reader doesn't take it for a copy-paste.

## #348's headline is wrong, and this PR records why the fix still stands

The issue asserts that for a **quoted** path with a space, the first token passes the in-scope check.

It does not. `read -r -a` does not strip quotes, so the surviving token is `".claude/worktrees/my` — with an unbalanced opening quote attached. The paired-quote strip in `path_in_scope()` requires a matched pair, so it never fires, and the token matches no scope prefix. **The quoted spelling was already blocked.**

The **backslash** spelling is the real gap, and it is a distinct mechanism from the one the issue described. Investigating a wrong claim surfaced a true adjacent defect.

## Validation

Validated against a known-bad case — the in-scope assertion fails against the pre-fix hook and passes after:

```
FAIL: backslash: escaped space in an in-scope path is refused (expected exit 2, got 0)
```

| Check | Result |
|---|---|
| `scripts/tests/*.sh` | 185/185 (worktree suite **83**, was 80) |
| bats | 197 pass, 5 fail (pre-existing #360 gap) |
| shellcheck -S info | clean, no disable directives |

## Relationship to #372

Independent. This is a one-line addition inside `path_in_scope()`; #372 changes the separator alternation in `worktree_re`. Branched off main rather than stacked, so the two can merge in either order.

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
