### PR TITLE
docs(hooks): record the accepted trade-off in unscoped worktree cleanup

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -17,7 +17,8 @@
 #                                 predating the ban was permanently
 #                                 un-cleanable by tooling, and held its
 #                                 branch checked out so `git branch -D`
-#                                 refused.
+#                                 refused. Deliberately NOT path-scoped --
+#                                 see the ACCEPTED TRADE-OFF note below.
 #     ALLOWED  add <path>         ONLY when <path> is under `.claude/worktrees/`.
 #                                 This matches the Agent tool's
 #                                 `isolation: "worktree"` convention
@@ -29,6 +30,29 @@
 #     BLOCKED  move, lock, unlock, repair
 #                                 rewrite worktree administrative state.
 #     BLOCKED  bare `git worktree`, unknown/future subcommands (fail closed).
+#
+#   ACCEPTED TRADE-OFF -- `remove`/`prune` accept ANY path, in or out of scope.
+#   Unlike `add`, cleanup runs no path inspection at all. `git worktree remove
+#   --force /anywhere/else` passes, and `--force` is itself allowed on purpose
+#   (agent worktrees carry untracked setup files, and plain `remove` refuses
+#   those). So one agent CAN destroy a peer agent's worktree along with its
+#   uncommitted work. That is a real consequence, not a theoretical one.
+#
+#   It is accepted rather than fixed because path-scoping `remove` would undo
+#   the exact thing dotfiles#200 fixed: the worktrees most needing cleanup are
+#   the pre-ban ones, which by definition sit at arbitrary paths OUTSIDE
+#   `.claude/worktrees/`. A scoped `remove` would leave them permanently
+#   un-cleanable and still holding their branches checked out -- the original
+#   bug. Scoping creation but not cleanup is the asymmetry that makes both
+#   halves work.
+#
+#   What bounds the risk: `remove` only affects worktrees already registered in
+#   `.git/config`, so it cannot reach into arbitrary directories; and cleanup
+#   only ever reduces worktree count, so it cannot recreate a collision. The
+#   residual exposure is peer-agent worktrees, which are registered by design.
+#   If concurrent-agent worktree clobbering is ever observed in practice, the
+#   fix belongs in agent orchestration (ownership metadata per worktree), not
+#   in a regex hook that cannot tell one agent's path from another's.
 #
 #   Why the ban was relaxed at all: "work directly on a feature branch instead"
 #   assumed one worker per checkout. Subagent-driven execution is now the
@@ -246,6 +270,12 @@ for match in "${matches[@]}"; do
       ;;
     # Cleanup: only ever reduces worktree count, so it cannot recreate the
     # collision conditions the ban was written for.
+    #
+    # Intentionally NOT path-scoped, unlike `add` above. The worktrees most in
+    # need of cleanup are pre-ban ones living outside `.claude/worktrees/`, so
+    # scoping here would restore the un-cleanable-worktree bug dotfiles#200
+    # fixed. The cost is that an agent can remove a peer agent's worktree; see
+    # the ACCEPTED TRADE-OFF note in the header before narrowing this.
     remove | prune)
       continue
       ;;

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -69,6 +69,14 @@ inp="$(make_input 'git worktree remove --force .claude/worktrees/agent-abc')"
 check "cleanup: remove --force (required for dirty worktrees)" 0 "${inp}"
 inp="$(make_input 'git worktree prune --dry-run')"
 check "cleanup: prune --dry-run" 0 "${inp}"
+# ACCEPTED TRADE-OFF (#347): cleanup is deliberately NOT path-scoped, so the
+# forceful out-of-scope form -- the one that can destroy a peer agent's
+# worktree and its uncommitted work -- is allowed too. Pinned so that adding
+# path-scoping to `remove` trips a test instead of silently re-breaking the
+# pre-ban cleanup case dotfiles#200 fixed. See the header's ACCEPTED TRADE-OFF
+# note before changing this expectation.
+inp="$(make_input 'git worktree remove --force /tmp/other-agents-worktree')"
+check "cleanup: forceful out-of-scope remove (deliberately allowed, #347)" 0 "${inp}"
 
 # --- dotfiles#200: creation ALLOWED only under .claude/worktrees/ ---
 inp="$(make_input 'git worktree add .claude/worktrees/agent-abc123')"


### PR DESCRIPTION
Closes #347.

Documentation only — **31 comment lines, zero non-comment changes** to the hook — plus one test pinning the deliberate allowance.

## The risk is real, and larger than the issue's framing

#347 describes the exposure as "real-world-low". Reproduced live in a sandbox repo, it is not:

```
peer contents before: precious.txt
--- plain remove ---
fatal: '...' contains modified or untracked files, use --force to delete it
--- forced remove ---
peer dir after: DELETED
precious.txt: DESTROYED
```

Plain `remove` refuses untracked files, but `--force` is allowed **on purpose** — agent worktrees always carry untracked setup files, so it is the form actually used. Concurrent agents therefore *can* clobber each other's uncommitted work.

That is worth stating plainly given this repo routinely runs many parallel agents, each holding a worktree.

## Chesterton's Fence — why it stays unscoped

Path-scoping `remove` would undo exactly what dotfiles#200 fixed. The worktrees most in need of cleanup are the **pre-ban** ones, which by definition sit at arbitrary paths *outside* `.claude/worktrees/`. A scoped `remove` would leave them permanently un-cleanable by tooling and still holding their branches checked out, so `git branch -D` would refuse.

Scoping creation but *not* cleanup is the asymmetry that makes both halves work.

**What bounds the risk:** `remove` only affects worktrees already registered in `.git/config`, so it cannot reach arbitrary directories; and cleanup only ever reduces worktree count, so it cannot recreate the collision conditions the ban was written for.

The residual exposure is peer-agent worktrees, which are registered by design. If clobbering is ever observed in practice, the fix belongs in **agent orchestration** — per-worktree ownership metadata — not in a regex hook that cannot tell one agent's path from another's.

## The issue also cites a stale location

#347 points at "the test at line 544". No such bats file exists — the assertion is in `scripts/tests/test-hook-block-git-worktree.sh` at lines 60-61. Corrected here so the next reader doesn't chase it.

## Validation

The new test pins `remove --force` of an out-of-scope path as expected-exit-0. Validated against a known-bad case: patching `path_in_scope()` into the `remove`/`prune` branch trips **7 assertions**, so the pin genuinely detects the regression it exists to catch — rather than passing for the wrong reason.

| Check | Result |
|---|---|
| `scripts/tests/*.sh` | 183/183 (worktree suite **81**, was 80) |
| bats | 197 pass, 5 fail (pre-existing #360 gap) |
| shellcheck -S info | clean |

Branched off main, independent of #372 and #373.

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
