### PR TITLE
fix(tests): unset the inherited review-script override in gh wrapper fixtures

### DIFF
--- a/tests/test_gh_binary_wrapper.bats
+++ b/tests/test_gh_binary_wrapper.bats
@@ -17,6 +17,15 @@
 GH_WRAPPER="${HOME}/.local/bin/gh"
 
 setup() {
+  # The wrapper's review-script location is an exported override
+  # (_gh_wrapper_review_script). If the developer's interactive shell exported
+  # it -- and sourcing gh-wrapper.sh does exactly that -- bats inherits the
+  # value, and it wins over the sandboxed HOME below. The mock hook would then
+  # be ignored in favour of the real one, which fails for reasons unrelated to
+  # anything under test. Unset it so HOME is genuinely the only input.
+  # See smartwatermelon/dotfiles#222 and #360.
+  unset _gh_wrapper_review_script
+
   MOCK_DIR="$(mktemp -d)"
   export MOCK_DIR
   export PATH="${MOCK_DIR}:${PATH}"

--- a/tests/test_gh_wrapper.bats
+++ b/tests/test_gh_wrapper.bats
@@ -14,6 +14,15 @@
 FUNCTIONS_SH="${HOME}/.config/bash/functions.sh"
 
 setup() {
+  # The wrapper's review-script location is an exported override
+  # (_gh_wrapper_review_script). If the developer's interactive shell exported
+  # it -- and sourcing gh-wrapper.sh does exactly that -- bats inherits the
+  # value, and it wins over the sandboxed HOME below. The mock hook would then
+  # be ignored in favour of the real one, which fails for reasons unrelated to
+  # anything under test. Unset it so HOME is genuinely the only input.
+  # See smartwatermelon/dotfiles#222 and #360.
+  unset _gh_wrapper_review_script
+
   MOCK_DIR="$(mktemp -d)"
   export MOCK_DIR
   export PATH="${MOCK_DIR}:${PATH}"

--- a/tests/test_gh_wrapper_api_merge.bats
+++ b/tests/test_gh_wrapper_api_merge.bats
@@ -15,6 +15,15 @@
 FUNCTIONS_SH="${HOME}/.config/bash/functions.sh"
 
 setup() {
+  # The wrapper's review-script location is an exported override
+  # (_gh_wrapper_review_script). If the developer's interactive shell exported
+  # it -- and sourcing gh-wrapper.sh does exactly that -- bats inherits the
+  # value, and it wins over the sandboxed HOME below. The mock hook would then
+  # be ignored in favour of the real one, which fails for reasons unrelated to
+  # anything under test. Unset it so HOME is genuinely the only input.
+  # See smartwatermelon/dotfiles#222 and #360.
+  unset _gh_wrapper_review_script
+
   MOCK_DIR="$(mktemp -d)"
   export MOCK_DIR
   export PATH="${MOCK_DIR}:${PATH}"


### PR DESCRIPTION
Closes #360.

## ⚠️ Depends on smartwatermelon/dotfiles#222 — merge that first

This is half of a two-repo fix and **does not stand alone**. Measured, not assumed:

| Wrapper | `_gh_wrapper_review_script` | Failures |
|---|---|---|
| old (dotfiles `main`) | unset (CI condition) | **5** |
| old | exported (developer shell) | **7** |
| new (dotfiles#222) | unset | **0** |
| new | exported | **0** |

The old wrapper fails in CI too, not only for developers with the variable exported. Merging this first leaves the suite red.

## The bug

The three gh-wrapper fixtures sandbox `HOME` so the wrapper finds a mock pre-merge hook. They didn't account for `_gh_wrapper_review_script`, which `gh-wrapper.sh` **exports**: a developer's interactive shell has it set, bats inherits it, and it takes precedence over the sandboxed `HOME`.

The wrapper then ran the **real** pre-merge hook, which failed with `Claude CLI not found` — an error about neither the wrapper nor the tests. That misdirection is why #360 was filed against a missing `claude` stub.

## The fix

`unset _gh_wrapper_review_script` in each `setup()`, so `HOME` is genuinely the only input.

## #360's diagnosis was wrong

I filed #360 myself, saying the fixture "sandboxes HOME without stubbing the `claude` binary."

The missing stub was a **symptom**. The real hook only ran at all because the path had already been resolved against the real `HOME` — half here (inherited override), half in `gh-wrapper.sh` (resolved once at source time). Closing #360 against the actual cause rather than the reported one.

## Validation

Validated against a known-bad case under the realistic condition — the variable exported, as an interactive shell leaves it:

- without this change: **7 failures**
- with it: **0**

| Check | Result |
|---|---|
| bats | **202 pass, 0 fail** (was 197 pass / 5 fail) |
| `scripts/tests/*.sh` | 195/195 |

This clears the last known failing tests in the suite.

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
