### PR TITLE
fix(review): flag unverified claims about how tools and runtimes behave

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -745,6 +745,11 @@ _VERIFY_ASSERTION_MARKERS=(
   "silently ignore"
   "silently fail"
   "silently succeed"
+  # These two are broad on purpose. "this guard avoids false positives in
+  # the rate limiter" does flag -- but that sentence IS a claim about how
+  # something behaves, which is the target. The gate only labels and
+  # annotates; it never suppresses. Asking a behavioral claim to show its
+  # check is the intended outcome.
   "false positive"
   "false negative"
   "no such flag"

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -710,6 +710,50 @@ _VERIFY_ASSERTION_MARKERS=(
   "has not been confirmed"
   "was not verified"
   "not been validated"
+  # Group 3: claims about how a tool, runtime, or API actually BEHAVES
+  # (projectinsomnia #124/#128/#131/#132/#133/#137). Six findings in one
+  # session asserted mechanism -- what process.argv holds, whether `if:
+  # failure()` covers a prior step, how `grep -w` treats `/`, whether an
+  # empty vulnerabilities object passes -- and all six were wrong. None used
+  # Group 1 phrasing, so none were labelled; each cost a human a command to
+  # disprove.
+  #
+  # These are worth flagging precisely because they are the CHEAPEST claims
+  # to check: every one fell to a single one-liner. A reviewer asserting
+  # mechanism it did not run is the exact shape this gate exists to mark.
+  #
+  # Measured against the same corpus as Groups 1-2 plus the 13 findings in
+  # tests/test_pre_merge_nonblocking.bats that must stay unflagged (the
+  # test-54 "careful phrasing" set and a style-finding set): 6/6 of the real
+  # false findings flag, 0/13 legitimate findings do. Re-run that measurement
+  # before adding anything here -- broad terms like "treats" or "resolves to"
+  # were rejected for catching careful phrasing.
+  "process.argv"
+  "argv["
+  "off-by-one"
+  "word-splitting"
+  "word splitting"
+  "will be skipped"
+  "is skipped"
+  "only runs"
+  "does not run"
+  "never fires"
+  "silently drop"
+  "silently lose"
+  "silently lost"
+  "silently swallow"
+  "silently ignore"
+  "silently fail"
+  "silently succeed"
+  "false positive"
+  "false negative"
+  "no such flag"
+  "no such option"
+  "no such version"
+  "no such release"
+  "has no v"
+  "produce an empty"
+  "returns an empty"
 )
 
 # Does this finding assert that something is factually incorrect/broken?
@@ -740,6 +784,10 @@ _unverified_caveat_body() {
   printf '%s\n' "> field recording a command that was actually run to check it."
   printf '%s\n' "> Confirm the assertion against reality before acting on it — several"
   printf '%s\n' "> such findings have turned out to be false."
+  printf '%s\n' ">"
+  printf '%s\n' "> Run the check before you fix anything. If the claim is about how a"
+  printf '%s\n' "> tool or runtime behaves, it is usually one command — and if it is"
+  printf '%s\n' "> wrong, close this issue with the output rather than changing code."
   printf '%s\n' ""
   printf '%s\n' "${body}"
 }

--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -848,6 +848,11 @@ IMPORTANT RULES for NON_BLOCKING_ISSUE:
   either (a) run the command that checks it and record the command plus its
   observed output in a VERIFIED: field, or (b) soften the claim into a question
   instead of an assertion. Never assert a checkable fact you did not check.
+- HOW A TOOL OR RUNTIME BEHAVES IS EXTERNAL STATE. "argv[1] is the script
+  path", "if: failure() only covers the previous step", "grep -w splits on
+  /", "that flag does not exist", "an empty object passes" — all checkable,
+  usually by one command. Six such findings in one session were asserted from
+  memory and every one was false. Run the one-liner, or ask the question.
 - VERIFIED: may span multiple lines and must come last in the block, after
   DETAILS. Omit it entirely when the finding makes no factual claim about
   external state (style, structure, maintainability concerns need no command).

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -1210,6 +1210,13 @@ ONE of these two things:
   2. If you cannot run the check, SOFTEN the claim into a question rather
      than an assertion — write \"is this SHA on the v4 line?\" instead of
      \"this SHA belongs to the v4 line, not v7.0.1\".
+
+HOW A TOOL OR RUNTIME BEHAVES COUNTS AS EXTERNAL STATE. Claims like \"argv[1]
+is the script path\", \"if: failure() only covers the previous step\", \"grep -w
+splits on /\", \"this flag does not exist\", or \"an empty object passes\" are
+all checkable, usually by one command. Six such findings in a single session
+were asserted from memory and every one was false. Run the one-liner, or ask
+the question instead of making the assertion.
 Never assert a checkable fact you did not check. Findings that assert
 incorrectness with no VERIFIED: field are filed with an \"unverified\" label
 and a warning banner, because past unverified assertions of exactly this

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1480,3 +1480,30 @@ END_ISSUE"
   ! _asserts_incorrectness "" "The entry is not present in the allowlist."
   ! _asserts_incorrectness "" "The helper cannot be found on PATH."
 }
+
+@test "gate3: behavior-mechanism claims are flagged (projectinsomnia #124/#128/#131/#132/#133/#137)" {
+  _load_gate3_fns
+
+  # Six findings in one session asserted how a tool or runtime BEHAVES,
+  # from memory, and every one was false. None used Group 1 phrasing, so
+  # none were labelled -- each cost a human a one-line command to disprove.
+  _asserts_incorrectness "" "The commit message claims node receives the name via argv, but line 135 never extracts process.argv[1]."
+  _asserts_incorrectness "" "if: failure() is scoped to the preceding step, so a failing audit will be skipped and the log is dropped."
+  _asserts_incorrectness "" "GNU grep -w treats / as a word character, so @netlify/dev will produce false negatives."
+  _asserts_incorrectness "" "The jq filter returns an empty array, causing the script to silently succeed."
+  _asserts_incorrectness "" "The current released major is v4 — this action has no v7 release."
+  _asserts_incorrectness "" "Those sections only render when credentials are configured; otherwise the page does not run that path."
+}
+
+@test "gate3: style and structure findings stay UNflagged" {
+  _load_gate3_fns
+
+  # Group 3 must not catch findings that make no factual claim about
+  # external state -- those legitimately carry no VERIFIED: field.
+  ! _asserts_incorrectness "" "The function is long and would read better split into two helpers."
+  ! _asserts_incorrectness "" "Consider extracting this duplicated block into a shared helper."
+  ! _asserts_incorrectness "" "This variable name is ambiguous; rename for clarity."
+  ! _asserts_incorrectness "" "The comment density here is lower than the surrounding file."
+  ! _asserts_incorrectness "" "Test coverage for the error path is missing."
+  ! _asserts_incorrectness "" "This adds a second source of truth for the same list."
+}


### PR DESCRIPTION
Tunes `lib-review-issues.sh` so findings that assert **mechanism** — how a tool, runtime, or API behaves — get the unverified label when they carry no `VERIFIED:` field.

## Why

Six findings filed against one session's PRs in `projectinsomnia` asserted mechanism and **every one was wrong**:

| Issue | Asserted | Disproved by |
| --- | --- | --- |
| #124 | actions have no v7 release | `gh api .../tags` |
| #128 | sections need OAuth to render | `curl` production |
| #131 | empty `vulnerabilities` = false pass | ran the script |
| #132 | `grep -qw` breaks on scoped names | ran `grep -qw` |
| #133 | failing audit drops the artifact | `if: failure()` semantics |
| #137 | `process.argv[1]` off-by-one | `node -e` one-liner |

Two were **BLOCKING** and overturned by the arbiter. One proposed a fix using `gh api --arg` — a flag that doesn't exist — which would have broken the script it claimed to repair.

## The gap

The `VERIFIED:` mechanism and prompt instructions already existed and are well-written. The reviewer ignored them, and nothing caught it.

Measured against the current markers: **all six evade Group 1 entirely.** That group matches explicit phrasings (`"is wrong"`, `"does not exist"`), but real false findings assert incorrectness *implicitly* — "off-by-one", "will be skipped", "silent false-pass", "has no v7 release".

## The fix

Adds **Group 3** for behavioral claims. These are worth flagging precisely because they're the *cheapest* to check — every one of the six fell to a single command.

Deliberately **fixed strings, not regex**, preserving the existing `grep -qF` contract so model-authored text is never read as a pattern.

Per the file's own instruction to measure before adding:

- **6/6** real false findings flag
- **0/13** legitimate findings do — the test-54 "careful phrasing" corpus plus a new style-finding set

Broad terms like `"treats"` and `"resolves to"` were tested and **rejected** for catching careful phrasing — the same failure mode #334 identified. I deliberately did not widen Group 1's negatives, since test 54 documents a 137-finding measurement showing those catch the reviewer being careful.

Also updates both prompts to say plainly that how a tool behaves *is* external state, and extends the caveat banner to say what to do: run the check first, and if the claim is false, close the issue with the output rather than changing code.

## Tests

New behavior-mechanism test **fails against the old markers** and passes with the new ones (verified by stashing the fix). The style/structure test guards against over-flagging and passes both ways.

Full suite: **204/204**.

## Note

This gate only labels and annotates — it never suppresses. A finding asserting behavior is asked to show its check; nothing is dropped.