### PR TITLE
fix(hooks): stop blocking quoted mentions of the worktree phrase

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -274,7 +274,60 @@ worktree_re="(^|&&|\\|\\||;|\\||&|\\(|\\{|${bt}|'|\"|[[:space:]]then|[[:space:]]
 
 mapfile -t matches < <(printf '%s\n' "${cmd}" | grep -oE "${worktree_re}" || true)
 
+# Commands that EXECUTE a quoted string argument. Only these turn a quoted
+# occurrence into a real invocation; anything else that merely carries the
+# phrase as text does not.
+#
+# This is an allowlist, so an unrecognized command keeps the quoted occurrence
+# under inspection: a new executor that nobody listed here fails CLOSED (still
+# blocked), never open. The cost is that an unlisted printer stays a false
+# positive, which is the safe direction for this trade.
+_executes_quoted_string() {
+  case "$1" in
+    # *sh covers sh/bash/zsh/ksh/dash and any path-qualified form.
+    *sh | eval | *xargs | *env) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 for match in "${matches[@]}"; do
+  # Skip a quoted MENTION of the phrase rather than an invocation of it.
+  #
+  # Adding the quote characters to the separator alternation (so that
+  # `bash -c 'git worktree add ...'` gets inspected) also made a quoted string
+  # merely CONTAINING the phrase match. `echo "git worktree add /tmp/x"` and
+  # `grep -r "git worktree add" docs/` were blocked despite executing nothing,
+  # which made writing docs and tests about this hook impossible.
+  #
+  # The captured match is identical in both cases -- quote, phrase, quote --
+  # so the match alone cannot decide. What differs is the command PRECEDING
+  # the quote: `bash -c` and `eval` run the string, `echo` and `grep` do not.
+  # Look back at the text before this occurrence and take the last word.
+  if [[ "${match:0:1}" == "'" || "${match:0:1}" == '"' ]]; then
+    prefix="${cmd%%"${match}"*}"
+    # Trailing whitespace off, then the final word of what came before.
+    prefix="${prefix%"${prefix##*[![:space:]]}"}"
+    # Walk back over flags: `bash -c 'X'` puts `-c` immediately before the
+    # quote, not `bash`, so testing only the last word misses every real
+    # executor invocation.
+    # ANSI-C quoting puts a bare `$` immediately before the quote
+    # (`bash -c $'...'`), which would otherwise read as the preceding word and
+    # match no executor. Drop a trailing sigil so the real command is found.
+    prefix="${prefix%$}"
+    prefix="${prefix%"${prefix##*[![:space:]]}"}"
+    read -r -a _pre_tokens <<<"${prefix}" || true
+    preceding=""
+    for ((_i = ${#_pre_tokens[@]} - 1; _i >= 0; _i--)); do
+      if [[ "${_pre_tokens[_i]}" != -* ]]; then
+        preceding="${_pre_tokens[_i]}"
+        break
+      fi
+    done
+    if [[ -n "${preceding}" ]] && ! _executes_quoted_string "${preceding}"; then
+      continue
+    fi
+  fi
+
   # Isolate the argument list that follows the `worktree` keyword in this
   # specific occurrence, then split it into tokens.
   args="${match#*worktree}"

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -278,14 +278,30 @@ mapfile -t matches < <(printf '%s\n' "${cmd}" | grep -oE "${worktree_re}" || tru
 # occurrence into a real invocation; anything else that merely carries the
 # phrase as text does not.
 #
-# This is an allowlist, so an unrecognized command keeps the quoted occurrence
-# under inspection: a new executor that nobody listed here fails CLOSED (still
-# blocked), never open. The cost is that an unlisted printer stays a false
-# positive, which is the safe direction for this trade.
+# KNOWN LIMITATION -- this carve-out fails OPEN, not closed.
+#
+# The lookback takes the last non-flag word before the quote. When that word is
+# an unrecognized command the occurrence is treated as a MENTION and skipped, so
+# `pyenv exec "git worktree add /tmp/evil"` passes: the deciding word is `exec`,
+# not `pyenv`. Ordinary wrappers are unaffected, because they leave a shell
+# adjacent to the quote -- `sudo bash -c`, `env bash -c`, `xargs ... bash -c`
+# and `command bash -c` were all checked and still block.
+#
+# Widening this to fail closed would re-break the false positive it exists to
+# fix: `echo`, `grep` and `printf` are precisely "unrecognized commands before a
+# quoted string". Both cannot be satisfied by a lookback of this kind, and
+# separating them needs real tokenization -- the same boundary the header's
+# KNOWN LIMITATION block already describes. Naming the executors is the smaller
+# error, since a missed exotic wrapper is one more instance of a gap class this
+# hook already documents rather than a new kind of hole.
 _executes_quoted_string() {
   case "$1" in
     # *sh covers sh/bash/zsh/ksh/dash and any path-qualified form.
-    *sh | eval | *xargs | *env) return 0 ;;
+    # `env` is exact (plus a path form): a bare *env glob would also catch
+    # pyenv/rbenv/direnv/goenv, which do not execute their argument as a shell
+    # string. Over-matching there is safe (it keeps the block) but inaccurate,
+    # so name what is actually meant.
+    *sh | eval | xargs | */xargs | env | */env) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -310,6 +310,20 @@ inp="$(make_input "sh -c ${sq}git worktree add /tmp/evil${sq}")"
 check "invocation: sh -c still blocks despite the mention carve-out" 2 "${inp}"
 inp="$(make_input "bash -c ${dq}git worktree add /tmp/evil${dq}")"
 check "invocation: bash -c double-quoted still blocks" 2 "${inp}"
+inp="$(make_input "eval ${dq}git worktree add /tmp/evil${dq}")"
+check "invocation: eval double-quoted still blocks" 2 "${inp}"
+# Wrappers that leave a shell adjacent to the quote must still block -- these
+# are the forms that actually occur.
+inp="$(make_input "sudo bash -c ${dq}git worktree add /tmp/evil${dq}")"
+check "invocation: sudo bash -c still blocks" 2 "${inp}"
+inp="$(make_input "command bash -c ${dq}git worktree add /tmp/evil${dq}")"
+check "invocation: command bash -c still blocks" 2 "${inp}"
+# KNOWN GAP, pinned as CURRENT behavior: a wrapper whose last non-flag word is
+# not itself an executor (`pyenv exec`) is read as a mention and skipped. See
+# the KNOWN LIMITATION note above _executes_quoted_string for why closing this
+# would re-break the echo/grep false positive.
+inp="$(make_input "pyenv exec ${dq}git worktree add /tmp/evil${dq}")"
+check "KNOWN GAP: non-executor wrapper word is read as a mention" 0 "${inp}"
 
 # --- PERMANENTLY OPEN gaps, asserted as CURRENT behavior, not desired ---
 # Documented in the KNOWN LIMITATION block in the hook header. A PreToolUse

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -286,6 +286,31 @@ check "backslash: escaped space in an out-of-scope path is refused" 2 "${inp}"
 inp="$(make_input "git worktree add .claude/worktrees/plain")"
 check "backslash: an unescaped scoped path is still allowed" 0 "${inp}"
 
+# --- Quoted MENTION vs quoted INVOCATION (#371) ---
+# Making the quote a separator (so `bash -c 'git worktree add ...'` is
+# inspected) also matched a quoted string that merely CONTAINS the phrase.
+# `echo` and `grep` of the phrase were blocked despite executing nothing, which
+# made writing docs and tests about this hook impossible.
+#
+# The captured match is identical either way -- quote, phrase, quote -- so the
+# discriminator is the command PRECEDING the quote. Only a shell or `eval` runs
+# the string. The lookback skips flags (`bash -c` puts `-c` next to the quote)
+# and the ANSI-C `$` sigil.
+inp="$(make_input "echo ${dq}git worktree add /tmp/x${dq}")"
+check "mention: echo of a creation string is not an invocation" 0 "${inp}"
+inp="$(make_input "echo ${dq}git worktree list${dq}")"
+check "mention: echo of a read-only string is not an invocation" 0 "${inp}"
+inp="$(make_input "grep -r ${dq}git worktree add${dq} docs/")"
+check "mention: grep for the phrase in docs is allowed" 0 "${inp}"
+inp="$(make_input "printf '%s' ${dq}git worktree move a b${dq}")"
+check "mention: printf of an admin string is allowed" 0 "${inp}"
+
+# The executor forms must still block -- this is the half that must not regress.
+inp="$(make_input "sh -c ${sq}git worktree add /tmp/evil${sq}")"
+check "invocation: sh -c still blocks despite the mention carve-out" 2 "${inp}"
+inp="$(make_input "bash -c ${dq}git worktree add /tmp/evil${dq}")"
+check "invocation: bash -c double-quoted still blocks" 2 "${inp}"
+
 # --- PERMANENTLY OPEN gaps, asserted as CURRENT behavior, not desired ---
 # Documented in the KNOWN LIMITATION block in the hook header. A PreToolUse
 # hook sees the raw, unexpanded command string with no access to the executing


### PR DESCRIPTION
Closes #371.

## The regression

#372 added the quote characters to the separator alternation so that `bash -c 'git worktree add ...'` would be inspected. That also made a quoted string merely **containing** the phrase match as though it were an invocation:

```
echo "git worktree add /tmp/x"      -> blocked  (was allowed)
grep -r "git worktree add" docs/    -> blocked  (was allowed)
```

Neither executes anything. Writing documentation or tests about this hook became impossible — I hit this three times while working, once while trying to write the test that reproduces it.

## The fix

The captured match is identical either way — quote, phrase, quote — so the match alone cannot decide. What differs is the command **preceding** the quote: `bash -c` and `eval` run the string; `echo` and `grep` do not. The lookback walks back past flags and the ANSI-C `$` sigil to find that command, and skips the occurrence unless it is a known executor.

Both details were found by testing, not reasoning:
- `bash -c '...'` puts `-c` next to the quote, not `bash`
- `bash -c $'...'` leaves a bare `$` there — missing this let ANSI-C invocations through, caught by the existing pin from #372

## The second commit corrects a false claim I wrote in the first

The first commit's comment said the carve-out "fails CLOSED (still blocked), never open."

**That was wrong**, and a test I added to prove it failed instead. `pyenv exec "git worktree add /tmp/evil"` is skipped as a mention, because the deciding word is `exec`, not `pyenv`. It fails **open**.

I checked how far that reaches rather than assuming. The wrappers that actually occur all still block, since they leave a shell adjacent to the quote: `sudo bash -c`, `env bash -c`, `xargs ... bash -c`, `command bash -c`. Only a wrapper whose final word is itself a non-executor slips through.

Closing that gap is not simply better: `echo`, `grep` and `printf` are precisely "unrecognized command before a quoted string", so failing closed re-breaks the false positive this exists to fix. Both cannot come from a lookback of this kind — separating them needs real tokenization, the same boundary the header's KNOWN LIMITATION block already describes. The gap is now pinned as a KNOWN GAP test asserting current behaviour, in the same style as the alias and variable-obfuscation pins.

Also folds in #384 (narrow `*env`, which over-matched pyenv/rbenv/direnv) and #385 (missing `eval "..."` double-quote test).

## Validation

Validated against a known-bad case: the three mention assertions **fail against the pre-fix hook** and pass after it. The invocation assertions pass in both, correctly — blocking was never broken.

| Check | Result |
|---|---|
| worktree suite | **103 passed** (was 93) |
| all `scripts/tests/*.sh` | 205/205 |
| bats | 204 pass, 0 fail |
| shellcheck -S info | clean on the hook |

## Not addressed

**#383** — `%%` takes the last match position when the identical quoted literal appears twice with different preceding commands. Needs an occurrence index rather than a suffix strip; the realistic trigger is a command repeating the same literal in both a safe and an executing position.

## Note on scope

This backlog is at a spawn ratio near 1.9 — 15 issues opened this session against 8 closed. This PR is deliberately the last fix in that chain rather than the next link: #383 and the dedup bug behind #376/#377 are filed with diagnoses rather than fixed here.

https://claude.ai/code/session_019iYVzS5S8LvhEeype5C519
