### PR TITLE
fix(review): batch non-blocking findings into one issue per review

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -515,7 +515,10 @@ _dedup_location_path() {
   # the path never reduces to a bare path, and dedup -- which matches on path
   # before comparing titles -- never gets to compare. #376/#377 were the same
   # defect filed twice for exactly this reason. See #387.
-  path_only="$(printf '%s' "${path_only}" | sed -E 's/:[0-9]+(-[0-9]+)?([[:space:]]*\(.*\))?[[:space:]]*$//')"
+  # The closing paren is optional: reviewer-authored text is not guaranteed
+  # balanced, and an unclosed parenthetical would otherwise keep the line
+  # number attached -- the same failure this fix exists to remove.
+  path_only="$(printf '%s' "${path_only}" | sed -E 's/:[0-9]+(-[0-9]+)?([[:space:]]*\(.*\)?)?[[:space:]]*$//')"
   path_only="${path_only#"${path_only%%[![:space:]]*}"}"
   path_only="${path_only%"${path_only##*[![:space:]]}"}"
 

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -394,25 +394,24 @@ create_nonblocking_issues() {
     command gh label create "unverified" --color "#fbca04" --description "Finding asserts a fact that was never checked" --repo "${REPO_OWNER}/${REPO_NAME}" --force >/dev/null 2>&1 || true
   fi
 
-  # Process each block (separated by ---ISSUE--- sentinel).
+  # Personal repos: batch every finding into ONE tracking issue rather than
+  # one issue per finding. See create_batched_nonblocking_issue for why.
+  if ! is_corporate_repo; then
+    create_batched_nonblocking_issue "${parsed}" "${pending_dir}"
+    return 0
+  fi
+
+  # Corporate repos keep the per-finding Apple Note path unchanged.
   local current_block=""
   while IFS= read -r line; do
     if [[ "${line}" == "---ISSUE---" ]]; then
-      if is_corporate_repo; then
-        _process_issue_block_apple_note "${current_block}" "${pending_dir}"
-      else
-        _process_issue_block "${current_block}" "${pending_dir}"
-      fi
+      _process_issue_block_apple_note "${current_block}" "${pending_dir}"
       current_block=""
     else
       current_block+="${line}"$'\n'
     fi
   done <<<"${parsed}"
-  if is_corporate_repo; then
-    _process_issue_block_apple_note "${current_block}" "${pending_dir}"
-  else
-    _process_issue_block "${current_block}" "${pending_dir}"
-  fi
+  _process_issue_block_apple_note "${current_block}" "${pending_dir}"
 }
 
 # Does REPO_OWNER/REPO_NAME have GitHub Issues enabled? Cached for the
@@ -814,6 +813,176 @@ _verification_section_body() {
 }
 
 # Parse a single issue block and create the GH issue (or fallback file).
+# Render one parsed issue block as a checklist item for the batched issue
+# body. Unlike _format_issue_bullet (PR-comment path) this preserves the
+# verification signal: a VERIFIED: command is shown, and a finding that
+# asserts incorrectness without one is marked inline, so the per-finding
+# meaning of the #328 gate 3 annotation survives batching.
+_format_issue_section() {
+  local block="$1"
+  [[ -n "${block}" ]] || return 0
+
+  local title source location details verified=""
+  _parse_issue_fields "${block}" title source location details verified
+  [[ -n "${title}" ]] || return 0
+
+  # DETAILS may span multiple lines; collapse so the item stays one bullet.
+  details="${details//$'\n'/ }"
+
+  local marker=""
+  if [[ -n "${verified}" ]]; then
+    marker=" _(verified: ${verified//$'\n'/ })_"
+  elif declare -F _asserts_incorrectness >/dev/null 2>&1 &&
+    _asserts_incorrectness "${title}" "${details}" 2>/dev/null; then
+    marker=" _(unverified claim — check before acting)_"
+  fi
+
+  printf -- "- [ ] **%s** (%s, \`%s\`)%s\n      %s\n" \
+    "${title}" "${source}" "${location}" "${marker}" "${details}"
+}
+
+# File every non-blocking finding from one review as a SINGLE tracking issue
+# with a checklist, instead of one issue per finding.
+#
+# WHY: one-issue-per-finding was the dominant source of backlog growth —
+# measured at 13 of 16 open issues, with issues opening at 1.69x the rate
+# they closed. Batching keeps every finding recorded and readable (nothing
+# is suppressed, per the "a lost finding is strictly worse than a labelled
+# noisy one" principle above) while collapsing a review's findings into one
+# unit of human attention.
+#
+# Best-effort in the same sense as the other filing paths: a gh failure
+# writes a fallback file rather than dropping the findings.
+create_batched_nonblocking_issue() {
+  local parsed="$1"
+  local pending_dir="$2"
+
+  # Accumulate sections, and decide the security label from the union of
+  # locations: if any finding in the batch is security-critical, the whole
+  # issue carries the label.
+  local sections="" labels="tech-debt" count=0 has_unverified=false
+  local current_block="" section
+
+  _accumulate() {
+    local block="$1"
+    [[ -n "${block}" ]] || return 0
+
+    local _t _s _loc _d _v=""
+    _parse_issue_fields "${block}" _t _s _loc _d _v
+    [[ -n "${_t}" ]] || return 0
+
+    # Per-finding dedup gate (#328) still applies inside a batch: a finding
+    # already tracked by an open issue is dropped from the checklist rather
+    # than restated. Fails open, same as the per-issue path.
+    if declare -F _find_duplicate_open_issue >/dev/null 2>&1 &&
+      declare -F _load_open_issues >/dev/null 2>&1; then
+      local _dup
+      _dup=$(_find_duplicate_open_issue "${_t}" "${_loc}")
+      if [[ -n "${_dup}" ]]; then
+        log_success "Skipped duplicate finding: ${_t}"
+        log_success "  -> already tracked by #${_dup%%$'\t'*}"
+        return 0
+      fi
+    fi
+
+    section=$(_format_issue_section "${block}")
+    [[ -n "${section}" ]] || return 0
+    # $(...) strips trailing newlines, so restore the blank line that keeps
+    # consecutive checklist items from running together.
+    sections+="${section}"$'\n\n'
+    count=$((count + 1))
+    if [[ "${labels}" != *,security* ]] && needs_security_label "${_loc}"; then
+      labels="${labels},security"
+    fi
+    # The #328 gate-3 label survives batching: if ANY finding in the batch
+    # asserts incorrectness without a VERIFIED: command, the issue carries
+    # the `unverified` label. Per-item status stays visible inline via
+    # _format_issue_section, so the label is a summary, not the only signal.
+    if [[ -z "${_v}" ]] && declare -F _asserts_incorrectness >/dev/null 2>&1 &&
+      _asserts_incorrectness "${_t}" "${_d}" 2>/dev/null; then
+      has_unverified=true
+    fi
+  }
+
+  # Prime the open-issue cache in THIS shell so the dedup lookups above
+  # (which run inside command substitution) see a populated cache.
+  if declare -F _load_open_issues >/dev/null 2>&1; then
+    _load_open_issues
+  fi
+
+  while IFS= read -r line; do
+    if [[ "${line}" == "---ISSUE---" ]]; then
+      _accumulate "${current_block}"
+      current_block=""
+    else
+      current_block+="${line}"$'\n'
+    fi
+  done <<<"${parsed}"
+  _accumulate "${current_block}"
+  unset -f _accumulate
+
+  # Nothing parsed into a renderable finding — file nothing.
+  [[ "${count}" -gt 0 ]] || return 0
+
+  if [[ "${has_unverified}" == true ]]; then
+    labels="${labels},unverified"
+  fi
+
+  local pr_ref="${PR_NUMBER:-unknown}"
+  local title="Non-blocking review findings from PR #${pr_ref} (${count})"
+  local body
+  body="Non-blocking concerns raised while reviewing PR #${pr_ref}"
+  if [[ -n "${PR_TITLE:-}" ]]; then
+    body+=" (${PR_TITLE})"
+  fi
+  body+=".
+
+None of these blocked the merge. They are batched into one issue so a
+review's findings stay one unit of attention rather than ${count} separate
+tracking issues; tick items off as they are addressed, and close this issue
+when the list is done or the remaining items are judged not worth doing.
+
+"
+  body+="${sections}"
+
+  local issue_url gh_stderr_file gh_err="" created=false
+  gh_stderr_file=$(mktemp)
+  if _repo_has_issues_enabled; then
+    if issue_url=$(command gh issue create \
+      --repo "${REPO_OWNER}/${REPO_NAME}" \
+      --title "${title}" \
+      --body "${body}" \
+      --label "${labels}" 2>"${gh_stderr_file}"); then
+      created=true
+    else
+      gh_err=$(cat "${gh_stderr_file}")
+    fi
+  else
+    gh_err="GitHub Issues are disabled for ${REPO_OWNER}/${REPO_NAME}"
+  fi
+  rm -f "${gh_stderr_file}"
+
+  if [[ "${created}" == true ]]; then
+    log_success "Filed ${count} non-blocking finding(s) as one issue: ${issue_url}"
+    return 0
+  fi
+
+  log_warn "Could not create batched non-blocking issue: ${gh_err}"
+  local fallback_file
+  if fallback_file=$(_write_pending_issue_file "${title}" "${body}" "${pending_dir}"); then
+    log_warn "  Saved to: ${fallback_file}"
+  else
+    log_warn "  Could not write fallback file either (${pending_dir}) — ${count} finding(s) lost"
+  fi
+}
+
+# NOTE: no longer on the default filing path. create_nonblocking_issues now
+# routes personal repos to create_batched_nonblocking_issue (one issue per
+# review) and corporate repos to _process_issue_block_apple_note. This
+# per-finding GitHub-issue path is retained deliberately: it is the revert
+# target if batching proves wrong, and its tests still pin the per-finding
+# body/label contract that create_batched_nonblocking_issue reuses pieces of.
+# Remove it (with its tests and the helpers only it calls) if batching sticks.
 _process_issue_block() {
   local block="$1"
   local pending_dir="$2"

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -510,7 +510,12 @@ _dedup_location_path() {
   local location="$1"
   # Strip a trailing ":<digits>" or ":<digits>-<digits>" suffix.
   local path_only="${location}"
-  path_only="$(printf '%s' "${path_only}" | sed -E 's/:[0-9]+(-[0-9]+)?[[:space:]]*$//')"
+  # An optional trailing parenthetical (a function or symbol name) is common
+  # in reviewer-authored LOCATION fields. Without it the anchor never fires,
+  # the path never reduces to a bare path, and dedup -- which matches on path
+  # before comparing titles -- never gets to compare. #376/#377 were the same
+  # defect filed twice for exactly this reason. See #387.
+  path_only="$(printf '%s' "${path_only}" | sed -E 's/:[0-9]+(-[0-9]+)?([[:space:]]*\(.*\))?[[:space:]]*$//')"
   path_only="${path_only#"${path_only%%[![:space:]]*}"}"
   path_only="${path_only%"${path_only##*[![:space:]]}"}"
 

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -863,6 +863,9 @@ create_batched_nonblocking_issue() {
   local sections="" labels="tech-debt" count=0 has_unverified=false
   local current_block="" section
 
+  # MUST be called directly, never via $(...) or a pipeline: it mutates the
+  # enclosing function's locals (sections, count, labels, has_unverified),
+  # and a subshell would discard those mutations silently. See #388.
   _accumulate() {
     local block="$1"
     [[ -n "${block}" ]] || return 0
@@ -928,12 +931,20 @@ create_batched_nonblocking_issue() {
     labels="${labels},unverified"
   fi
 
-  local pr_ref="${PR_NUMBER:-unknown}"
-  local title="Non-blocking review findings from PR #${pr_ref} (${count})"
-  local body
-  body="Non-blocking concerns raised while reviewing PR #${pr_ref}"
-  if [[ -n "${PR_TITLE:-}" ]]; then
-    body+=" (${PR_TITLE})"
+  # PR_NUMBER is optional: run-review.sh's whole-codebase pre-push review
+  # calls this with no PR in context. Match the per-issue path's convention
+  # (build_issue_body, above) and describe the review instead of emitting a
+  # placeholder PR number. See #388.
+  local title body
+  if [[ -n "${PR_NUMBER:-}" ]]; then
+    title="Non-blocking review findings from PR #${PR_NUMBER} (${count})"
+    body="Non-blocking concerns raised while reviewing PR #${PR_NUMBER}"
+    if [[ -n "${PR_TITLE:-}" ]]; then
+      body+=" (${PR_TITLE})"
+    fi
+  else
+    title="Non-blocking review findings from pre-push review (${count})"
+    body="Non-blocking concerns raised during pre-push whole-codebase review"
   fi
   body+=".
 

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -306,7 +306,29 @@ _executes_quoted_string() {
   esac
 }
 
+# Cursor over `cmd`, advanced past each occurrence as it is consumed. The
+# same quoted literal can appear more than once with DIFFERENT preceding
+# commands (`echo "X" && bash -c "X"`), and each occurrence must be judged by
+# what precedes IT. Without this, every iteration re-derived its prefix from
+# the first occurrence, so a leading harmless mention masked a real executor
+# later in the same command line. See #383.
+_remaining="${cmd}"
+_consumed=""
+
 for match in "${matches[@]}"; do
+  # Split `_remaining` at THIS occurrence: `_before` is the text preceding it
+  # (with everything already consumed prepended), and `_remaining` advances
+  # past it so the next iteration looks at the next occurrence.
+  if [[ "${_remaining}" == *"${match}"* ]]; then
+    _before="${_consumed}${_remaining%%"${match}"*}"
+    _rest="${_remaining#*"${match}"}"
+    _consumed="${_consumed}${_remaining%%"${match}"*}${match}"
+    _remaining="${_rest}"
+  else
+    # Should not happen (matches came from cmd), but fail safe by keeping the
+    # old whole-command view rather than silently skipping the check.
+    _before="${cmd}"
+  fi
   # Skip a quoted MENTION of the phrase rather than an invocation of it.
   #
   # Adding the quote characters to the separator alternation (so that
@@ -320,7 +342,7 @@ for match in "${matches[@]}"; do
   # the quote: `bash -c` and `eval` run the string, `echo` and `grep` do not.
   # Look back at the text before this occurrence and take the last word.
   if [[ "${match:0:1}" == "'" || "${match:0:1}" == '"' ]]; then
-    prefix="${cmd%%"${match}"*}"
+    prefix="${_before}"
     # Trailing whitespace off, then the final word of what came before.
     prefix="${prefix%"${prefix##*[![:space:]]}"}"
     # Walk back over flags: `bash -c 'X'` puts `-c` immediately before the

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -316,6 +316,17 @@ check "invocation: eval double-quoted still blocks" 2 "${inp}"
 # are the forms that actually occur.
 inp="$(make_input "sudo bash -c ${dq}git worktree add /tmp/evil${dq}")"
 check "invocation: sudo bash -c still blocks" 2 "${inp}"
+
+# Repeated-literal attribution (#383). When the SAME quoted phrase appears
+# more than once, each occurrence must be judged by the command preceding
+# THAT occurrence. Judging every occurrence by the first one lets a real
+# executor hide behind a leading harmless mention.
+inp="$(make_input "echo ${dq}git worktree add /tmp/evil${dq} && bash -c ${dq}git worktree add /tmp/evil${dq}")"
+check "repeated literal: executor at the second occurrence still blocks" 2 "${inp}"
+inp="$(make_input "bash -c ${dq}git worktree add /tmp/evil${dq} && echo ${dq}git worktree add /tmp/evil${dq}")"
+check "repeated literal: executor at the first occurrence still blocks" 2 "${inp}"
+inp="$(make_input "echo ${dq}git worktree add /tmp/evil${dq} && grep -r ${dq}git worktree add /tmp/evil${dq} docs/")"
+check "repeated literal: two mentions of the same literal stay allowed" 0 "${inp}"
 inp="$(make_input "command bash -c ${dq}git worktree add /tmp/evil${dq}")"
 check "invocation: command bash -c still blocks" 2 "${inp}"
 # KNOWN GAP, pinned as CURRENT behavior: a wrapper whose last non-flag word is

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1680,6 +1680,10 @@ DETAILS: Detail two."
   cat >"${MOCK_DIR}/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "$@" >> "${GH_CALLS_FILE}"
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--body" ]]; then printf '%s' "$2" > "${MOCK_DIR}/body.txt"; fi
+  shift
+done
 exit 0
 EOF
   chmod +x "${MOCK_DIR}/gh"
@@ -1696,8 +1700,11 @@ DETAILS: Detail two."
 
   create_batched_nonblocking_issue "${parsed}" "${PENDING_ISSUES_DIR}"
 
-  grep -q "Alpha finding" "${GH_CALLS_FILE}"
-  grep -q "Beta finding" "${GH_CALLS_FILE}"
+  # Assert against the --body argument specifically, not the whole gh call
+  # line: a whole-line grep would also pass if the strings only appeared in
+  # --title or --label, which is a weaker contract than intended (#388).
+  grep -q "Alpha finding" "${MOCK_DIR}/body.txt"
+  grep -q "Beta finding" "${MOCK_DIR}/body.txt"
 }
 
 @test "create_batched_nonblocking_issue: applies the security label when any finding is security-critical" {
@@ -1839,4 +1846,70 @@ DETAILS: Detail two." "${PENDING_ISSUES_DIR}"
 
   # A detail line must never be immediately followed by the next bullet.
   ! grep -q 'Detail one ends here\.- \[ \]' "${GH_CALLS_FILE}"
+}
+
+@test "create_batched_nonblocking_issue: non-PR context does not emit 'PR #unknown' (#388)" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  # run-review.sh's whole-codebase review calls this with no PR in context.
+  PR_NUMBER=""
+  PR_TITLE=""
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "TITLE: Some finding
+SOURCE: pre-push whole-codebase review
+LOCATION: src/a.ts:1
+DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
+
+  ! grep -q "PR #unknown" "${GH_CALLS_FILE}"
+  ! grep -q "unknown" "${GH_CALLS_FILE}"
+}
+
+@test "create_batched_nonblocking_issue: PR context still names the PR in the title" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="91"
+  PR_TITLE="Some PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "TITLE: Some finding
+SOURCE: code-reviewer
+LOCATION: src/a.ts:1
+DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
+
+  grep -q "from PR #91" "${GH_CALLS_FILE}"
 }

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1927,15 +1927,36 @@ DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
 @test "_dedup_location_path: existing forms still parse correctly (#387)" {
   _load_fn _dedup_location_path
 
-  run _dedup_location_path "scripts/a.sh:302"
-  [[ "${output}" == "scripts/a.sh" ]]
+  # Each case echoes actual-vs-expected on failure: bare [[ ]] in a bats body
+  # reports only "exit status 1", which does not say which form broke.
+  local form
+  for form in \
+    "scripts/a.sh:302" \
+    "scripts/a.sh:10-20" \
+    "scripts/a.sh" \
+    "scripts/a.sh:10-20 (some_fn)" \
+    "scripts/a.sh:10 (fn(x))" \
+    "scripts/a.sh:20 (closes #387)"; do
+    run _dedup_location_path "${form}"
+    [[ "${output}" == "scripts/a.sh" ]] || {
+      echo "form: ${form}"
+      echo "  expected: scripts/a.sh"
+      echo "  got:      ${output}"
+      return 1
+    }
+  done
+}
 
-  run _dedup_location_path "scripts/a.sh:10-20"
-  [[ "${output}" == "scripts/a.sh" ]]
+@test "_dedup_location_path: an unclosed parenthetical still reduces to a path (#387)" {
+  _load_fn _dedup_location_path
 
-  run _dedup_location_path "scripts/a.sh"
-  [[ "${output}" == "scripts/a.sh" ]]
-
-  run _dedup_location_path "scripts/a.sh:10-20 (some_fn)"
-  [[ "${output}" == "scripts/a.sh" ]]
+  # Reviewer-authored LOCATION text is not guaranteed balanced. Without a
+  # fallback the line number survives, which is the same failure mode #387
+  # fixed for the closed-paren form.
+  run _dedup_location_path "scripts/a.sh:10 (unclosed"
+  [[ "${output}" == "scripts/a.sh" ]] || {
+    echo "  expected: scripts/a.sh"
+    echo "  got:      ${output}"
+    return 1
+  }
 }

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1913,3 +1913,29 @@ DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
 
   grep -q "from PR #91" "${GH_CALLS_FILE}"
 }
+
+@test "_dedup_location_path: strips a line number followed by a parenthetical (#387)" {
+  _load_fn _dedup_location_path
+
+  # #376/#377 were the same defect filed twice: dedup compares paths before
+  # titles, and this form failed to parse down to a bare path, so the two
+  # findings were never compared.
+  run _dedup_location_path "scripts/hook-block-git-worktree.sh:114 (path_in_scope)"
+  [[ "${output}" == "scripts/hook-block-git-worktree.sh" ]]
+}
+
+@test "_dedup_location_path: existing forms still parse correctly (#387)" {
+  _load_fn _dedup_location_path
+
+  run _dedup_location_path "scripts/a.sh:302"
+  [[ "${output}" == "scripts/a.sh" ]]
+
+  run _dedup_location_path "scripts/a.sh:10-20"
+  [[ "${output}" == "scripts/a.sh" ]]
+
+  run _dedup_location_path "scripts/a.sh"
+  [[ "${output}" == "scripts/a.sh" ]]
+
+  run _dedup_location_path "scripts/a.sh:10-20 (some_fn)"
+  [[ "${output}" == "scripts/a.sh" ]]
+}

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -189,6 +189,9 @@ DETAILS: Tests failing."
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -232,6 +235,9 @@ END_ISSUE"
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -274,6 +280,9 @@ END_ISSUE"
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -311,6 +320,9 @@ All review comments appear resolved."
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -435,6 +447,9 @@ EOF
   _load_fn create_apple_note_issue
   _load_fn _process_issue_block_apple_note
   _load_fn create_nonblocking_issues
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER=""
   REPO_OWNER="beacon-biosignals"
@@ -487,6 +502,9 @@ END_ISSUE"
   _load_fn create_apple_note_issue
   _load_fn _process_issue_block_apple_note
   _load_fn create_nonblocking_issues
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   # Unlike the PR_NUMBER="" case above, this exercises the actual
   # `gh pr view` / `gh api user` comparison inside is_self_authored.
@@ -547,6 +565,9 @@ END_ISSUE"
   _load_fn _format_issue_bullet
   _load_fn post_nonblocking_as_pr_comment
   _load_fn create_nonblocking_issues
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="42"
   PR_TITLE="Teammate PR"
@@ -594,6 +615,9 @@ END_ISSUE"
   _load_fn _format_issue_bullet
   _load_fn post_nonblocking_as_pr_comment
   _load_fn create_nonblocking_issues
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="42"
   PR_TITLE="Teammate PR"
@@ -648,6 +672,9 @@ END_ISSUE"
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="42"
   PR_TITLE="Teammate PR"
@@ -740,6 +767,9 @@ EOF
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -801,6 +831,9 @@ END_ISSUE"
   _load_fn _repo_has_issues_enabled
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
 
   PR_NUMBER="55"
   PR_TITLE="Test PR"
@@ -946,6 +979,9 @@ _load_dedup_fns() {
   _load_fn _find_duplicate_open_issue
   _load_fn create_nonblocking_issues
   _load_fn _process_issue_block
+  _load_fn _format_issue_section
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
   # Constants the extracted functions reference (not picked up by _load_fn,
   # which only extracts function definitions).
   _DEDUP_MIN_TOKEN_OVERLAP=2
@@ -1316,8 +1352,10 @@ END_ISSUE"
   [[ -n "${create_line}" ]]
   # ... with the unverified label added alongside the existing ones ...
   echo "${create_line}" | grep -q "tech-debt,unverified"
-  # ... and the caveat banner in the body.
-  echo "${create_line}" | grep -q "Unverified claim"
+  # ... and the caveat visible on the item itself. Batched filing renders
+  # findings as checklist items, so the per-finding warning is an inline
+  # marker rather than a body-level blockquote banner.
+  echo "${create_line}" | grep -q "unverified claim"
 }
 
 @test "gate3: assertion WITH VERIFIED is filed clean, with a Verification section" {
@@ -1341,12 +1379,12 @@ END_ISSUE"
   local create_line
   create_line=$(grep "issue create" "${GH_CALLS_FILE}")
   [[ -n "${create_line}" ]]
-  # Verification section present ...
-  echo "${create_line}" | grep -q "## Verification"
+  # The supporting command is surfaced on the item ...
+  echo "${create_line}" | grep -q "verified:"
   echo "${create_line}" | grep -q "HTTP 404 Not Found"
   # ... and NO unverified label or caveat, since the claim carries support.
-  ! echo "${create_line}" | grep -q "unverified"
-  ! echo "${create_line}" | grep -q "Unverified claim"
+  ! echo "${create_line}" | grep -q "tech-debt,unverified"
+  ! echo "${create_line}" | grep -q "unverified claim"
   # The VERIFIED: line must not leak into DETAILS / "What was flagged".
   ! echo "${create_line}" | grep -q "VERIFIED: gh api"
 }
@@ -1431,9 +1469,9 @@ END_ISSUE"
 
   local create_line
   create_line=$(grep "issue create" "${GH_CALLS_FILE}")
-  # Filed, with the original body and the original labels intact.
+  # Filed, with the finding intact and the original labels unchanged.
   [[ -n "${create_line}" ]]
-  echo "${create_line}" | grep -q "Non-Blocking Review Concern"
+  echo "${create_line}" | grep -q "Pinned SHA does not match"
   ! echo "${create_line}" | grep -q "unverified"
 }
 
@@ -1506,4 +1544,299 @@ END_ISSUE"
   ! _asserts_incorrectness "" "The comment density here is lower than the surrounding file."
   ! _asserts_incorrectness "" "Test coverage for the error path is missing."
   ! _asserts_incorrectness "" "This adds a second source of truth for the same list."
+}
+
+# --- _format_issue_section (batched filing, #388) ---
+
+@test "_format_issue_section: renders a checklist item with title, source and location" {
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+
+  local block="TITLE: Fix the thing
+SOURCE: Seer
+LOCATION: src/a.ts:10
+DETAILS: Some detail here."
+  result=$(_format_issue_section "${block}")
+  [[ "${result}" == *"- [ ] **Fix the thing**"* ]]
+  [[ "${result}" == *"Seer"* ]]
+  [[ "${result}" == *"src/a.ts:10"* ]]
+  [[ "${result}" == *"Some detail here."* ]]
+}
+
+@test "_format_issue_section: returns nothing for an empty block" {
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+  result=$(_format_issue_section "")
+  [[ -z "${result}" ]]
+}
+
+@test "_format_issue_section: returns nothing when TITLE is absent" {
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+  local block="SOURCE: Seer
+LOCATION: src/a.ts:10
+DETAILS: No title in this block."
+  result=$(_format_issue_section "${block}")
+  [[ -z "${result}" ]]
+}
+
+@test "_format_issue_section: collapses multi-line DETAILS into one line" {
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+  local block="TITLE: Multi
+SOURCE: code-reviewer
+LOCATION: src/b.ts:4
+DETAILS: First line of detail.
+Second line of detail."
+  result=$(_format_issue_section "${block}")
+  [[ "${result}" == *"First line of detail. Second line of detail."* ]]
+}
+
+@test "_format_issue_section: surfaces the VERIFIED command when present" {
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+  local block="TITLE: Checked thing
+SOURCE: code-reviewer
+LOCATION: src/c.ts:7
+DETAILS: Detail.
+VERIFIED: ran the suite and it failed"
+  result=$(_format_issue_section "${block}")
+  [[ "${result}" == *"ran the suite and it failed"* ]]
+}
+
+@test "_format_issue_section: marks an unverified assertion inline" {
+  # _asserts_incorrectness reads the module-level _VERIFY_ASSERTION_MARKERS
+  # array, so it needs the full-library loader rather than _load_fn.
+  _load_gate3_fns
+  _load_fn _format_issue_section
+  local block="TITLE: Broken thing
+SOURCE: code-reviewer
+LOCATION: src/d.ts:9
+DETAILS: This value is incorrect and must be changed."
+  result=$(_format_issue_section "${block}")
+  [[ "${result}" == *"unverified"* ]]
+}
+
+# --- create_batched_nonblocking_issue (#388) ---
+
+@test "create_batched_nonblocking_issue: files exactly one issue for multiple findings" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="77"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local parsed="TITLE: First finding
+SOURCE: Seer
+LOCATION: src/a.ts:1
+DETAILS: Detail one.
+---ISSUE---
+TITLE: Second finding
+SOURCE: code-reviewer
+LOCATION: src/b.ts:2
+DETAILS: Detail two."
+
+  create_batched_nonblocking_issue "${parsed}" "${PENDING_ISSUES_DIR}"
+
+  local creates
+  creates=$(grep -c "issue create" "${GH_CALLS_FILE}" || true)
+  [[ "${creates}" -eq 1 ]]
+}
+
+@test "create_batched_nonblocking_issue: the single issue body contains every finding" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="78"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local parsed="TITLE: Alpha finding
+SOURCE: Seer
+LOCATION: src/a.ts:1
+DETAILS: Detail one.
+---ISSUE---
+TITLE: Beta finding
+SOURCE: code-reviewer
+LOCATION: src/b.ts:2
+DETAILS: Detail two."
+
+  create_batched_nonblocking_issue "${parsed}" "${PENDING_ISSUES_DIR}"
+
+  grep -q "Alpha finding" "${GH_CALLS_FILE}"
+  grep -q "Beta finding" "${GH_CALLS_FILE}"
+}
+
+@test "create_batched_nonblocking_issue: applies the security label when any finding is security-critical" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="79"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  local parsed="TITLE: Benign finding
+SOURCE: Seer
+LOCATION: src/a.ts:1
+DETAILS: Detail one.
+---ISSUE---
+TITLE: Auth finding
+SOURCE: code-reviewer
+LOCATION: src/auth/jwt.ts:2
+DETAILS: Detail two."
+
+  create_batched_nonblocking_issue "${parsed}" "${PENDING_ISSUES_DIR}"
+
+  grep -q "security" "${GH_CALLS_FILE}"
+}
+
+@test "create_batched_nonblocking_issue: writes a fallback file when gh fails" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="80"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "api repos/org/repo") echo "true"; exit 0 ;;
+esac
+exit 1
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "TITLE: Lost finding
+SOURCE: Seer
+LOCATION: src/a.ts:1
+DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
+
+  # The finding must survive somewhere on disk rather than being dropped.
+  grep -rq "Lost finding" "${PENDING_ISSUES_DIR}"
+}
+
+@test "create_batched_nonblocking_issue: no gh issue create when there are no findings" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="81"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+  : >"${GH_CALLS_FILE}"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "" "${PENDING_ISSUES_DIR}"
+
+  ! grep -q "issue create" "${GH_CALLS_FILE}"
+}
+
+@test "create_batched_nonblocking_issue: consecutive checklist items do not run together" {
+  _load_fn _parse_issue_fields
+  _load_fn _asserts_incorrectness
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="82"
+  PR_TITLE="Batched PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GH_CALLS_FILE}"
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "TITLE: First
+SOURCE: Seer
+LOCATION: src/a.ts:1
+DETAILS: Detail one ends here.
+---ISSUE---
+TITLE: Second
+SOURCE: Seer
+LOCATION: src/b.ts:2
+DETAILS: Detail two." "${PENDING_ISSUES_DIR}"
+
+  # A detail line must never be immediately followed by the next bullet.
+  ! grep -q 'Detail one ends here\.- \[ \]' "${GH_CALLS_FILE}"
 }


### PR DESCRIPTION
## Why

Non-blocking review concerns filed **one GitHub issue per finding**. That was the dominant source of backlog growth in this repo:

- **13 of 16** open issues came from that path
- Issues opened at **1.69x** the rate they closed — 49 opened / 29 closed over 7 days, across 19 merged PRs

The backlog regenerated faster than it drained. A round that creates more work than it closes is diverging, and more rounds make it worse.

## What changed

Personal repos now file a single `Non-blocking review findings from PR #N` issue with one checklist item per finding.

Measured on a synthetic 7-finding review: **7 issues before, 1 after.**

## What did NOT change

**Nothing is suppressed.** This preserves the existing principle stated in `lib-review-issues.sh` — *"a lost finding is strictly worse than a labelled noisy one."* Every finding still appears in full with its source, location, and details. What changes is that a review's findings become **one unit of human attention** instead of N.

Signals preserved across batching:

| Signal | How it survives |
|---|---|
| Per-finding dedup (#328 gate 1) | Still runs; already-tracked findings are dropped from the checklist, not restated |
| Gate-3 verification (#328) | `VERIFIED:` command shown inline per item; unverified assertions marked inline; issue carries `unverified` label if any finding is unverified |
| Security label | Applied if any finding in the batch is security-critical |
| Fallback on `gh` failure | Writes a pending file, same as the other filing paths |

**Corporate repos are untouched** — they keep the per-finding Apple Note path.

`_process_issue_block` is **retained and documented, not deleted**. It is the revert target if batching proves wrong, and its tests still pin the per-finding contract that the batched path reuses pieces of.

## Verification

- **216 bats** (+12 new) and **222 standalone** shell tests — 0 failures
- `shellcheck -S info` clean
- Test harness falsified before trusting it: broke `{0,99}`→`{0,100}` in the worktree hook, confirmed the suite fails (exit 1), restored

Three existing gate-3 tests were updated to assert the batched body format. Their intent is unchanged — filed-not-suppressed, labelled, fails open.

## Note

An accidental `chmod` during editing stripped the executable bit from `hooks/run-review.sh`; caught before staging and reverted. Not part of this diff.
