### PR TITLE
fix: second backlog pass — vacuous-green guard, quoted paths, unworked reporting

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -100,6 +100,18 @@ path_in_scope() {
     path="${BASH_REMATCH[1]}"
   fi
 
+  # A multi-token quoted match leaves the CLOSING quote on the path token
+  # rather than the subcommand: `bash -c 'git worktree add
+  # .claude/worktrees/ok'` arrives here as `.claude/worktrees/ok'`. That was
+  # accepted only because the scope prefix match below ends in `?*`, which
+  # tolerates a stray quote inside the leaf name -- the right answer for an
+  # incidental reason. Strip one unmatched trailing quote so the acceptance
+  # is explicit, and so tightening that match later (e.g. to an exact-segment
+  # comparison) does not silently reject legitimate quoted creation.
+  # Unscoped paths were and remain rejected either way. See #377.
+  path="${path%\'}"
+  path="${path%\"}"
+
   # Reject unexpanded shell constructs. We cannot resolve these statically,
   # so they can never be proven in-scope. Covers $VAR, ${VAR}, $(cmd),
   # backticks, ~ expansion, and glob characters.

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -327,6 +327,20 @@ inp="$(make_input "bash -c ${dq}git worktree add /tmp/evil${dq} && echo ${dq}git
 check "repeated literal: executor at the first occurrence still blocks" 2 "${inp}"
 inp="$(make_input "echo ${dq}git worktree add /tmp/evil${dq} && grep -r ${dq}git worktree add /tmp/evil${dq} docs/")"
 check "repeated literal: two mentions of the same literal stay allowed" 0 "${inp}"
+
+# Trailing-quote normalization on the path token (#377). In a multi-token
+# quoted match the closing quote lands on the PATH, not the subcommand, so
+# `bash -c 'git worktree add .claude/worktrees/ok'` reached path_in_scope as
+# `.claude/worktrees/ok'`. It was accepted only because the prefix match
+# tolerates a stray quote in the leaf name -- correct outcome, incidental
+# reason. These pin the behaviour so a future tightening of that match does
+# not silently break legitimate quoted creation.
+inp="$(make_input "bash -c ${sq}git worktree add .claude/worktrees/ok${sq}")"
+check "quoted path: scoped creation via bash -c is allowed" 0 "${inp}"
+inp="$(make_input "bash -c ${dq}git worktree add .claude/worktrees/ok${dq}")"
+check "quoted path: scoped creation via bash -c double-quoted is allowed" 0 "${inp}"
+inp="$(make_input "bash -c ${sq}git worktree add /tmp/evil${sq}")"
+check "quoted path: unscoped creation via bash -c is still blocked" 2 "${inp}"
 inp="$(make_input "command bash -c ${dq}git worktree add /tmp/evil${dq}")"
 check "invocation: command bash -c still blocks" 2 "${inp}"
 # KNOWN GAP, pinned as CURRENT behavior: a wrapper whose last non-flag word is

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -341,6 +341,14 @@ inp="$(make_input "bash -c ${dq}git worktree add .claude/worktrees/ok${dq}")"
 check "quoted path: scoped creation via bash -c double-quoted is allowed" 0 "${inp}"
 inp="$(make_input "bash -c ${sq}git worktree add /tmp/evil${sq}")"
 check "quoted path: unscoped creation via bash -c is still blocked" 2 "${inp}"
+# A path ending in BOTH quote characters has both stripped. Quotes are not in
+# the metacharacter reject list, so this was accepted before the #377 strip
+# too -- behaviour is unchanged, and scope is still what decides. Pinned so
+# the sequence-of-two-strips is a documented choice, not an accident.
+inp="$(make_input "git worktree add .claude/worktrees/ok${sq}${dq}")"
+check "quoted path: trailing quote pair on a scoped path stays allowed" 0 "${inp}"
+inp="$(make_input "git worktree add /tmp/evil${sq}${dq}")"
+check "quoted path: trailing quote pair on an unscoped path stays blocked" 2 "${inp}"
 inp="$(make_input "command bash -c ${dq}git worktree add /tmp/evil${dq}")"
 check "invocation: command bash -c still blocks" 2 "${inp}"
 # KNOWN GAP, pinned as CURRENT behavior: a wrapper whose last non-flag word is

--- a/settings.json
+++ b/settings.json
@@ -150,7 +150,7 @@
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark",
   "editorMode": "normal",
-  "verbose": true,
+  "verbose": false,
   "remoteControlAtStartup": true,
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,

--- a/skills/converging-issue-backlogs/SKILL.md
+++ b/skills/converging-issue-backlogs/SKILL.md
@@ -191,7 +191,19 @@ about half.
 above: pipelined fix->verify chains, worktree isolation, verdict-driven re-queue
 and quarantine, cumulative dedup, severity triage, and all five stop conditions.
 
-Invoke with `Workflow({scriptPath: '<this dir>/issue-convergence-loop.js', args})`:
+Normally you do not invoke this directly — reading this skill is the entry
+point, and the loop structure above is the deliverable. The script is for
+programmatic or embedded use, when you want the harness to run the rounds:
+
+```
+Workflow({
+  scriptPath: '~/.claude/skills/converging-issue-backlogs/issue-convergence-loop.js',
+  args,
+})
+```
+
+Skills are symlinked into `~/.claude`, so that path resolves whether you are
+working in the `claude-config` checkout or anywhere else.
 
 | arg | purpose |
 |---|---|

--- a/skills/converging-issue-backlogs/issue-convergence-loop.js
+++ b/skills/converging-issue-backlogs/issue-convergence-loop.js
@@ -462,11 +462,17 @@ NOT merge, rebase, push, or delete anything, and do NOT remove any worktree.`,
   queue = nextQueue
 }
 
-// If we broke out on the cap, whatever is still queued was never worked. Report
+// Whatever is still queued on ANY non-converged stop was never worked. Report
 // it explicitly — a silent drop here would read as "everything got done".
-const unworked = stopReason === 'capped' ? queue : []
+//
+// retryQueue matters for `diverging` and `no_progress`: both break above the
+// `retryQueue = []` reset, so items the verifier rejected and re-queued that
+// round are still sitting there and would otherwise be dropped. On `capped`
+// and `queue_explosion` retryQueue is already empty or already folded into
+// `queue`, and the spread is a harmless no-op. See #364.
+const unworked = stopReason === 'converged' ? [] : [...queue, ...retryQueue]
 if (unworked.length) {
-  log(`CAP REACHED after ${round} round(s): ${unworked.length} follow-up(s) left unworked`)
+  log(`STOPPED (${stopReason}) after ${round} round(s): ${unworked.length} item(s) left unworked`)
 }
 
 return {

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1302,6 +1302,20 @@ _load_gate3_fns() {
   # guard.
   unset _LIB_REVIEW_ISSUES_LOADED
   source "${SCRIPT}"
+
+  # Fail loudly if the source did not actually take effect. If a fixture
+  # sources the library earlier WITHOUT clearing the guard, the source above
+  # returns immediately and _VERIFY_ASSERTION_MARKERS stays empty or stale --
+  # at which point _asserts_incorrectness matches nothing and every gate3
+  # test passes vacuously. Verified reachable: with the guard pre-set, the
+  # re-source is a no-op and "The SHA is incorrect" stops being flagged.
+  # See #356.
+  if [[ "${#_VERIFY_ASSERTION_MARKERS[@]}" -eq 0 ]]; then
+    echo "_load_gate3_fns: _VERIFY_ASSERTION_MARKERS is empty after sourcing" >&2
+    echo "  ${SCRIPT} was likely already sourced with the guard set," >&2
+    echo "  making the source a no-op. gate3 tests would pass vacuously." >&2
+    return 1
+  fi
   # _load_fn extraction still runs afterwards, so these tests keep exercising
   # the same individually-extracted definitions they always did.
   _load_dedup_fns


### PR DESCRIPTION
Second pass on the backlog. Five issues, plus one settings change.

## #356 — vacuous gate3 green

`_load_gate3_fns` unsets the source guard before sourcing the library, but nothing asserted the source took effect. If a fixture sources `lib-review-issues.sh` earlier **without** clearing the guard, the source is a no-op, `_VERIFY_ASSERTION_MARKERS` stays empty, `_asserts_incorrectness` matches nothing, and every gate3 test passes while testing nothing.

Verified reachable, not theoretical — pre-setting the guard leaves the array at 0 entries and `"The SHA is incorrect"` stops being flagged.

Now asserts the array is non-empty and fails with a diagnostic. **Falsified:** with the guard pre-set, 10 gate3 tests fail loudly instead of passing vacuously.

## #377 — quoted path token

In a multi-token quoted match the closing quote lands on the *path*, so `bash -c 'git worktree add .claude/worktrees/ok'` reached `path_in_scope` as `.claude/worktrees/ok'`. Accepted only because the scope prefix match ends in `?*`, which tolerates a stray quote in the leaf — right answer, incidental reason, and a future tightening to exact-segment comparison would have silently broken legitimate quoted creation.

Outcomes unchanged, including rejections: `/tmp/evil'` still blocked, `.claude/worktrees'` still blocked (stripping leaves no leaf).

## #364 — unworked items silently dropped

`unworked` was `stopReason === 'capped' ? queue : []`, so `diverging`, `no_progress`, and `queue_explosion` reported an empty list with items still queued. The comment beside it says a silent drop *"would read as everything got done"* — which is what those three paths did.

`retryQueue` matters for two: the `diverging` and `no_progress` breaks fire **above** the `retryQueue = []` reset, so verifier-rejected retries were dropped.

Verified across all five stop paths:

```
converged        queue=0 retry=0 -> unworked=0
capped           queue=2 retry=0 -> unworked=2
diverging        queue=1 retry=1 -> unworked=2
no_progress      queue=0 retry=1 -> unworked=1
queue_explosion  queue=2 retry=0 -> unworked=2
```

## #367 — unresolvable skill path

`<this dir>/issue-convergence-loop.js` required the caller to know the install path. Replaced with the deployed `~/.claude/...` path (verified the symlink resolves), and stated that reading the skill is the normal entry point.

## #393 — settings

`verbose: true` → `false`.

## Also

Pinned the trailing-quote-pair behavior an earlier review raised. The reviewer said the metacharacter check would reject such paths; it does not — quotes aren't in that list. Confirmed identical against `HEAD~1`, so behavior is unchanged and scope still decides. Two tests document it.

## Verification

221 bats + 230 standalone, 0 failures. `shellcheck -S info` clean. `node --check` clean.

## Not included

**#374** proposes worktree ownership metadata or audit logging for peer-agent clobbering. That's a design decision, not a defect — leaving it for your call.
