### PR TITLE
fix: third backlog pass — timeout ceiling warning, vacuous label test, nameref guard

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -875,10 +875,15 @@ create_batched_nonblocking_issue() {
   local sections="" labels="tech-debt" count=0 has_unverified=false
   local current_block="" section
 
+  # Bash has no nested-function scope: this name lands in the GLOBAL function
+  # namespace while create_batched_nonblocking_issue runs, so it is prefixed
+  # to avoid clobbering an unrelated `_accumulate` in a calling context. See
+  # #391.
+  #
   # MUST be called directly, never via $(...) or a pipeline: it mutates the
   # enclosing function's locals (sections, count, labels, has_unverified),
   # and a subshell would discard those mutations silently. See #388.
-  _accumulate() {
+  _cbni_accumulate() {
     local block="$1"
     [[ -n "${block}" ]] || return 0
 
@@ -927,14 +932,14 @@ create_batched_nonblocking_issue() {
 
   while IFS= read -r line; do
     if [[ "${line}" == "---ISSUE---" ]]; then
-      _accumulate "${current_block}"
+      _cbni_accumulate "${current_block}"
       current_block=""
     else
       current_block+="${line}"$'\n'
     fi
   done <<<"${parsed}"
-  _accumulate "${current_block}"
-  unset -f _accumulate
+  _cbni_accumulate "${current_block}"
+  unset -f _cbni_accumulate
 
   # Nothing parsed into a renderable finding — file nothing.
   [[ "${count}" -gt 0 ]] || return 0

--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -192,8 +192,12 @@ _parse_issue_fields() {
   # stopping at a VERIFIED: header or an END_ISSUE terminator if one follows.
   _pif_details=$(echo "${block}" | { awk '/^VERIFIED:/{found=0} /^END_ISSUE$/{found=0} /^DETAILS:/{found=1; sub(/^DETAILS: /,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
 
-  # VERIFIED is optional and so is this nameref.
-  if [[ -n "${6:-}" ]]; then
+  # VERIFIED is optional and so is this nameref. Test arg COUNT, not the
+  # argument's content: `-n "${6:-}"` asks "is the name non-empty", which
+  # happens to work only because every caller passes a variable name. A
+  # caller passing "" would silently skip VERIFIED extraction instead of
+  # failing. `$# -ge 6` states the actual intent -- was a 6th arg given.
+  if [[ $# -ge 6 ]]; then
     local -n _pif_verified="$6"
     _pif_verified=$(echo "${block}" | { awk '/^(TITLE|SOURCE|LOCATION|DETAILS):/{found=0} /^END_ISSUE$/{found=0} /^VERIFIED:/{found=1; sub(/^VERIFIED:[[:space:]]*/,""); print; next} found{print}' || true; } | { sed '/^[[:space:]]*$/d' || true; })
   fi

--- a/hooks/pre-merge-review.sh
+++ b/hooks/pre-merge-review.sh
@@ -930,7 +930,9 @@ ANALYSIS_TEXT=$(echo "${FULL_PROMPT}" | timeout "${TIMEOUT_SECONDS}" env -u CLAU
     log_error "  1. Re-run the merge - the analysis often completes on a retry."
     log_error "  2. If it times out repeatedly, raise the ceiling explicitly:"
     log_error "       git config --global review.preMergeTimeout $((TIMEOUT_SECONDS * 2))"
-    log_error "     That value is honored verbatim and disables size-based scaling."
+    log_error "     That value is honored verbatim and disables both size-based"
+    log_error "     scaling and the ${TIMEOUT_CEILING_SECONDS}s ceiling, so the suggestion above can"
+    log_error "     exceed the ceiling. Set it deliberately, not just to silence this."
   else
     log_error "Claude CLI failed (exit code: ${EXIT_CODE})"
     log_error "${ANALYSIS_TEXT}"

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -2018,6 +2018,9 @@ SOURCE: code-reviewer
 LOCATION: src/a.ts:1
 DETAILS: This value is incorrect and must change." "${PENDING_ISSUES_DIR}"
 
+  # Order-sensitive by design: production builds this as "${labels},unverified"
+  # with labels starting at "tech-debt". If that construction changes, update
+  # this rather than loosening it -- the point is that the label FIRES.
   grep -q "tech-debt,unverified" "${MOCK_DIR}/label.txt" || {
     echo "unverified label did not fire; markers likely not loaded"
     echo "  label: $(cat "${MOCK_DIR}/label.txt" 2>/dev/null)"

--- a/tests/test_pre_merge_nonblocking.bats
+++ b/tests/test_pre_merge_nonblocking.bats
@@ -1974,3 +1974,54 @@ DETAILS: Detail one." "${PENDING_ISSUES_DIR}"
     return 1
   }
 }
+
+@test "create_batched_nonblocking_issue: unverified label actually fires (#391)" {
+  # Uses _load_gate3_fns, NOT _load_fn _asserts_incorrectness: the latter
+  # extracts the function without _VERIFY_ASSERTION_MARKERS, so the marker
+  # match silently returns false and the unverified path is never exercised.
+  # Without this test the label could regress to never firing and every other
+  # batched test would still pass. Same vacuous-green trap as #356.
+  _load_gate3_fns
+  _load_fn _parse_issue_fields
+  _load_fn _format_issue_section
+  _load_fn needs_security_label
+  _load_fn is_security_critical
+  _load_fn _repo_has_issues_enabled
+  _load_fn _write_pending_issue_file
+  _load_fn create_batched_nonblocking_issue
+
+  PR_NUMBER="95"
+  PR_TITLE="Label PR"
+  REPO_OWNER="org"
+  REPO_NAME="repo"
+  GH_CALLS_FILE="${MOCK_DIR}/gh_calls"
+  PENDING_ISSUES_DIR="${MOCK_DIR}/pending"
+
+  # Capture --label and --body to their own files: `echo "$@"` flattens every
+  # argument onto one line, so a grep for "issue create" stops at the first
+  # newline inside the body and never sees the label.
+  cat >"${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label) printf '%s' "$2" > "${MOCK_DIR}/label.txt" ;;
+    --body) printf '%s' "$2" > "${MOCK_DIR}/body.txt" ;;
+  esac
+  shift
+done
+exit 0
+EOF
+  chmod +x "${MOCK_DIR}/gh"
+
+  create_batched_nonblocking_issue "TITLE: The pinned SHA is incorrect
+SOURCE: code-reviewer
+LOCATION: src/a.ts:1
+DETAILS: This value is incorrect and must change." "${PENDING_ISSUES_DIR}"
+
+  grep -q "tech-debt,unverified" "${MOCK_DIR}/label.txt" || {
+    echo "unverified label did not fire; markers likely not loaded"
+    echo "  label: $(cat "${MOCK_DIR}/label.txt" 2>/dev/null)"
+    return 1
+  }
+  grep -q "unverified claim" "${MOCK_DIR}/body.txt"
+}

--- a/tests/test_pre_merge_timeout.bats
+++ b/tests/test_pre_merge_timeout.bats
@@ -210,3 +210,22 @@ _setup_timeout_fn() {
 @test "message: timeout error tells the operator to re-run the merge" {
   grep -qi "Re-run the merge" "${SCRIPT}"
 }
+
+@test "message: timeout error warns the override bypasses the ceiling (#355)" {
+  # The suggested value is TIMEOUT_SECONDS * 2. At the ceiling that is 1800s,
+  # double the documented cap -- an operator following the instruction should
+  # be told the override leaves the ceiling behind, not just that scaling is
+  # skipped.
+  # Assert on the rendered message block, not on single-line layout: the
+  # sentence wraps across log_error calls, so a one-line regex is brittle.
+  local msg
+  msg=$(grep -A4 'honored verbatim' "${SCRIPT}" | tr '\n' ' ')
+  [[ "${msg}" == *"scaling"* ]] || {
+    echo "override note does not mention scaling: ${msg}"
+    return 1
+  }
+  [[ "${msg}" == *"ceiling"* ]] || {
+    echo "override note does not warn that the ceiling is bypassed: ${msg}"
+    return 1
+  }
+}


### PR DESCRIPTION
Third backlog pass. Three issues fixed, one triaged to you, one finding disproven.

## #355 — timeout override bypasses the ceiling silently

On timeout the operator is told to run `git config --global review.preMergeTimeout $((TIMEOUT_SECONDS * 2))`. At the 900s ceiling that suggests **1800s**. The message said the value "disables size-based scaling" but never that it also leaves the ceiling behind — so an operator following the instruction lands on a 30-minute hard timeout on what they understood to be a capped value.

Rendered at the ceiling now:

```
  2. If it times out repeatedly, raise the ceiling explicitly:
       git config --global review.preMergeTimeout 1800
     That value is honored verbatim and disables both size-based
     scaling and the 900s ceiling, so the suggestion above can
     exceed the ceiling. Set it deliberately, not just to silence this.
```

## #391 — the unverified label was never actually tested

The significant one. All 8 batched tests loaded `_asserts_incorrectness` via `_load_fn`, which extracts the function **without** `_VERIFY_ASSERTION_MARKERS`. The marker loop then iterates an empty array and always returns false, so the unverified label path was never exercised. Every one of those tests would still pass if the label regressed to never firing.

Same vacuous-green trap as #356, one layer out. Verified: under `_load_fn`, `"The SHA is incorrect"` is not flagged.

Added a test using `_load_gate3_fns` that asserts the label actually appears. **Falsified** — swapping in `_load_fn _asserts_incorrectness` makes it fail with a diagnostic naming the cause.

That test also needed a better mock: the shared `echo "$@"` mock flattens every argument onto one line, so `grep "issue create"` stopped at the first newline in the body and never reached `--label`. The production code was correct throughout; the assertion mechanism was not.

Also renamed the inner helper to `_cbni_accumulate` — bash has no nested-function scope, so a generic `_accumulate` sits in the global namespace while the outer function runs and would clobber an unrelated helper in a calling context.

## #392 — one real, one disproven

Real: `_parse_issue_fields` guarded its optional 6th nameref by testing whether the *name* was non-empty. Now tests argument count, so an empty name fails loudly instead of silently skipping VERIFIED extraction.

**Disproven, no code changed:** the claim that `unset -f _accumulate` is skipped on the zero-findings early return. The unset is at line 933, the early return at 936 — the unset runs first. Verified by exercising the zero-findings path and checking `declare -F` afterward: no leak.

## Verification

223 bats + 230 standalone, 0 failures. `shellcheck -S info` clean. The two SC1091 source-follow infos in `pre-merge-review.sh` are pre-existing — confirmed identical with the change stashed.

## Triaged, not fixed

**#390** targets `beacon-biosignals/infra` (branch `arich/git-pkgs-proxy-terraform`), filed here because arbiter FAILs are treated as tooling facts. The finding looks substantively correct — `k8s_cluster_roles = ["view"]` binds a cluster-scoped ClusterRole, which grants read across all namespaces regardless of `k8s_namespaces`. Unlike #358/#378 I can't verify upstream state on a private repo, so I annotated it and left it open for you rather than closing it.
