### PR TITLE
fix: drain the deferred-cosmetic backlog (#365, #366, #369, #381)

### DIFF
--- a/hooks/lib-review-issues.sh
+++ b/hooks/lib-review-issues.sh
@@ -735,7 +735,8 @@ _VERIFY_ASSERTION_MARKERS=(
   #
   # Measured against the same corpus as Groups 1-2 plus the 13 findings in
   # tests/test_pre_merge_nonblocking.bats that must stay unflagged (the
-  # test-54 "careful phrasing" set and a style-finding set): 6/6 of the real
+  # "broad negative phrasing stays UNflagged" set (7) and the "style and
+  # structure findings stay UNflagged" set (6)): 6/6 of the real
   # false findings flag, 0/13 legitimate findings do. Re-run that measurement
   # before adding anything here -- broad terms like "treats" or "resolves to"
   # were rejected for catching careful phrasing.

--- a/skills/converging-issue-backlogs/issue-convergence-loop.js
+++ b/skills/converging-issue-backlogs/issue-convergence-loop.js
@@ -181,8 +181,21 @@ followUps must be genuinely NEW problems this work exposed — not restatements 
 Returning an empty followUps array is the expected common answer.
 `
 
+// Dedup is best-effort text matching over LLM-generated output, not semantic
+// similarity. Two reports of one concern differ in incidental ways -- whitespace,
+// and especially precision: `scripts/foo.sh:42` and `scripts/foo.sh` name the
+// same file. Normalizing both away costs nothing (a genuinely distinct concern
+// in the same file still differs by title) and closes the re-admission path
+// that keeps a backlog alive. Near-duplicates that survive this still need a
+// human to merge them.
 function keyOf(c) {
-  return `${(c.location ?? '').trim()}::${c.title.trim().toLowerCase().slice(0, 80)}`
+  const location = (c.location ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+(?::\d+)?$/, '') // drop trailing :line or :line:col
+    .replace(/\s+/g, '')
+  const title = c.title.trim().toLowerCase().replace(/\s+/g, ' ').slice(0, 80)
+  return `${location}::${title}`
 }
 
 const MAX_ATTEMPTS = args?.maxAttempts ?? 2
@@ -355,7 +368,11 @@ holds=false when genuinely uncertain. Do NOT edit files, commit, or push.`,
   const fetchable = retrievable.filter(
     (r) => SAFE_REF.test(r.fix.branch) && SAFE_PATH.test(r.fix.worktreePath) && !r.fix.branch.startsWith('-'),
   )
-  for (const r of retrievable.filter((x) => !fetchable.includes(x))) {
+  // Set membership over object refs, not `fetchable.includes` inside a filter:
+  // the same pattern copy-pasted into a higher-fan-out context is quadratic.
+  const fetchableRefs = new Set(fetchable)
+  for (const r of retrievable) {
+    if (fetchableRefs.has(r)) continue
     log(`WARNING: refusing to fetch #${r.fix.issue} — unsafe branch or worktree path, retrieve it by hand`)
   }
 
@@ -480,7 +497,10 @@ return {
   roundsRun: round,
   maxRounds: MAX_ROUNDS,
   ledger: ledger.filter((e) => e.issue !== undefined),
-  deferredCosmetic: ledger.flatMap((e) => e.deferredCosmetic ?? []),
+  // Stamped with the round it was deferred in. `roundStats[].deferred` gives the
+  // per-round count; without `round` on the entries themselves a caller reading
+  // this list cannot line the two up, and reads convergence history blind.
+  deferredCosmetic: ledger.flatMap((e) => (e.deferredCosmetic ?? []).map((c) => ({ ...c, round: e.round }))),
   roundStats,
   integrated,
   quarantined,


### PR DESCRIPTION
Drains the four remaining `deferred-cosmetic` issues. All four sit in the
convergence loop's own instrumentation or its calibration comment, so closing
them empties the backlog rather than feeding it.

The other four open issues are all `needs-human-decision` and are deliberately
untouched — they are design calls no fixer agent is authorized to make.

## Changes

| Issue | Fix |
|---|---|
| #365 | `keyOf()` normalizes location: lowercase, strip trailing `:line`/`:line:col`, collapse whitespace. `scripts/foo.sh:42` and `scripts/foo.sh` now dedup to one key. |
| #366 | `Set` membership over object refs instead of `includes()` inside a filter. |
| #369 | `deferredCosmetic` entries carry the round they were deferred in. |
| #381 | The count was already right; the `test-54` identifier was the stale part. |

## On #381

The issue claimed the "13 findings" comment was stale and the true count was
18. It isn't. The two named sets total 7 + 6 = 13, exactly as written — the
issue undercounted the first set and then double-counted the second as a new
addition when it was already included.

The real defect it surfaced is `test-54`, an identifier naming no existing
test. Both set references now use their current test descriptions with inline
counts, so the next person to re-run the calibration can find them.

## Verification

- 223/223 bats, 5/5 `scripts/tests/*.sh` — both suites enumerated by scanning
  the repo, not from recall.
- Falsified before trusting: sabotaging a Group-3 marker failed test 53 as
  designed, confirming the suite resolves `hooks/` from the repo rather than
  the deployed `~/.claude` tree.
- `keyOf` checked behaviorally including the negative case — distinct titles
  in the same file still key apart.
- `shellcheck -S info` clean, `node --check` OK.

https://claude.ai/code/session_01NXuVW5yLazLNxYitGLXFGj
