### PR TITLE
feat(hooks): audit out-of-scope worktree removes (#374)

### DIFF
--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -215,12 +215,14 @@ extract_path_operand() {
 # on purpose (see the ACCEPTED TRADE-OFF note in the header) but leaves no
 # trace otherwise. A distinct prefix keeps it out of anything counting
 # "BLOCKED GIT WORKTREE" -- this is an audit record, not a refusal.
-# Reads ${cmd} from the enclosing scope, matching block() below. Both are
-# defined only for use inside the command-scanning loop where ${cmd} is set.
+# Takes the offending command explicitly rather than reading the script-level
+# ${cmd}, so the function is callable from anywhere and shellcheck can see the
+# dependency. block() still reads ${cmd} directly; that predates this and its
+# four call sites are out of scope here (#397).
 warn_out_of_scope_remove() {
-  local target="${1}"
+  local target="${1}" offending_cmd="${2}"
   printf '%s AUDIT GIT WORKTREE REMOVE (out of scope: %s): %s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${target}" "${cmd}" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${target}" "${offending_cmd}" \
     >>"${HOME}/.claude/blocked-commands.log"
   printf '⚠️  NOTE: removing a worktree outside %s/ (%s)\n' "${WORKTREE_SCOPE}" "${target}" >&2
   printf '   Allowed, and logged for audit. If this was a peer agent'"'"'s worktree,\n' >&2
@@ -444,7 +446,7 @@ for match in "${matches[@]}"; do
     remove)
       target="$(extract_path_operand "${tokens[@]:1}")"
       if [[ -n "${target}" ]] && ! path_in_scope "${target}"; then
-        warn_out_of_scope_remove "${target}"
+        warn_out_of_scope_remove "${target}" "${cmd}"
       fi
       continue
       ;;

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -54,6 +54,13 @@
 #   fix belongs in agent orchestration (ownership metadata per worktree), not
 #   in a regex hook that cannot tell one agent's path from another's.
 #
+#   What IS detected (#374): an out-of-scope `remove` is allowed but logged to
+#   ~/.claude/blocked-commands.log under an `AUDIT GIT WORKTREE REMOVE` prefix,
+#   so the post-mortem has a trail instead of silence. This is deliberately
+#   observe-only -- it must never block, or it reintroduces the un-cleanable
+#   pre-ban worktrees described above. It does not tell whose worktree it was;
+#   that still needs ownership metadata.
+#
 #   Why the ban was relaxed at all: "work directly on a feature branch instead"
 #   assumed one worker per checkout. Subagent-driven execution is now the
 #   documented default in CLAUDE.md, and a branch is not isolation when two
@@ -170,7 +177,10 @@ path_in_scope() {
 # Walk the tokens, consuming flags (and the value of those flags that take one),
 # and return the first bare operand -- that is the path. A trailing <commit-ish>
 # may follow it, which we ignore.
-extract_add_path() {
+# First non-flag operand of a subcommand's argument list. Correct for both
+# `add <path>` and `remove [--force] <worktree>`: --force is valueless, so the
+# valueless-flag arm skips it and the worktree path is still the first operand.
+extract_path_operand() {
   local -a tokens=("$@")
   local i=0 tok
   while ((i < ${#tokens[@]})); do
@@ -193,6 +203,21 @@ extract_add_path() {
   done
   # No operand found.
   return 0
+}
+
+# Observe-only counterpart to block(): records an event and RETURNS. Used for
+# `remove` targeting a path outside the sanctioned scope, which stays allowed
+# on purpose (see the ACCEPTED TRADE-OFF note in the header) but leaves no
+# trace otherwise. A distinct prefix keeps it out of anything counting
+# "BLOCKED GIT WORKTREE" -- this is an audit record, not a refusal.
+warn_out_of_scope_remove() {
+  local target="${1}"
+  printf '%s AUDIT GIT WORKTREE REMOVE (out of scope: %s): %s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${target}" "${cmd}" \
+    >>"${HOME}/.claude/blocked-commands.log"
+  printf '⚠️  NOTE: removing a worktree outside %s/ (%s)\n' "${WORKTREE_SCOPE}" "${target}" >&2
+  printf '   Allowed, and logged for audit. If this was a peer agent'"'"'s worktree,\n' >&2
+  printf '   its uncommitted work is gone -- see %s/.claude/blocked-commands.log\n' "${HOME}" >&2
 }
 
 block() {
@@ -405,13 +430,24 @@ for match in "${matches[@]}"; do
     # scoping here would restore the un-cleanable-worktree bug dotfiles#200
     # fixed. The cost is that an agent can remove a peer agent's worktree; see
     # the ACCEPTED TRADE-OFF note in the header before narrowing this.
-    remove | prune)
+    # `remove` is still ALWAYS allowed -- the audit call cannot block. It only
+    # leaves a trace when the target is outside scope, which is the peer-agent
+    # clobbering case the header calls a real consequence (#374). `prune` takes
+    # no path operand, so there is nothing to inspect.
+    remove)
+      target="$(extract_path_operand "${tokens[@]:1}")"
+      if [[ -n "${target}" ]] && ! path_in_scope "${target}"; then
+        warn_out_of_scope_remove "${target}"
+      fi
+      continue
+      ;;
+    prune)
       continue
       ;;
     # Creation: permitted only when the target path is provably inside the
     # sanctioned scope.
     add)
-      target="$(extract_add_path "${tokens[@]:1}")"
+      target="$(extract_path_operand "${tokens[@]:1}")"
       if path_in_scope "${target}"; then
         continue
       fi

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -215,6 +215,12 @@ extract_path_operand() {
 # on purpose (see the ACCEPTED TRADE-OFF note in the header) but leaves no
 # trace otherwise. A distinct prefix keeps it out of anything counting
 # "BLOCKED GIT WORKTREE" -- this is an audit record, not a refusal.
+# Every failure path here is swallowed. Under `set -e` an unwritable log (no
+# ~/.claude on first run, full disk, bad permissions) would exit non-zero, and
+# a non-zero exit from a PreToolUse hook BLOCKS the command -- turning a missing
+# audit line into a refused removal, the exact outcome the header forbids
+# (#398). Losing the record is bad; losing the removal is worse.
+#
 # Takes the offending command explicitly rather than reading the script-level
 # ${cmd}, so the function is callable from anywhere and shellcheck can see the
 # dependency. block() still reads ${cmd} directly; that predates this and its
@@ -223,7 +229,7 @@ warn_out_of_scope_remove() {
   local target="${1}" offending_cmd="${2}"
   printf '%s AUDIT GIT WORKTREE REMOVE (out of scope: %s): %s\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${target}" "${offending_cmd}" \
-    >>"${HOME}/.claude/blocked-commands.log"
+    >>"${HOME}/.claude/blocked-commands.log" || true
   printf '⚠️  NOTE: removing a worktree outside %s/ (%s)\n' "${WORKTREE_SCOPE}" "${target}" >&2
   printf '   Allowed, and logged for audit. If this was a peer agent'"'"'s worktree,\n' >&2
   printf '   its uncommitted work is gone -- see %s/.claude/blocked-commands.log\n' "${HOME}" >&2

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -201,7 +201,12 @@ extract_path_operand() {
         ;;
     esac
   done
-  # No operand found.
+  # No operand found. Callers diverge on what that means, deliberately:
+  # `add` treats an empty result as "creation with no explicit path" and
+  # BLOCKS it (a path that cannot be shown in scope is not allowed); `remove`
+  # treats it as "nothing to inspect" and skips the audit, since a removal with
+  # no operand is rejected by git itself. Returning empty rather than failing
+  # keeps that policy choice at the call site.
   return 0
 }
 
@@ -210,6 +215,8 @@ extract_path_operand() {
 # on purpose (see the ACCEPTED TRADE-OFF note in the header) but leaves no
 # trace otherwise. A distinct prefix keeps it out of anything counting
 # "BLOCKED GIT WORKTREE" -- this is an audit record, not a refusal.
+# Reads ${cmd} from the enclosing scope, matching block() below. Both are
+# defined only for use inside the command-scanning loop where ${cmd} is set.
 warn_out_of_scope_remove() {
   local target="${1}"
   printf '%s AUDIT GIT WORKTREE REMOVE (out of scope: %s): %s\n' \

--- a/scripts/hook-block-git-worktree.sh
+++ b/scripts/hook-block-git-worktree.sh
@@ -170,16 +170,17 @@ path_in_scope() {
   return 1
 }
 
-# Pull the target path out of a creation invocation's argument list.
+# Pull the target path out of a subcommand's argument list.
 #
-# Creation accepts flags before the path (`-b <branch>`, `-B <branch>`,
+# Both callers accept flags before the path (`-b <branch>`, `-B <branch>`,
 # `--detach`, `--force`, ...), so the path is NOT reliably the first argument.
 # Walk the tokens, consuming flags (and the value of those flags that take one),
 # and return the first bare operand -- that is the path. A trailing <commit-ish>
 # may follow it, which we ignore.
-# First non-flag operand of a subcommand's argument list. Correct for both
-# `add <path>` and `remove [--force] <worktree>`: --force is valueless, so the
-# valueless-flag arm skips it and the worktree path is still the first operand.
+#
+# Correct for both `add <path>` and `remove [--force] <worktree>`: --force is
+# valueless, so the valueless-flag arm skips it and the path is still the first
+# bare operand.
 extract_path_operand() {
   local -a tokens=("$@")
   local i=0 tok

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -369,6 +369,43 @@ check "PERMANENT GAP: variable-obfuscated git is not detected" 0 "${inp}"
 inp="$(make_input 'wt worktree add /tmp/evil')"
 check "PERMANENT GAP: alias/function resolving to git is not detected" 0 "${inp}"
 
+# --- #374: out-of-scope `remove` is ALLOWED but audited ---
+# Exit-code assertions cannot express this: the whole point is that exit stays
+# 0. These run the hook under a throwaway HOME and assert on the log instead.
+check_audit() {
+  local desc="${1}" expect_logged="${2}" input="${3}"
+  local tmphome logfile actual=0 logged=no
+  tmphome="$(mktemp -d)"
+  mkdir -p "${tmphome}/.claude"
+  logfile="${tmphome}/.claude/blocked-commands.log"
+  printf '%s\n' "${input}" | HOME="${tmphome}" "${HOOK}" >/dev/null 2>&1 || actual=$?
+  [[ -s "${logfile}" ]] && grep -q 'AUDIT GIT WORKTREE REMOVE' "${logfile}" && logged=yes
+  rm -rf "${tmphome}"
+  if [[ "${actual}" -eq 0 && "${logged}" == "${expect_logged}" ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (exit ${actual} want 0; logged=${logged} want ${expect_logged})"
+    ((fail += 1))
+  fi
+}
+
+inp="$(make_input 'git worktree remove /tmp/peer-agent-wt')"
+check_audit "remove outside scope is allowed AND audited" yes "${inp}"
+inp="$(make_input 'git worktree remove --force /tmp/peer-agent-wt')"
+check_audit "remove --force outside scope is allowed AND audited" yes "${inp}"
+inp="$(make_input 'git worktree remove .claude/worktrees/mine')"
+check_audit "remove inside scope is allowed and NOT audited" no "${inp}"
+inp="$(make_input 'git worktree prune')"
+check_audit "prune takes no path, so it is never audited" no "${inp}"
+# Bare `prune` cannot distinguish correct routing from a broken audit -- it has
+# no operand, so the -n guard short-circuits either way. `prune --expire <time>`
+# does have a trailing operand, so it is audited as a bogus path if `prune` is
+# ever folded back into the `remove` branch. This is the assertion that fails
+# on that regression; the bare-prune one above does not.
+inp="$(make_input 'git worktree prune --expire 3.days.ago')"
+check_audit "prune --expire operand is not mistaken for a worktree path" no "${inp}"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -411,6 +411,27 @@ check_audit "prune takes no path, so it is never audited" no "${inp}"
 inp="$(make_input 'git worktree prune --expire 3.days.ago')"
 check_audit "prune --expire operand is not mistaken for a worktree path" no "${inp}"
 
+# #398: an unwritable log must NOT block the removal. check_audit cannot cover
+# this -- it creates ${HOME}/.claude, so the log is always writable under it.
+# A non-zero exit from a PreToolUse hook blocks the command, so a failed audit
+# write would refuse a removal the policy requires be allowed.
+check_unwritable_log_allows() {
+  local desc="${1}" input="${2}" tmphome actual=0
+  tmphome="$(mktemp -d)" # deliberately WITHOUT .claude/, as on first run
+  printf '%s\n' "${input}" | HOME="${tmphome}" "${HOOK}" >/dev/null 2>&1 || actual=$?
+  rm -rf "${tmphome}"
+  if [[ "${actual}" -eq 0 ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (exit ${actual}, want 0 -- audit failure must not block)"
+    ((fail += 1))
+  fi
+}
+
+inp="$(make_input 'git worktree remove /tmp/peer-agent-wt')"
+check_unwritable_log_allows "unwritable audit log still allows the remove" "${inp}"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -384,7 +384,7 @@ check_audit() {
   # bug that split the record apart would still pass. Match the whole shape --
   # timestamp, prefix, scope path, then the command.
   if [[ -s "${logfile}" ]] && grep -qE \
-    '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z AUDIT GIT WORKTREE REMOVE \(out of scope: [^)]+\): .*git worktree remove' \
+    '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z AUDIT GIT WORKTREE REMOVE \(out of scope: [^)]+\): .*git worktree remove' \
     "${logfile}"; then
     logged=yes
   fi

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -379,7 +379,12 @@ check_audit() {
   mkdir -p "${tmphome}/.claude"
   logfile="${tmphome}/.claude/blocked-commands.log"
   printf '%s\n' "${input}" | HOME="${tmphome}" "${HOOK}" >/dev/null 2>&1 || actual=$?
-  [[ -s "${logfile}" ]] && grep -q 'AUDIT GIT WORKTREE REMOVE' "${logfile}" && logged=yes
+  # Assert the command text too, not just the prefix: an audit line that lost
+  # its interpolation still says AUDIT and is useless for the post-mortem.
+  if [[ -s "${logfile}" ]] && grep -q 'AUDIT GIT WORKTREE REMOVE' "${logfile}" \
+    && grep -q 'git worktree remove' "${logfile}"; then
+    logged=yes
+  fi
   rm -rf "${tmphome}"
   if [[ "${actual}" -eq 0 && "${logged}" == "${expect_logged}" ]]; then
     echo "  PASS: ${desc}"

--- a/scripts/tests/test-hook-block-git-worktree.sh
+++ b/scripts/tests/test-hook-block-git-worktree.sh
@@ -379,10 +379,13 @@ check_audit() {
   mkdir -p "${tmphome}/.claude"
   logfile="${tmphome}/.claude/blocked-commands.log"
   printf '%s\n' "${input}" | HOME="${tmphome}" "${HOOK}" >/dev/null 2>&1 || actual=$?
-  # Assert the command text too, not just the prefix: an audit line that lost
-  # its interpolation still says AUDIT and is useless for the post-mortem.
-  if [[ -s "${logfile}" ]] && grep -q 'AUDIT GIT WORKTREE REMOVE' "${logfile}" \
-    && grep -q 'git worktree remove' "${logfile}"; then
+  # One anchored pattern over a single line, not two independent greps: separate
+  # greps are satisfied by a prefix on one line and a command on another, so a
+  # bug that split the record apart would still pass. Match the whole shape --
+  # timestamp, prefix, scope path, then the command.
+  if [[ -s "${logfile}" ]] && grep -qE \
+    '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z AUDIT GIT WORKTREE REMOVE \(out of scope: [^)]+\): .*git worktree remove' \
+    "${logfile}"; then
     logged=yes
   fi
   rm -rf "${tmphome}"


### PR DESCRIPTION
Closes #374.

The hook header called peer-agent worktree clobbering "a real consequence, not
a theoretical one" and then left it undetectable: `remove` runs no path
inspection, so an agent destroying a peer's worktree — and its uncommitted
work — left no trace at all.

Now it logs. `git worktree remove <path-outside-scope>` writes an
`AUDIT GIT WORKTREE REMOVE` line to `~/.claude/blocked-commands.log`.

## Observe-only, by design

It must never block. Path-scoping `remove` would restore the exact bug
dotfiles#200 fixed: pre-ban worktrees live at arbitrary paths outside
`.claude/worktrees/`, and a scoped `remove` would leave them permanently
un-cleanable. Allow, record, move on.

The `AUDIT` prefix is deliberately distinct from `BLOCKED` — these are not
refusals, and anything counting `BLOCKED GIT WORKTREE` must not pick them up.

`prune` stays a separate case arm: no path operand, nothing to inspect.

## One real bug found along the way

Pre-push review caught a genuine defect in my own first version (#398). The
audit `printf` redirects under `set -euo pipefail`, so a failed log write would
exit non-zero — and a non-zero exit from a PreToolUse hook **blocks the
command**. An unwritable log would have refused a removal the policy requires
be allowed, reintroducing the un-cleanable worktrees through the very feature
meant to be observe-only.

Reproduced before fixing, with a `HOME` lacking `.claude/`:

```
exit=1   (0=allowed, nonzero=BLOCKED)
```

My tests could not have caught it — `check_audit` does `mkdir -p
"${tmphome}/.claude"`, so the log is always writable under it. Added
`check_unwritable_log_allows`, which runs against a `HOME` with no `.claude/`.

## Verification

117/117 hook tests, 5/5 standalone, 223/223 bats, shellcheck clean.

Every assertion was falsified before being trusted:

| Sabotage | Result |
|---|---|
| Disable the audit call | 2 positive assertions fail |
| Audit unconditionally | in-scope assertion fails |
| Fold `prune` into the `remove` arm | **failed nothing** — see below |
| Replace audit with `block()` | 5 fail, incl. `exit 2 want 0` |
| Blank the command interpolation | 2 fail |
| Split the record across two lines | 2 fail |
| Emit a malformed timestamp | 2 fail |
| Revert the `\|\| true` | unwritable-log test fails |

The third sabotage caught a vacuous test. Bare `git worktree prune` has no
operand, so the non-empty guard short-circuits whether or not routing is
correct — the assertion was true for the wrong reason. Added a `prune --expire`
case, which carries a trailing operand and does fail on that regression.

## Review findings

`#397` and `#398` are fixed here. Two findings were **not** actioned:

- **#399, second item** — claims line 235 embeds `${HOME}` in the format string
  and needs normalizing for SC2059. It already passes it as a `%s` argument.
  Factually wrong; no change.
- **#400** — both items are self-declared out-of-scope (`block()`'s `${cmd}`
  pattern, which predates this PR) or low-severity (stderr text unasserted).
  Left open as tracked debt, which is what the issue text asks for.

Findings per round went 1 → 1 → 2 → 2 while severity fell to zero, so I stopped
hardening rather than keep fixing a reviewer's opinions about a file it
re-reads every push.

https://claude.ai/code/session_01NXuVW5yLazLNxYitGLXFGj
