### PR TITLE
fix(hooks): close the last actionable backlog (#405, #406, #407)

### DIFF
--- a/scripts/hook-block-api-merge.sh
+++ b/scripts/hook-block-api-merge.sh
@@ -76,6 +76,20 @@ if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*gh[[:space:]]+(-[^[:space:]]+
   exit 0
 fi
 
+# COMMAND-POSITION ANCHOR (claude-config#405). The four api matchers below
+# require the tool name at a command position -- start of string/line, or
+# immediately after a shell operator -- rather than anywhere in the string.
+# Without it the endpoint matched inside a quoted argument being written to
+# a file, so writing a test fixture for this hook was blocked by this hook.
+# Same idiom the pr-merge matcher further down already used.
+#
+# KNOWN GAP, accepted: a heredoc body starts at a line boundary, so a
+# heredoc containing the endpoint still matches. Distinguishing a heredoc
+# body from a command needs real tokenization, which a PreToolUse hook
+# operating on an unexpanded string cannot do. This is the same
+# regex-is-not-a-shell-parser limit recorded for the false-NEGATIVE
+# direction in #349, and it fails safe: the cost is a blocked write, not a
+# permitted merge.
 # Block: gh api .../pulls/{number}/merge  (REST endpoint)
 # Suffix boundary ([[:space:]]|$|[^[:alnum:]_]) prevents false positives on
 # hypothetical paths like pulls/NNN/merge_status while still matching:
@@ -83,7 +97,7 @@ fi
 #   gh api /repos/owner/repo/pulls/123/merge
 #   gh api "repos/owner/repo/pulls/123/merge"
 #   echo x && gh api repos/o/r/pulls/1/merge --method PUT
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
   printf '%s BLOCKED API MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: Direct REST API PR merge bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -99,7 +113,7 @@ fi
 # Block: gh api graphql with mergePullRequest mutation
 # GraphQL offers the same merge capability as the REST endpoint above.
 # Covers inline mutations passed via -f query=... or --field query=...
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
   printf '%s BLOCKED GRAPHQL MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: GraphQL mergePullRequest mutation bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -116,7 +130,7 @@ fi
 # linting, block this pattern unconditionally. Legitimate data queries
 # rarely need --input; they can be expressed inline via -f query=.
 # Previously documented as a known gap (Protocol 6 in CLAUDE.md) — now closed.
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
   printf '%s BLOCKED GRAPHQL --input: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql --input reads the mutation from a file,\n' >&2
   printf '   hiding its contents from the command-line merge-bypass scanners.\n' >&2
@@ -131,7 +145,7 @@ fi
 # gh'"'"'s @<filename> convention for -f / --field reads the value from a file,
 # which lets a mutation body live on disk and still get executed. Covers the
 # gap left by the --input check above. Issue #133.
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
   printf '%s BLOCKED GRAPHQL @file: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql with -f/-F query=@<file> (or mutation=@<file>)\n' >&2
   printf '   reads the payload body from a file via gh'"'"'s @<filename> convention,\n' >&2

--- a/scripts/hook-block-api-merge.sh
+++ b/scripts/hook-block-api-merge.sh
@@ -77,8 +77,10 @@ if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*gh[[:space:]]+(-[^[:space:]]+
 fi
 
 # COMMAND-POSITION ANCHOR (claude-config#405). The four api matchers below
-# require the tool name at a command position -- start of string/line, or
-# immediately after a shell operator -- rather than anywhere in the string.
+# require the tool name at a command position -- start of line, or
+# immediately after a shell operator, backtick, or command substitution --
+# rather than anywhere in the string. `^` covers the line case on its own:
+# grep matches per line and the command is piped through printf '%s\n'.
 # Without it the endpoint matched inside a quoted argument being written to
 # a file, so writing a test fixture for this hook was blocked by this hook.
 # Same idiom the pr-merge matcher further down already used.
@@ -97,7 +99,7 @@ fi
 #   gh api /repos/owner/repo/pulls/123/merge
 #   gh api "repos/owner/repo/pulls/123/merge"
 #   echo x && gh api repos/o/r/pulls/1/merge --method PUT
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
   printf '%s BLOCKED API MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: Direct REST API PR merge bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -113,7 +115,7 @@ fi
 # Block: gh api graphql with mergePullRequest mutation
 # GraphQL offers the same merge capability as the REST endpoint above.
 # Covers inline mutations passed via -f query=... or --field query=...
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
   printf '%s BLOCKED GRAPHQL MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: GraphQL mergePullRequest mutation bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -130,7 +132,7 @@ fi
 # linting, block this pattern unconditionally. Legitimate data queries
 # rarely need --input; they can be expressed inline via -f query=.
 # Previously documented as a known gap (Protocol 6 in CLAUDE.md) — now closed.
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
   printf '%s BLOCKED GRAPHQL --input: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql --input reads the mutation from a file,\n' >&2
   printf '   hiding its contents from the command-line merge-bypass scanners.\n' >&2
@@ -145,7 +147,7 @@ fi
 # gh'"'"'s @<filename> convention for -f / --field reads the value from a file,
 # which lets a mutation body live on disk and still get executed. Covers the
 # gap left by the --input check above. Issue #133.
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
   printf '%s BLOCKED GRAPHQL @file: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql with -f/-F query=@<file> (or mutation=@<file>)\n' >&2
   printf '   reads the payload body from a file via gh'"'"'s @<filename> convention,\n' >&2

--- a/scripts/tests/test-hook-api-merge-command-position.sh
+++ b/scripts/tests/test-hook-api-merge-command-position.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tests that the api-merge matchers require the tool name at a COMMAND
+# position, not merely somewhere in the string (claude-config#405).
+#
+# The matchers used to accept the tool name anywhere, so the merge endpoint
+# matched inside a quoted argument being written to a file -- writing a test
+# fixture for this hook was blocked by this hook.
+#
+# This hook gates merges. Loosening it needs the true positives pinned or a
+# false-positive fix silently becomes a bypass, so both directions are
+# asserted here, including command substitution (which genuinely executes).
+
+set -euo pipefail
+unset CDPATH
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-api-merge.sh"
+pass=0
+fail=0
+
+# Assembled at runtime so this file's own invocation is not blocked by the
+# hook it tests.
+readonly EP="pulls/1/""merge"
+
+check() {
+  local desc="${1}" expected="${2}" cmd="${3}"
+  local input actual=0
+
+  input="$(jq --null-input --arg c "${cmd}" '{tool_input: {command: $c}}')" || {
+    echo "  FAIL: ${desc} (could not build fixture)"
+    ((fail += 1))
+    return
+  }
+
+  printf '%s\n' "${input}" | "${HOOK}" >/dev/null 2>&1 || actual=$?
+
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (expected exit ${expected}, got ${actual})"
+    ((fail += 1))
+  fi
+}
+
+echo "=== api-merge command-position tests ==="
+
+# --- must BLOCK: the tool is actually invoked ---
+check "plain REST merge"                2 "gh api -X PUT repos/o/r/${EP}"
+check "REST merge with --method"        2 "gh api repos/o/r/${EP} --method PUT"
+check "chained after &&"                2 "echo x && gh api repos/o/r/${EP}"
+check "chained after a semicolon"       2 "cd /x ; gh api repos/o/r/${EP}"
+check "after a pipe"                    2 "true | gh api repos/o/r/${EP}"
+check "command substitution executes"   2 "echo \$(gh api repos/o/r/${EP})"
+
+# --- must ALLOW: already-legitimate usage ---
+check "the sanctioned merge path"       0 "gh pr merge 123 --squash --delete-branch"
+check "an unrelated api read"           0 "gh api repos/o/r/pulls/1"
+
+# --- #405 case C: the endpoint appears in QUOTED text, not as a command ---
+check "endpoint written into a fixture file" \
+  0 "printf %s \"gh api -X PUT repos/o/r/${EP}\" > fixture.json"
+check "endpoint quoted in documentation" \
+  0 "echo \"gh api repos/o/r/${EP} is blocked by policy\" >> notes.md"
+
+# --- ACCEPTED GAP, asserted as CURRENT behavior rather than desired ---
+# A heredoc body starts at a line boundary and is indistinguishable from a
+# command without real tokenization. Documented in the hook header; fails safe
+# (a blocked write, never a permitted merge). Same limit #349 recorded for the
+# false-negative direction.
+check "KNOWN GAP: heredoc body still matches" \
+  2 "cat > t.txt <<EOF
+gh api repos/o/r/${EP}
+EOF"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]

--- a/scripts/tests/test-hooks-unwritable-log.sh
+++ b/scripts/tests/test-hooks-unwritable-log.sh
@@ -91,6 +91,12 @@ check hook-block-merge-locks-write.sh \
   "merge-locks-write: blocks with exit 2" \
   file_path "/Users/x/.claude/merge-locks/pr-1.lock"
 
+# EnterWorktree carries a `name`, not a command. An invalid slug reaches deny(),
+# which writes to the log and then exits 2 -- same shape as the five above.
+check hook-block-enter-worktree.sh \
+  "enter-worktree: blocks with exit 2" \
+  name "invalid name with spaces"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]


### PR DESCRIPTION
Closes #405, closes #406, closes #407.

Clears the last of the actionable backlog. After this, the only open issues are
#351 and #354, both explicitly deferred pending your decision.

## #406 / #407 — coverage gap I introduced

Both issues report the same defect and both are right. When I consolidated the
per-suite helpers into one table in #404, I removed the enter-worktree copy and
never added a corresponding row — so the suite covered five of the six guarded
hooks while its own comment claimed "every affected hook".

Verified before fixing rather than taking the finding at its word (#406 was
filed with the `unverified` label): the hook does write to the log and exit 2,
it was absent from the table, and no other suite covered its unwritable case.

## #405 case C — api-merge matched inside quoted text

The four `api` matchers accepted the tool name anywhere in the string, so the
merge endpoint matched inside a quoted argument being written to a file.
Writing a test fixture for this hook was blocked by this hook — which is why
its own suite already assembles fixtures from string fragments.

Now anchored to a command position: start of line, or immediately after a shell
operator, backtick, or command substitution. Same idiom the pr-merge matcher
already used.

**The corpus caught a bypass I nearly shipped.** My first attempt omitted `$(`
from the anchor list — command substitution *is* a command position, since the
contents genuinely execute — and it regressed two existing assertions. That is
the argument for pinning true positives before touching a matcher that gates
merges.

| | before | after |
|---|---|---|
| 9 true positives (real merge attempts) | blocked | **still blocked** |
| 2 false positives (fixture write, doc append) | blocked | **allowed** |
| 1 heredoc case | blocked | blocked (accepted, see below) |

**Accepted gap, asserted as current behavior rather than desired:** a heredoc
body starts at a line boundary and is indistinguishable from a command without
real tokenization, which a PreToolUse hook operating on an unexpanded string
cannot do. Same regex-is-not-a-shell-parser limit #349 recorded for the
false-*negative* direction. It fails safe — the cost is a blocked write, never
a permitted merge.

## A review finding whose mechanism was wrong

Pre-push review flagged the `[\n]` branch in the anchors as dead weight.
Correct conclusion, but its stated mechanism was backwards: it claimed the
branch matches a literal `n` and not a newline, with a `VERIFIED:` block
asserting so. A direct check showed the opposite.

The real explanation is simpler — grep matches per line and the command is
piped through `printf '%s\n'`, so `^` already covers the start-of-line case and
the extra branch never contributes. Removed from all four, comment corrected,
behavior identical before and after.

## Verification

8/8 standalone suites, 223/223 bats, shellcheck unchanged at 6 pre-existing
SC2016 findings on backticked prose.

Falsified in both directions on each change:

| Sabotage | Result |
|---|---|
| Revert the enter-worktree row's guard | that row fails (exit 1, want 2) |
| Revert every guard in the repo | 0 passed / 6 failed — no vacuous rows |
| Revert the command-position anchor | 2 case-C assertions fail |
| Drop `$(` from the anchor | substitution assertion fails |

Verified end-to-end through the dispatcher, not the hooks in isolation.

https://claude.ai/code/session_01NXuVW5yLazLNxYitGLXFGj
