### PR TITLE
docs: codify the pre-push review dry-run

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -96,9 +96,10 @@ sed -n '/NON_BLOCKING_ISSUE:/,/END_ISSUE/p' /tmp/dryrev/out.txt
 Fix what it reports, commit, re-run until the count is 0, then push.
 
 **Why the stub:** filing is gated on the output containing
-`NON_BLOCKING_ISSUE:`, and `gh` failing makes the filing step write a local
-fallback file instead of creating an issue. Nothing is lost and no issue is
-created.
+`NON_BLOCKING_ISSUE:`, and `gh` failing makes the filing step fall back to a
+local file under `~/.claude/pending-issues/` instead of creating an issue. If
+that write also fails the findings are dropped with a warning — but you are
+reading them from `out.txt` anyway, which is the point of the dry-run.
 
 **Bonus:** the review cache is keyed on the diff hash, so a clean dry-run makes
 the real push a cache hit — it reports "Codebase review cached: identical diff

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -45,6 +45,10 @@
 ```
 □ All pre-commit checks pass
 □ Adversarial review clean (runs on every commit via hook)
+□ Dry-run the pre-push codebase reviewer and FIX what it finds, before pushing
+  (see "Pre-Push Review Dry-Run" below). The pre-push hook files its
+  non-blocking findings as GitHub issues; reading them first means fixing
+  them instead of inheriting a backlog.
 □ If subagent-driven-development was used: treat all subagent-reported reviews
   as UNVERIFIED. Before pushing, run a full-diff adversarial review manually:
     git diff main..HEAD | claude --agent adversarial-reviewer -p --tools ""
@@ -64,6 +68,61 @@
 □ Ready to monitor CI and respond to reviewer
 □ Will not context-switch until Protocol 5 complete
 ```
+
+---
+
+## Pre-Push Review Dry-Run
+
+The pre-push hook runs a whole-codebase review and **files every non-blocking
+finding as a GitHub issue**. Learning about findings after the push means
+inheriting them as a backlog; running the same reviewer first means fixing
+them.
+
+Run the reviewer the hook would run, with `gh` stubbed out so it cannot file:
+
+```bash
+mkdir -p /tmp/dryrev/bin
+printf '#!/bin/sh\nexit 1\n' > /tmp/dryrev/bin/gh
+chmod +x /tmp/dryrev/bin/gh
+
+git diff origin/main...HEAD > /tmp/dryrev/diff.txt
+PATH="/tmp/dryrev/bin:$PATH" ~/.claude/hooks/run-review.sh --mode=codebase \
+  < /tmp/dryrev/diff.txt > /tmp/dryrev/out.txt 2>&1
+
+grep -c 'NON_BLOCKING_ISSUE:' /tmp/dryrev/out.txt   # 0 means nothing will be filed
+sed -n '/NON_BLOCKING_ISSUE:/,/END_ISSUE/p' /tmp/dryrev/out.txt
+```
+
+Fix what it reports, commit, re-run until the count is 0, then push.
+
+**Why the stub:** filing is gated on the output containing
+`NON_BLOCKING_ISSUE:`, and `gh` failing makes the filing step write a local
+fallback file instead of creating an issue. Nothing is lost and no issue is
+created.
+
+**Bonus:** the review cache is keyed on the diff hash, so a clean dry-run makes
+the real push a cache hit — it reports "Codebase review cached: identical diff
+previously passed" and does not re-review.
+
+### Treat findings as claims, not facts
+
+A finding can be right about *what* to change and wrong about *why*. One in
+this repo asserted that `[\n]` in an ERE bracket matches a literal `n` and not
+a newline, with a `VERIFIED:` block stating so; a one-line check showed the
+opposite. The conclusion (dead weight, remove it) was still correct.
+
+Check the mechanism before acting on it, especially when the finding explains
+how a tool or runtime behaves. That is what `lib-review-issues.sh` Group 3
+exists to flag, and it applies to findings about your own diff too.
+
+### Do not loosen a matcher without pinning the true positives first
+
+When a finding asks you to stop something from matching, build the corpus of
+cases that MUST still match before you touch the pattern, and re-run it after.
+A fix to the api-merge hook here omitted `$(` from a command-position anchor —
+command substitution executes, so that silently un-blocked a real bypass. The
+existing suite caught it. Falsify in both directions: the loosened case must
+now pass, and every previously-blocking case must still block.
 
 ---
 

--- a/scripts/hook-block-api-merge.sh
+++ b/scripts/hook-block-api-merge.sh
@@ -76,6 +76,20 @@ if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*gh[[:space:]]+(-[^[:space:]]+
   exit 0
 fi
 
+# COMMAND-POSITION ANCHOR (claude-config#405). The four api matchers below
+# require the tool name at a command position -- start of string/line, or
+# immediately after a shell operator -- rather than anywhere in the string.
+# Without it the endpoint matched inside a quoted argument being written to
+# a file, so writing a test fixture for this hook was blocked by this hook.
+# Same idiom the pr-merge matcher further down already used.
+#
+# KNOWN GAP, accepted: a heredoc body starts at a line boundary, so a
+# heredoc containing the endpoint still matches. Distinguishing a heredoc
+# body from a command needs real tokenization, which a PreToolUse hook
+# operating on an unexpanded string cannot do. This is the same
+# regex-is-not-a-shell-parser limit recorded for the false-NEGATIVE
+# direction in #349, and it fails safe: the cost is a blocked write, not a
+# permitted merge.
 # Block: gh api .../pulls/{number}/merge  (REST endpoint)
 # Suffix boundary ([[:space:]]|$|[^[:alnum:]_]) prevents false positives on
 # hypothetical paths like pulls/NNN/merge_status while still matching:
@@ -83,7 +97,7 @@ fi
 #   gh api /repos/owner/repo/pulls/123/merge
 #   gh api "repos/owner/repo/pulls/123/merge"
 #   echo x && gh api repos/o/r/pulls/1/merge --method PUT
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
   printf '%s BLOCKED API MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: Direct REST API PR merge bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -99,7 +113,7 @@ fi
 # Block: gh api graphql with mergePullRequest mutation
 # GraphQL offers the same merge capability as the REST endpoint above.
 # Covers inline mutations passed via -f query=... or --field query=...
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
   printf '%s BLOCKED GRAPHQL MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: GraphQL mergePullRequest mutation bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -116,7 +130,7 @@ fi
 # linting, block this pattern unconditionally. Legitimate data queries
 # rarely need --input; they can be expressed inline via -f query=.
 # Previously documented as a known gap (Protocol 6 in CLAUDE.md) — now closed.
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
   printf '%s BLOCKED GRAPHQL --input: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql --input reads the mutation from a file,\n' >&2
   printf '   hiding its contents from the command-line merge-bypass scanners.\n' >&2
@@ -131,7 +145,7 @@ fi
 # gh'"'"'s @<filename> convention for -f / --field reads the value from a file,
 # which lets a mutation body live on disk and still get executed. Covers the
 # gap left by the --input check above. Issue #133.
-if printf '%s\n' "${cmd}" | grep -qE 'gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
   printf '%s BLOCKED GRAPHQL @file: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql with -f/-F query=@<file> (or mutation=@<file>)\n' >&2
   printf '   reads the payload body from a file via gh'"'"'s @<filename> convention,\n' >&2

--- a/scripts/hook-block-api-merge.sh
+++ b/scripts/hook-block-api-merge.sh
@@ -77,8 +77,10 @@ if printf '%s\n' "${cmd}" | grep -qE '^[[:space:]]*gh[[:space:]]+(-[^[:space:]]+
 fi
 
 # COMMAND-POSITION ANCHOR (claude-config#405). The four api matchers below
-# require the tool name at a command position -- start of string/line, or
-# immediately after a shell operator -- rather than anywhere in the string.
+# require the tool name at a command position -- start of line, or
+# immediately after a shell operator, backtick, or command substitution --
+# rather than anywhere in the string. `^` covers the line case on its own:
+# grep matches per line and the command is piped through printf '%s\n'.
 # Without it the endpoint matched inside a quoted argument being written to
 # a file, so writing a test fixture for this hook was blocked by this hook.
 # Same idiom the pr-merge matcher further down already used.
@@ -97,7 +99,7 @@ fi
 #   gh api /repos/owner/repo/pulls/123/merge
 #   gh api "repos/owner/repo/pulls/123/merge"
 #   echo x && gh api repos/o/r/pulls/1/merge --method PUT
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*pulls/[0-9]+/merge([[:space:]]|$|[^[:alnum:]_])'; then
   printf '%s BLOCKED API MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: Direct REST API PR merge bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -113,7 +115,7 @@ fi
 # Block: gh api graphql with mergePullRequest mutation
 # GraphQL offers the same merge capability as the REST endpoint above.
 # Covers inline mutations passed via -f query=... or --field query=...
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*mergePullRequest'; then
   printf '%s BLOCKED GRAPHQL MERGE: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: GraphQL mergePullRequest mutation bypasses code quality gates.\n' >&2
   printf '\n' >&2
@@ -130,7 +132,7 @@ fi
 # linting, block this pattern unconditionally. Legitimate data queries
 # rarely need --input; they can be expressed inline via -f query=.
 # Previously documented as a known gap (Protocol 6 in CLAUDE.md) — now closed.
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(--input([[:space:]=]|$)|(-F|--field)[[:space:]=]*input)'; then
   printf '%s BLOCKED GRAPHQL --input: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql --input reads the mutation from a file,\n' >&2
   printf '   hiding its contents from the command-line merge-bypass scanners.\n' >&2
@@ -145,7 +147,7 @@ fi
 # gh'"'"'s @<filename> convention for -f / --field reads the value from a file,
 # which lets a mutation body live on disk and still get executed. Covers the
 # gap left by the --input check above. Issue #133.
-if printf '%s\n' "${cmd}" | grep -qE '(^|[\n]|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
+if printf '%s\n' "${cmd}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*|[|&][[:space:]]*|\`|\$\()[[:space:]]*gh[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^|;&[:space:]]*[[:space:]]+)?)*api[[:space:]].*graphql.*(-[fF]|--field)[[:space:]=]*(query|mutation)[[:space:]]*=[[:space:]]*@'; then
   printf '%s BLOCKED GRAPHQL @file: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ || true)" "${cmd}" >>"${HOME}/.claude/blocked-commands.log" || true
   printf '🛑 BLOCKED: gh api graphql with -f/-F query=@<file> (or mutation=@<file>)\n' >&2
   printf '   reads the payload body from a file via gh'"'"'s @<filename> convention,\n' >&2

--- a/scripts/tests/test-hook-api-merge-command-position.sh
+++ b/scripts/tests/test-hook-api-merge-command-position.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tests that the api-merge matchers require the tool name at a COMMAND
+# position, not merely somewhere in the string (claude-config#405).
+#
+# The matchers used to accept the tool name anywhere, so the merge endpoint
+# matched inside a quoted argument being written to a file -- writing a test
+# fixture for this hook was blocked by this hook.
+#
+# This hook gates merges. Loosening it needs the true positives pinned or a
+# false-positive fix silently becomes a bypass, so both directions are
+# asserted here, including command substitution (which genuinely executes).
+
+set -euo pipefail
+unset CDPATH
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/hook-block-api-merge.sh"
+pass=0
+fail=0
+
+# Assembled at runtime so this file's own invocation is not blocked by the
+# hook it tests.
+readonly EP="pulls/1/""merge"
+
+check() {
+  local desc="${1}" expected="${2}" cmd="${3}"
+  local input actual=0
+
+  input="$(jq --null-input --arg c "${cmd}" '{tool_input: {command: $c}}')" || {
+    echo "  FAIL: ${desc} (could not build fixture)"
+    ((fail += 1))
+    return
+  }
+
+  printf '%s\n' "${input}" | "${HOOK}" >/dev/null 2>&1 || actual=$?
+
+  if [[ "${actual}" -eq "${expected}" ]]; then
+    echo "  PASS: ${desc}"
+    ((pass += 1))
+  else
+    echo "  FAIL: ${desc} (expected exit ${expected}, got ${actual})"
+    ((fail += 1))
+  fi
+}
+
+echo "=== api-merge command-position tests ==="
+
+# --- must BLOCK: the tool is actually invoked ---
+check "plain REST merge"                2 "gh api -X PUT repos/o/r/${EP}"
+check "REST merge with --method"        2 "gh api repos/o/r/${EP} --method PUT"
+check "chained after &&"                2 "echo x && gh api repos/o/r/${EP}"
+check "chained after a semicolon"       2 "cd /x ; gh api repos/o/r/${EP}"
+check "after a pipe"                    2 "true | gh api repos/o/r/${EP}"
+check "command substitution executes"   2 "echo \$(gh api repos/o/r/${EP})"
+
+# --- must ALLOW: already-legitimate usage ---
+check "the sanctioned merge path"       0 "gh pr merge 123 --squash --delete-branch"
+check "an unrelated api read"           0 "gh api repos/o/r/pulls/1"
+
+# --- #405 case C: the endpoint appears in QUOTED text, not as a command ---
+check "endpoint written into a fixture file" \
+  0 "printf %s \"gh api -X PUT repos/o/r/${EP}\" > fixture.json"
+check "endpoint quoted in documentation" \
+  0 "echo \"gh api repos/o/r/${EP} is blocked by policy\" >> notes.md"
+
+# --- ACCEPTED GAP, asserted as CURRENT behavior rather than desired ---
+# A heredoc body starts at a line boundary and is indistinguishable from a
+# command without real tokenization. Documented in the hook header; fails safe
+# (a blocked write, never a permitted merge). Same limit #349 recorded for the
+# false-negative direction.
+check "KNOWN GAP: heredoc body still matches" \
+  2 "cat > t.txt <<EOF
+gh api repos/o/r/${EP}
+EOF"
+
+echo ""
+echo "Results: ${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]

--- a/scripts/tests/test-hooks-unwritable-log.sh
+++ b/scripts/tests/test-hooks-unwritable-log.sh
@@ -91,6 +91,12 @@ check hook-block-merge-locks-write.sh \
   "merge-locks-write: blocks with exit 2" \
   file_path "/Users/x/.claude/merge-locks/pr-1.lock"
 
+# EnterWorktree carries a `name`, not a command. An invalid slug reaches deny(),
+# which writes to the log and then exits 2 -- same shape as the five above.
+check hook-block-enter-worktree.sh \
+  "enter-worktree: blocks with exit 2" \
+  name "invalid name with spaces"
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [[ "${fail}" -eq 0 ]]

--- a/skills/converging-issue-backlogs/SKILL.md
+++ b/skills/converging-issue-backlogs/SKILL.md
@@ -133,6 +133,29 @@ asserted logic; and a second suite never run.
 Fixes land looking verified, vacuous green hides what is wrong, the next round
 rediscovers it as new. Fix the verification before running rounds.
 
+### Read review findings before the tooling files them
+
+If your review tooling files its findings as issues, the backlog is
+self-feeding by construction: every push that fixes issues creates the next
+round of them, and you only learn what they say after they exist. Rounds
+measured this way look like progress while the queue never drains.
+
+Run the same reviewer yourself, before the push, with its filing path disabled
+-- a stubbed CLI, a dry-run flag, whatever the tool offers. Then a finding is
+something you fix, not something you inherit.
+
+Two rules for acting on what it says:
+
+- **A finding can be right about what to change and wrong about why.** Check the
+  mechanism before you act on it, especially when the finding explains how a
+  tool or runtime behaves. One in a real run asserted a regex matched a literal
+  character rather than a newline, with a "verified" note attached; a one-line
+  check showed the opposite. The conclusion was still correct.
+- **Never loosen a matcher without pinning its true positives first.** Build the
+  corpus of cases that must still match, then change the pattern, then re-run.
+  A fix that stops one false positive is one character away from silently
+  un-blocking a real one.
+
 ## Admitting Follow-Ups
 
 Agents are rewarded for finishing. Filing a follow-up is the cheapest way to
@@ -172,6 +195,8 @@ about half.
 - Round cap treated as the stopping rule, with no convergence measure
 - A follow-up with no artifact, only a description
 - A round reported as complete while its code sits uncommitted in a worktree
+- Review tooling that files findings as issues, run without reading them first
+- A matcher loosened to kill a false positive, with no corpus of true positives
 
 ## Common Mistakes
 
@@ -184,6 +209,8 @@ about half.
 | Trusting green without falsifying it | The check is the bug; backlog regenerates |
 | Working cosmetic follow-ups | Loop never terminates |
 | Dedup against the queue only | Rejected concerns return every round |
+| Findings read only after the tooling files them | Every push seeds the next round |
+| Acting on a finding without checking its mechanism | You fix the wrong thing, confidently |
 
 ## Reference Implementation
 


### PR DESCRIPTION
Codifies the pre-push review dry-run that ended this session's issue loop.

## The problem

The pre-push hook runs a whole-codebase review and **files every non-blocking
finding as a GitHub issue**. Learning what they say only after the push means
inheriting them as a backlog — this session pushed repeatedly and each push
seeded the next round, which is exactly why "fix the backlog" had no visible
end.

Every finding filed today came from that pre-push reviewer. The commit
reviewers passed clean every single time.

## The fix

Run the same reviewer first, with `gh` stubbed so it cannot file. Then a
finding is something to fix, not something to inherit.

```bash
git diff origin/main...HEAD > /tmp/dryrev/diff.txt
PATH="/tmp/dryrev/bin:$PATH" ~/.claude/hooks/run-review.sh --mode=codebase \
  < /tmp/dryrev/diff.txt > /tmp/dryrev/out.txt 2>&1
grep -c 'NON_BLOCKING_ISSUE:' /tmp/dryrev/out.txt
```

Filing is gated on the output containing `NON_BLOCKING_ISSUE:`, and a failing
`gh` falls back to a local file rather than creating an issue.

There is a bonus: the review cache is keyed on the diff hash, so a clean
dry-run makes the real push a cache hit — it reports "Codebase review cached:
identical diff previously passed" and skips re-reviewing.

## Where it went, and why not the skill

`docs/CHECKLISTS.md` gets the procedure — it already owns the pre-push gate and
already carries a "run the reviewer manually" item for subagent work. The
command depends on `run-review.sh` and `lib-review-issues.sh` and is specific
to this setup.

The `converging-issue-backlogs` skill gets only the generalizable half: review
tooling that files findings as issues makes a backlog self-feeding by
construction. Plus a red flag and two mistake-table rows. The skill is about
agent loops you build — rounds, `spawn_ratio`, halt conditions — so the
repo-specific command does not belong in it.

## Two rules documented alongside, both learned today

- **A finding can be right about *what* to change and wrong about *why*.** One
  asserted that `[\n]` in an ERE bracket matches a literal `n` and not a
  newline, with a `VERIFIED:` block claiming so. A one-line check showed the
  opposite. The conclusion (dead weight, remove it) was still correct.
- **Never loosen a matcher without pinning its true positives first.** A fix to
  the api-merge hook omitted `$(` from a command-position anchor — command
  substitution executes — silently un-blocking a real bypass. The existing
  suite caught it.

## Verification

The documented commands were run verbatim against this branch's own diff: exit
0, 0 findings.

**The workflow then caught a defect in the commit that documents it.** The
dry-run flagged "Nothing is lost and no issue is created" as overstated — the
fallback write can itself fail, and `lib-review-issues.sh` has four paths that
warn a finding was dropped. Verified, corrected, re-ran to 0 findings, pushed.
Nothing was filed.

A second finding (the login cache not surviving command substitution) is
pre-existing, self-declared as such, and already carries a warning at its
definition. Fixing it means restructuring a function with one call site for a
hazard that appears only if a second is added — not bundled here.

https://claude.ai/code/session_01NXuVW5yLazLNxYitGLXFGj
