### PR TITLE
feat(review): downgrade version-pin unfamiliarity from BLOCKING to WARNING

### DIFF
--- a/docs/CODE-REVIEW.md
+++ b/docs/CODE-REVIEW.md
@@ -38,6 +38,7 @@
 - [ ] DRY — no unnecessary duplication
 - [ ] Appropriate level of abstraction
 - [ ] **Diagnostic granularity**: distinct failure modes produce distinct error messages (missing dependency ≠ missing file ≠ parse error ≠ value mismatch). Don't let `|| true` or empty-default fallbacks collapse several failure modes into one misleading message. See §Recurring CI Findings → "Logged patterns" for the example-driven rule.
+- [ ] **Comment minimalism**: comments are limited to what isn't obvious from the code. A comment that only restates what the code already says should be flagged and removed.
 
 ---
 
@@ -137,6 +138,45 @@ If review still fails to converge after these mechanisms are in place,
 that is itself worth a fresh issue — check `smartwatermelon/claude-config`
 issues for "Reviewer disagreement:"-titled entries first, since the
 arbiter-logging in mechanism 3 may already have captured the pattern.
+
+---
+
+## Version-Pin Unfamiliarity Is Not a Blocking Finding
+
+A reviewer model's training data has a cutoff. A manifest pin (any file, any
+ecosystem) for a tool/package version released after that cutoff reads to the
+reviewer as "this version doesn't exist" or "I don't recognize this" — a false
+BLOCKING FAIL on code that was pinned deliberately and already tested (Protocol
+3 requires tests pass before a diff reaches review, so "tests passed" is not
+re-verified here — it's inherited).
+
+**The rule:** `hooks/run-review.sh`'s `downgrade_version_unfamiliarity_findings`
+rewrites a BLOCKING finding to WARNING when its text matches unfamiliarity
+language ("does not exist," "no such version," "unfamiliar," "don't recognize")
+and does **not** match known-bad language (CVE, vulnerability, deprecated,
+yanked, breaking change, security advisory). A finding matching both is never
+downgraded — a substantive security or compatibility claim always wins over an
+unfamiliarity pattern. This is deliberately not ecosystem-aware (no
+package.json-vs-go.mod special-casing) and does not query any package registry;
+when the pinned tool has a local binary on PATH, its `--version` output is
+logged alongside the downgrade as corroborating evidence, but a missing local
+binary does not block the downgrade.
+
+A block is classified as a whole, from its `ISSUE:` line to the next one, so
+`DETAILS:` text counts toward the finding it belongs to. When a downgrade
+leaves no `SEVERITY: BLOCKING` anywhere in the output, the leading `VERDICT:`
+line is promoted `FAIL`/`REVISE` → `PASS` as well; `parse_verdict` reads only
+the `VERDICT:` line, so relabeling severities without that step would still
+block the commit. A finding that survives alongside the version pin — an
+unrelated blocking bug — keeps the verdict at FAIL.
+
+Downgraded findings stay visible — logged to `REVIEW_LOG` and relabeled
+`SEVERITY: WARNING` in the reviewer output, never deleted — same visibility
+standard as reviewer-disagreement arbitration above.
+
+Applies to the pre-commit review path only (whole-diff and chunked per-file);
+full-diff and codebase pre-push modes are unaffected, since a version pin is a
+per-file manifest fact, not a cross-file integration concern.
 
 ---
 

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -236,6 +236,9 @@ downgrade_version_unfamiliarity_findings() {
   # Language that indicates a substantive, non-familiarity objection.
   # If this matches anywhere in the block, the block is NEVER downgraded,
   # even if unfamiliarity language also appears — a known-bad claim wins.
+  # The dot in `supply.chain` is an intentional wildcard, not an unescaped
+  # literal: it covers "supply chain", "supply-chain", and "supply_chain".
+  # Do not "correct" it to `supply\.chain`.
   local _knownbad_re='CVE-|CVE[[:space:]]|vulnerab|RCE|exploit|deprecat|yanked|breaking change|incompatib|security advisory|malicious|supply.chain'
 
   # Walk the output one ISSUE:-delimited block at a time. Each block runs

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -305,14 +305,16 @@ downgrade_version_unfamiliarity_findings() {
     _result=$(printf '%s\n' "${_result}" | awk '
       BEGIN { done = 0 }
       !done && toupper($0) ~ /^VERDICT:[[:space:]]*(FAIL|REVISE)/ {
-        # Rebuild rather than sub(): awk sub() is case-sensitive, so a
-        # lowercase "verdict: revise" would match the toupper() guard and
-        # then survive the substitution unchanged. parse_verdict is
-        # case-insensitive, so that would still block the commit.
+        # Rebuild rather than sub(): awk sub() is case-sensitive, so any
+        # casing the toupper() guard admits ("verdict: revise", "fAiL")
+        # would survive a substitution unchanged. parse_verdict is
+        # case-insensitive, so that would still block the commit. Split on
+        # the uppercased copy and keep the original tail verbatim.
         rest = $0
         sub(/^[^:]*:[[:space:]]*/, "", rest)
-        sub(/^(FAIL|REVISE|fail|revise|Fail|Revise)/, "PASS", rest)
-        print "VERDICT: " rest
+        upper = toupper(rest)
+        keep = (upper ~ /^REVISE/) ? substr(rest, 7) : substr(rest, 5)
+        print "VERDICT: PASS" keep
         done = 1
         next
       }

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -299,7 +299,25 @@ downgrade_version_unfamiliarity_findings() {
   if [[ "${_downgraded}" == "yes" ]] \
     && ! printf '%s\n' "${_result}" | grep -qiE 'SEVERITY:[[:space:]]*BLOCKING'; then
     log_warn "All BLOCKING findings were version-pin unfamiliarity; promoting VERDICT to PASS"
-    _result=$(printf '%s\n' "${_result}" | sed -E '1,/^VERDICT:/ s/^(VERDICT:[[:space:]]*)(FAIL|REVISE)/\1PASS/I')
+    # awk, not `sed '1,/^VERDICT:/'`: that range ends at the SECOND match, so
+    # it would rewrite a trailing VERDICT line too, and BSD sed ignores the
+    # `0,/re/` form that would otherwise fix it. Rewrite the first line only.
+    _result=$(printf '%s\n' "${_result}" | awk '
+      BEGIN { done = 0 }
+      !done && toupper($0) ~ /^VERDICT:[[:space:]]*(FAIL|REVISE)/ {
+        # Rebuild rather than sub(): awk sub() is case-sensitive, so a
+        # lowercase "verdict: revise" would match the toupper() guard and
+        # then survive the substitution unchanged. parse_verdict is
+        # case-insensitive, so that would still block the commit.
+        rest = $0
+        sub(/^[^:]*:[[:space:]]*/, "", rest)
+        sub(/^(FAIL|REVISE|fail|revise|Fail|Revise)/, "PASS", rest)
+        print "VERDICT: " rest
+        done = 1
+        next
+      }
+      { print }
+    ')
   fi
 
   printf '%s\n' "${_result}"

--- a/hooks/run-review.sh
+++ b/hooks/run-review.sh
@@ -192,6 +192,119 @@ parse_verdict() {
   fi
 }
 
+# --- Version-pin-unfamiliarity downgrade ---
+# Rationale and rules: docs/CODE-REVIEW.md
+# §Version-Pin Unfamiliarity Is Not a Blocking Finding
+#
+# Reviewer models' training data has a cutoff; a manifest pin for a tool
+# version newer than that cutoff reads to the reviewer as "this version
+# doesn't exist" or "I don't recognize this" — a false BLOCKING FAIL on
+# code that was tested and pinned deliberately. Treat that specific
+# objection as invalid and downgrade it to WARNING, without per-ecosystem
+# manifest parsing and without a separate test-evidence check (tests-passed
+# is already assumed by Protocol 3 by the time a diff reaches review).
+#
+# What this function does NOT do, deliberately (YAGNI):
+#   - It does not verify the pin against a package registry.
+#   - It does not distinguish package.json from go.mod from Gemfile, etc.
+#   - It does not trust the reviewer's own "I don't recognize this" claim
+#     at face value — it re-classifies the DETAILS/ISSUE text itself, so
+#     a reviewer that mislabels a real CVE finding as "unfamiliar" still
+#     gets caught by the known-bad pattern below.
+#
+# $1 = raw reviewer output (VERDICT/ISSUE/SEVERITY/LOCATION/DETAILS blocks)
+# Prints the same text with qualifying BLOCKING lines rewritten to WARNING.
+# If that leaves no BLOCKING severity anywhere, the leading VERDICT: FAIL /
+# REVISE is rewritten to PASS as well — parse_verdict reads only the VERDICT
+# line, so without this the downgrade would relabel the issue while still
+# blocking the commit, which is the opposite of the intent.
+# Emits one log_warn per downgrade (stderr) so it stays visible, matching
+# how arbitration disagreements are logged elsewhere in this file.
+downgrade_version_unfamiliarity_findings() {
+  local _output="$1"
+  local -a _out_lines=()
+  local -a _block=()
+  local _line _block_text _is_blocking _tool_hint _result
+  local _tool_version _issue_title
+  local _downgraded="no"
+
+  # Language that indicates the reviewer's sole objection is "I don't
+  # recognize this version" (unfamiliarity), as opposed to a substantive
+  # claim about the version being bad. Case-insensitive.
+  local _unfamiliar_re='does not exist|doesn.?t exist|no such version|not aware of|unfamiliar|do not recognize|don.?t recognize|unrecognized version|not a (real|valid|known) version|nonexistent version'
+
+  # Language that indicates a substantive, non-familiarity objection.
+  # If this matches anywhere in the block, the block is NEVER downgraded,
+  # even if unfamiliarity language also appears — a known-bad claim wins.
+  local _knownbad_re='CVE-|CVE[[:space:]]|vulnerab|RCE|exploit|deprecat|yanked|breaking change|incompatib|security advisory|malicious|supply.chain'
+
+  # Walk the output one ISSUE:-delimited block at a time. Each block runs
+  # from an "ISSUE:" line up to (but not including) the next "ISSUE:" line
+  # or end of input. Blocks are classified as a whole so DETAILS: text on
+  # a later line still counts toward the block that owns it.
+  _flush_block() {
+    if [[ ${#_block[@]} -eq 0 ]]; then
+      return 0
+    fi
+    _block_text=$(printf '%s\n' "${_block[@]}")
+    _is_blocking=$(printf '%s\n' "${_block_text}" | grep -qiE 'SEVERITY:[[:space:]]*BLOCKING' && echo yes || echo no)
+    if [[ "${_is_blocking}" == "yes" ]] \
+      && printf '%s\n' "${_block_text}" | grep -qiE "${_unfamiliar_re}" \
+      && ! printf '%s\n' "${_block_text}" | grep -qiE "${_knownbad_re}"; then
+      # Best-effort local corroboration: if a tool name is present and
+      # invokable, log its installed version alongside the downgrade for
+      # a human to sanity-check later. Not required to downgrade — an
+      # absent local binary (an npm/pip package, say) is not a blocker.
+      # grep -E has no lookahead, so match "<name> <version>" whole and strip
+      # the version half with sed rather than trying to assert past it.
+      _tool_hint=$(printf '%s\n' "${_block_text}" \
+        | grep -oE '[a-zA-Z][a-zA-Z0-9_.-]{1,30}[[:space:]]+v?[0-9]+\.[0-9]' \
+        | head -1 \
+        | sed -E 's/[[:space:]]+v?[0-9]+\.[0-9].*$//' || true)
+      if [[ -n "${_tool_hint}" ]] && command -v "${_tool_hint}" >/dev/null 2>&1; then
+        _tool_version=$("${_tool_hint}" --version 2>/dev/null || true)
+        _tool_version=$(printf '%s\n' "${_tool_version}" | head -1)
+        [[ -n "${_tool_version}" ]] || _tool_version="unknown"
+        log_warn "version-pin downgrade: local '${_tool_hint} --version' -> ${_tool_version}"
+      fi
+      _issue_title=$(printf '%s\n' "${_block_text}" | grep -im1 '^ISSUE:' || true)
+      [[ -n "${_issue_title}" ]] || _issue_title="(untitled issue)"
+      log_warn "Downgrading BLOCKING -> WARNING (version-pin unfamiliarity, not a known-bad claim): ${_issue_title}"
+      _downgraded="yes"
+      _block_text=$(printf '%s\n' "${_block_text}" | sed -E 's/^(SEVERITY:[[:space:]]*)BLOCKING/\1WARNING/I')
+    fi
+    _out_lines+=("${_block_text}")
+    _block=()
+  }
+
+  while IFS= read -r _line; do
+    if [[ "${_line}" =~ ^ISSUE: ]]; then
+      _flush_block
+    fi
+    _block+=("${_line}")
+  done <<<"${_output}"
+  _flush_block
+
+  unset -f _flush_block
+
+  if [[ ${#_out_lines[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  _result=$(printf '%s\n' "${_out_lines[@]}")
+
+  # Only promote the verdict when a downgrade actually happened AND nothing
+  # blocking survives. A reviewer that raised an unrelated BLOCKING issue
+  # alongside the version pin still fails, as it should.
+  if [[ "${_downgraded}" == "yes" ]] \
+    && ! printf '%s\n' "${_result}" | grep -qiE 'SEVERITY:[[:space:]]*BLOCKING'; then
+    log_warn "All BLOCKING findings were version-pin unfamiliarity; promoting VERDICT to PASS"
+    _result=$(printf '%s\n' "${_result}" | sed -E '1,/^VERDICT:/ s/^(VERDICT:[[:space:]]*)(FAIL|REVISE)/\1PASS/I')
+  fi
+
+  printf '%s\n' "${_result}"
+}
+
 # --- Shared issue library (for --mode=codebase non-blocking issues) ---
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib-review-issues.sh
@@ -683,6 +796,7 @@ Focus on:
 2. Security: Hardcoded secrets, injection vulnerabilities, auth issues
 3. Error Handling: Silent failures, missing error cases
 4. Completeness: Edge cases, incomplete implementations
+5. Comments: limited to what isn't obvious from the code — flag comments that only restate what the code already says
 
 CRITICAL: Respond with this exact format:
 
@@ -759,6 +873,10 @@ ${file_diff}
       ((skipped_files += 1))
       continue
     fi
+
+    # Same version-pin-unfamiliarity downgrade as the whole-diff path, applied
+    # per-file so chunked review doesn't diverge in behavior from small diffs.
+    _rout=$(downgrade_version_unfamiliarity_findings "${_rout}")
 
     _chunk_verdict=$(parse_verdict "${_rout}")
     if [[ "${_chunk_verdict}" == "FAIL" || "${_chunk_verdict}" == "REVISE" ]]; then
@@ -1417,6 +1535,7 @@ Focus on:
 2. Security: Hardcoded secrets, injection vulnerabilities, auth issues
 3. Error Handling: Silent failures, missing error cases
 4. Completeness: Edge cases, incomplete implementations
+5. Comments: limited to what isn't obvious from the code — flag comments that only restate what the code already says
 
 CRITICAL: Respond with this exact format:
 
@@ -1494,6 +1613,14 @@ fi
 [[ -n "${CODE_REVIEWER_OUTPUT}" ]] || CODE_REVIEWER_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
 if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
   [[ -n "${ADVERSARIAL_OUTPUT}" ]] || ADVERSARIAL_OUTPUT="VERDICT: FAIL (agent error: invoke_agent produced no output)"
+fi
+
+# Version-pin-unfamiliarity downgrade: rewrite qualifying BLOCKING findings
+# to WARNING before verdict parsing, so a downgraded issue no longer flips
+# the verdict to FAIL. Applied to both reviewers' raw output.
+CODE_REVIEWER_OUTPUT=$(downgrade_version_unfamiliarity_findings "${CODE_REVIEWER_OUTPUT}")
+if [[ "${ADVERSARIAL_AVAILABLE}" == true ]]; then
+  ADVERSARIAL_OUTPUT=$(downgrade_version_unfamiliarity_findings "${ADVERSARIAL_OUTPUT}")
 fi
 
 # Parse verdict from code-reviewer output

--- a/tests/test_version_pin_downgrade.bats
+++ b/tests/test_version_pin_downgrade.bats
@@ -133,3 +133,18 @@ ISSUE: tool 1.2.3 does not exist
 SEVERITY: BLOCKING")
   [ "$(parse_verdict "${out}")" = "PASS" ]
 }
+
+@test "promotion handles arbitrary verdict casing and both keyword lengths" {
+  local out
+  for v in "VERDICT: fAiL" "VERDICT: rEvIsE" "verdict: revise - see below"; do
+    out=$(downgrade_version_unfamiliarity_findings "${v}
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING")
+    [ "$(parse_verdict "${out}")" = "PASS" ]
+  done
+  # REVISE is 6 chars and FAIL is 4; the tail must survive either way.
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: REVISE - see below
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING")
+  [ "$(printf '%s\n' "${out}" | head -1)" = "VERDICT: PASS - see below" ]
+}

--- a/tests/test_version_pin_downgrade.bats
+++ b/tests/test_version_pin_downgrade.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# Tests for downgrade_version_unfamiliarity_findings() in hooks/run-review.sh.
+#
+# Why this exists: a reviewer model's training cutoff makes any version pin
+# newer than that cutoff read as "this version doesn't exist" — a false
+# BLOCKING FAIL on a deliberate, tested pin. The function rewrites that
+# specific objection to WARNING, but never when the block also carries a
+# substantive claim (CVE, deprecation, breaking change), and never when an
+# unrelated blocking finding survives alongside it.
+#
+# Run: bats tests/test_version_pin_downgrade.bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../hooks/run-review.sh"
+  # log_warn is defined elsewhere in the script; stub it so sourcing just the
+  # one function under test is enough.
+  log_warn() { :; }
+  export -f log_warn
+  eval "$(sed -n '/^downgrade_version_unfamiliarity_findings() {/,/^}/p' "${SCRIPT}")"
+  eval "$(sed -n '/^parse_verdict() {/,/^}/p' "${SCRIPT}")"
+}
+
+@test "pure unfamiliarity: severity becomes WARNING" {
+  run downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: pin to actionlint 1.7.7 does not exist
+SEVERITY: BLOCKING
+DETAILS: no such version published"
+  [[ "${output}" == *"SEVERITY: WARNING"* ]]
+  [[ "${output}" != *"SEVERITY: BLOCKING"* ]]
+}
+
+@test "pure unfamiliarity: verdict is promoted so the commit is not blocked" {
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: pin to actionlint 1.7.7 does not exist
+SEVERITY: BLOCKING
+DETAILS: unrecognized version")
+  [ "$(parse_verdict "${out}")" = "PASS" ]
+}
+
+@test "a CVE claim is never downgraded, even when worded as unfamiliarity" {
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: lodash 4.17.19 unfamiliar
+SEVERITY: BLOCKING
+DETAILS: CVE-2020-8203 prototype pollution")
+  [[ "${out}" == *"SEVERITY: BLOCKING"* ]]
+  [ "$(parse_verdict "${out}")" = "FAIL" ]
+}
+
+@test "deprecation and breaking-change claims are never downgraded" {
+  run downgrade_version_unfamiliarity_findings "ISSUE: foo 9.9.9 not a known version
+SEVERITY: BLOCKING
+DETAILS: this release is deprecated"
+  [[ "${output}" == *"SEVERITY: BLOCKING"* ]]
+}
+
+@test "an unrelated blocking finding keeps the verdict at FAIL" {
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: pin to actionlint 1.7.7 does not exist
+SEVERITY: BLOCKING
+DETAILS: unrecognized version
+ISSUE: rm -rf on an unguarded variable
+SEVERITY: BLOCKING
+DETAILS: deletes / when the variable is empty")
+  [ "$(parse_verdict "${out}")" = "FAIL" ]
+  # The version-pin finding is still downgraded; only the real bug blocks.
+  [[ "${out}" == *"SEVERITY: WARNING"* ]]
+  [[ "${out}" == *"SEVERITY: BLOCKING"* ]]
+}
+
+@test "a clean PASS passes through untouched" {
+  local input="VERDICT: PASS
+No issues found."
+  [ "$(downgrade_version_unfamiliarity_findings "${input}")" = "${input}" ]
+}
+
+@test "empty input produces empty output" {
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "")
+  [ -z "${out}" ]
+}
+
+@test "downgraded findings are never deleted, only relabeled" {
+  run downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: pin to actionlint 1.7.7 does not exist
+SEVERITY: BLOCKING
+LOCATION: .github/workflows/ci.yml:14
+DETAILS: no such version published"
+  [[ "${output}" == *"ISSUE: pin to actionlint 1.7.7 does not exist"* ]]
+  [[ "${output}" == *"LOCATION: .github/workflows/ci.yml:14"* ]]
+  [[ "${output}" == *"DETAILS: no such version published"* ]]
+}
+
+@test "applying the function twice is idempotent" {
+  local once twice
+  once=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING")
+  twice=$(downgrade_version_unfamiliarity_findings "${once}")
+  [ "${once}" = "${twice}" ]
+}

--- a/tests/test_version_pin_downgrade.bats
+++ b/tests/test_version_pin_downgrade.bats
@@ -101,3 +101,35 @@ SEVERITY: BLOCKING")
   twice=$(downgrade_version_unfamiliarity_findings "${once}")
   [ "${once}" = "${twice}" ]
 }
+
+# --- Verdict-promotion regression cases (found in adversarial review) ---
+
+@test "promotion rewrites only the first VERDICT line, not a trailing one" {
+  # `sed '1,/^VERDICT:/'` looks correct but its range ends at the SECOND
+  # match, so it rewrote a trailing VERDICT line too.
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING
+VERDICT: FAIL")
+  [ "$(printf '%s\n' "${out}" | head -1)" = "VERDICT: PASS" ]
+  [ "$(printf '%s\n' "${out}" | tail -1)" = "VERDICT: FAIL" ]
+}
+
+@test "promotion preserves trailing text on the verdict line" {
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL (1 issue)
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING")
+  [ "$(printf '%s\n' "${out}" | head -1)" = "VERDICT: PASS (1 issue)" ]
+}
+
+@test "promotion handles a lowercase verdict, matching parse_verdict" {
+  # parse_verdict is case-insensitive, so a lowercase REVISE left unrewritten
+  # would still normalize to FAIL and block the commit.
+  local out
+  out=$(downgrade_version_unfamiliarity_findings "verdict: revise
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING")
+  [ "$(parse_verdict "${out}")" = "PASS" ]
+}

--- a/tests/test_version_pin_downgrade.bats
+++ b/tests/test_version_pin_downgrade.bats
@@ -148,3 +148,17 @@ ISSUE: tool 1.2.3 does not exist
 SEVERITY: BLOCKING")
   [ "$(printf '%s\n' "${out}" | head -1)" = "VERDICT: PASS - see below" ]
 }
+
+@test "supply-chain claims block regardless of separator" {
+  # The dot in the `supply.chain` pattern is an intentional wildcard; this
+  # pins the variants it must keep catching if anyone escapes it.
+  local out sep
+  for sep in " " "-" "_"; do
+    out=$(downgrade_version_unfamiliarity_findings "VERDICT: FAIL
+ISSUE: tool 1.2.3 does not exist
+SEVERITY: BLOCKING
+DETAILS: possible supply${sep}chain compromise")
+    [[ "${out}" == *"SEVERITY: BLOCKING"* ]]
+    [ "$(parse_verdict "${out}")" = "FAIL" ]
+  done
+}


### PR DESCRIPTION
## What

A reviewer model's training cutoff makes any manifest pin newer than that cutoff read as *"this version doesn't exist"* — a false BLOCKING FAIL on a deliberate, already-tested pin. This adds `downgrade_version_unfamiliarity_findings()`, which rewrites that specific objection to WARNING on both the whole-diff path (both reviewers) and per-file on the chunked path.

The downgrade is refused whenever the block also carries a substantive claim (CVE, vulnerability, deprecation, yanked, breaking change, security advisory, supply-chain) — a known-bad claim always beats an unfamiliarity pattern. Findings are relabeled, never deleted, and every downgrade is logged.

Also adds the comment-minimalism checklist item and the matching reviewer prompt rule.

## Bugs found and fixed while reviewing the change

The starting diff had a defect that made the feature a no-op, plus two more in the fix itself:

1. **The downgrade didn't unblock anything.** `parse_verdict` reads only the `VERDICT:` line, which the function never touched — so a relabeled finding still returned FAIL and still blocked the commit, the opposite of the intent. When a downgrade now leaves no BLOCKING severity anywhere, the leading `VERDICT: FAIL`/`REVISE` is promoted to PASS too. An unrelated blocking finding surviving alongside the version pin keeps the verdict at FAIL.
2. **`sed '1,/^VERDICT:/'` rewrote the wrong line.** The range reads as "the first VERDICT line" but sed searches for its end address from line 2, so it spans to the *second* match. The `0,/re/` form that would fix it is GNU-only — BSD sed on macOS silently ignores it and substitutes nothing. Replaced with awk.
3. **Case-sensitivity gap.** The awk guard used `toupper()` but substituted with `sub()`, which is case-sensitive, so `verdict: revise` and `fAiL` matched the guard and survived unchanged. Now splits on an uppercased copy and keeps the original tail verbatim.

Three smaller fixes: tool-hint extraction used PCRE lookahead that `grep -E` doesn't support (it was capturing `actionlint 1.7` instead of `actionlint`); the executable bit had been dropped from `run-review.sh` (755 → 644); and an empty-array `printf` emitted a stray blank line.

## Tests

14 new cases in `tests/test_version_pin_downgrade.bats` covering the downgrade, the known-bad refusals, verdict promotion, the mixed-findings case, passthrough, empty input, idempotence, and the separator variants of the `supply.chain` wildcard.

Each regression test was validated against the known-bad code first — the trailing-VERDICT case fails on the old sed, the lowercase case fails on the case-sensitive awk, the casing case fails on the variant enumeration, and the supply-chain case fails on an escaped dot. A green test on already-correct code proves nothing.

**Full suite: 237/237, no failures. Shellcheck clean** (3 pre-existing findings only: one SC2249 and two SC1091 for sourced libs).

Pre-push codebase review dry-run was run before pushing; the one finding it reported is a false positive — see #410.

https://claude.ai/code/session_014SZGtHtXGX69wz55PW1mMj